### PR TITLE
feat: create BaseCommand class to extract CLI telemetry boilerplate

### DIFF
--- a/src/cli/BaseCommand.ts
+++ b/src/cli/BaseCommand.ts
@@ -166,6 +166,7 @@ export abstract class BaseCommand extends Command {
       commandSpan.end({ code: SpanStatusCode.OK });
       metrics.observe(StandardMetrics.COMMAND_EXECUTION_DURATION_MS, duration, {
         command: this.commandName,
+        status: 'success',
       });
       metrics.increment(StandardMetrics.COMMAND_INVOCATIONS_TOTAL, {
         command: this.commandName,

--- a/tests/unit/BaseCommand.spec.ts
+++ b/tests/unit/BaseCommand.spec.ts
@@ -11,6 +11,7 @@ import { BaseCommand, type CommandContext } from '../../src/cli/BaseCommand';
 import type { StructuredLogger } from '../../src/telemetry/logger';
 import type { MetricsCollector } from '../../src/telemetry/metrics';
 import type { TraceManager } from '../../src/telemetry/traces';
+import { SpanStatusCode } from '../../src/telemetry/traces';
 
 vi.mock('../../src/telemetry/logger');
 vi.mock('../../src/telemetry/metrics');
@@ -205,7 +206,7 @@ describe('BaseCommand', () => {
       expect(mockMetrics.observe).toHaveBeenCalledWith(
         'command_execution_duration_ms',
         expect.any(Number),
-        { command: 'test-command' }
+        { command: 'test-command', status: 'success' }
       );
       expect(mockMetrics.increment).toHaveBeenCalledWith('command_invocations_total', {
         command: 'test-command',
@@ -219,7 +220,7 @@ describe('BaseCommand', () => {
 
       await command.run();
 
-      expect(mockSpan.end).toHaveBeenCalledWith({ code: 1 });
+      expect(mockSpan.end).toHaveBeenCalledWith({ code: SpanStatusCode.OK });
     });
   });
 
@@ -250,7 +251,7 @@ describe('BaseCommand', () => {
       await expect(command.run()).rejects.toThrow();
 
       expect(mockSpan.end).toHaveBeenCalledWith({
-        code: 2,
+        code: SpanStatusCode.ERROR,
         message: expect.stringContaining('Test error'),
       });
     });


### PR DESCRIPTION
## Summary

Phase 2 of code-duplication-elimination plan: Creates BaseCommand abstract class with shared telemetry initialization.

### Changes
- **CommandContext interface** with logger, metrics, traceManager, settings, runDir, featureId, flags
- **BaseCommand abstract class** extending oclif Command
- **Automatic telemetry initialization** (structured logger, metrics tracking, trace management)
- **Abstract execute(context) method** for subclasses to implement
- **requiresFeature getter** for commands that don't need a feature context
- **Span lifecycle management** with success/error states
- **Base flags** (json, verbose) inherited by all commands

### Impact
- Eliminates ~30 lines of boilerplate per command
- Standardizes telemetry across all 16 CLI commands
- 18 passing tests covering all functionality

### Testing
- Unit tests: `tests/unit/BaseCommand.spec.ts` (18 tests)
- All tests passing
- Lint passing

---
Stacked on #1