### PR TITLE
refactor(queue): use TaskPlan object parameter in initializeQueueFromPlan

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2227,7 +2226,6 @@
       "integrity": "sha512-vnDVpYPMzs4wunl27jHrfmwojOGKya0xyM3sH+UE5iv5uPS6vX7UIoh6m+vQc5LGBq52HBKPIn/zcSZVzeDEZg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2298,7 +2296,6 @@
       "integrity": "sha512-3xP4XzzDNQOIqBMWogftkwxhg5oMKApqY0BAflmLZiFYHqyhSOxv/cd/zPQLTcCXr4AkaKb25joocY0BD1WC6A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.51.0",
         "@typescript-eslint/types": "8.51.0",
@@ -2607,7 +2604,6 @@
       "integrity": "sha512-rkoPH+RqWopVxDnCBE/ysIdfQ2A7j1eDmW8tCxxrR9nnFBa9jKf86VgsSAzxBd1x+ny0GC4JgiD3SNfRHv3pOg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.0.16",
         "fflate": "^0.8.2",
@@ -2644,7 +2640,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2981,7 +2976,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3538,7 +3532,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4532,7 +4525,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -5653,7 +5645,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6521,7 +6512,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -6601,7 +6591,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6709,7 +6698,6 @@
       "integrity": "sha512-dZwN5L1VlUBewiP6H9s2+B3e3Jg96D0vzN+Ry73sOefebhYr9f94wwkMNN/9ouoU8pV1BqA1d1zGk8928cx0rg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -6785,7 +6773,6 @@
       "integrity": "sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.16",
         "@vitest/mocker": "4.0.16",

--- a/src/workflows/queueStore.ts
+++ b/src/workflows/queueStore.ts
@@ -162,15 +162,27 @@ export interface PlanTask {
   metadata?: Record<string, unknown>;
 }
 
+/**
+ * TaskPlan interface for queue initialization
+ *
+ * Represents a plan with a feature ID and associated tasks.
+ * This is a queue-specific DTO, distinct from PlanArtifact.
+ */
+export interface TaskPlan {
+  /** Feature identifier for queue initialization */
+  feature_id: string;
+  /** Array of plan tasks to transform to ExecutionTasks */
+  tasks: PlanTask[];
+}
+
 export async function initializeQueueFromPlan(
   runDir: string,
-  featureId: string,
-  planTasks: PlanTask[]
+  plan: TaskPlan,
 ): Promise<QueueOperationResult> {
   try {
-    await initializeQueue(runDir, featureId);
+    await initializeQueue(runDir, plan.feature_id);
 
-    if (planTasks.length === 0) {
+    if (plan.tasks.length === 0) {
       return {
         success: true,
         message: 'Queue initialized with no tasks',
@@ -179,10 +191,10 @@ export async function initializeQueueFromPlan(
     }
 
     const now = new Date().toISOString();
-    const executionTasks: ExecutionTask[] = planTasks.map((planTask) => ({
+    const executionTasks: ExecutionTask[] = plan.tasks.map((planTask) => ({
       schema_version: '1.0.0',
       task_id: planTask.id,
-      feature_id: featureId,
+      feature_id: plan.feature_id,
       title: planTask.title,
       task_type: planTask.task_type,
       status: 'pending' as const,

--- a/tests/unit/queueStore.spec.ts
+++ b/tests/unit/queueStore.spec.ts
@@ -1,0 +1,383 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  initializeQueueFromPlan,
+  type TaskPlan,
+  loadQueue,
+} from '../../src/workflows/queueStore.js';
+import { createRunDirectory } from '../../src/persistence/runDirectoryManager.js';
+import type { ExecutionTask } from '../../src/core/models/ExecutionTask.js';
+
+describe('queueStore - initializeQueueFromPlan', () => {
+  let tempDir: string;
+  let runDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'queuestore-test-'));
+    runDir = await createRunDirectory(tempDir, 'FEATURE-TEST', {
+      title: 'Test Feature',
+      repo: {
+        url: 'https://github.com/test/repo',
+        default_branch: 'main',
+      },
+    });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe('Normal Operation', () => {
+    it('should initialize queue with 3 tasks from plan', async () => {
+      const plan: TaskPlan = {
+        feature_id: 'FEATURE-123',
+        tasks: [
+          {
+            id: 'TASK-1',
+            title: 'First Task',
+            task_type: 'code_generation',
+            dependency_ids: [],
+          },
+          {
+            id: 'TASK-2',
+            title: 'Second Task',
+            task_type: 'review',
+            dependency_ids: ['TASK-1'],
+          },
+          {
+            id: 'TASK-3',
+            title: 'Third Task',
+            task_type: 'testing',
+            dependency_ids: ['TASK-2'],
+            config: { test_framework: 'vitest' },
+            metadata: { priority: 'high' },
+          },
+        ],
+      };
+
+      const result = await initializeQueueFromPlan(runDir, plan);
+
+      expect(result.success).toBe(true);
+      expect(result.tasksAffected).toBe(3);
+      expect(result.message).toContain('3 task(s)');
+
+      const tasks = await loadQueue(runDir);
+      expect(tasks.size).toBe(3);
+
+      const task1 = tasks.get('TASK-1');
+      expect(task1).toBeDefined();
+      expect(task1?.feature_id).toBe('FEATURE-123');
+      expect(task1?.title).toBe('First Task');
+      expect(task1?.task_type).toBe('code_generation');
+      expect(task1?.dependency_ids).toEqual([]);
+
+      const task3 = tasks.get('TASK-3');
+      expect(task3).toBeDefined();
+      expect(task3?.config).toEqual({ test_framework: 'vitest' });
+      expect(task3?.metadata).toEqual({ priority: 'high' });
+    });
+
+    it('should correctly set feature_id from plan.feature_id', async () => {
+      const plan: TaskPlan = {
+        feature_id: 'SPECIAL-FEATURE-ID',
+        tasks: [
+          {
+            id: 'TASK-X',
+            title: 'Test Task',
+            task_type: 'code_generation',
+          },
+        ],
+      };
+
+      await initializeQueueFromPlan(runDir, plan);
+
+      const tasks = await loadQueue(runDir);
+      const task = tasks.get('TASK-X');
+      expect(task?.feature_id).toBe('SPECIAL-FEATURE-ID');
+
+      // Verify queue manifest has correct feature_id
+      const queueDir = path.join(runDir, 'queue');
+      const manifestPath = path.join(queueDir, 'queue_manifest.json');
+      const manifestContent = await fs.readFile(manifestPath, 'utf-8');
+      const manifest = JSON.parse(manifestContent) as { feature_id: string };
+      expect(manifest.feature_id).toBe('SPECIAL-FEATURE-ID');
+    });
+  });
+
+  describe('Empty Plan (EC-EXEC-011)', () => {
+    it('should return success with no tasks message when plan has 0 tasks', async () => {
+      const plan: TaskPlan = {
+        feature_id: 'EMPTY-FEATURE',
+        tasks: [],
+      };
+
+      const result = await initializeQueueFromPlan(runDir, plan);
+
+      expect(result.success).toBe(true);
+      expect(result.tasksAffected).toBe(0);
+      expect(result.message).toContain('no tasks');
+
+      const tasks = await loadQueue(runDir);
+      expect(tasks.size).toBe(0);
+    });
+  });
+
+  describe('Task Transformation', () => {
+    it('should map all PlanTask fields to ExecutionTask schema', async () => {
+      const plan: TaskPlan = {
+        feature_id: 'FEAT-MAP',
+        tasks: [
+          {
+            id: 'TASK-FULL',
+            title: 'Full Task',
+            task_type: 'code_generation',
+            dependency_ids: ['DEP-1', 'DEP-2'],
+            config: { key: 'value', nested: { prop: 123 } },
+            metadata: { author: 'test', version: 2 },
+          },
+        ],
+      };
+
+      await initializeQueueFromPlan(runDir, plan);
+
+      const tasks = await loadQueue(runDir);
+      const task = tasks.get('TASK-FULL') as ExecutionTask;
+
+      expect(task.task_id).toBe('TASK-FULL');
+      expect(task.title).toBe('Full Task');
+      expect(task.task_type).toBe('code_generation');
+      expect(task.dependency_ids).toEqual(['DEP-1', 'DEP-2']);
+      expect(task.config).toEqual({ key: 'value', nested: { prop: 123 } });
+      expect(task.metadata).toEqual({ author: 'test', version: 2 });
+    });
+
+    it('should set schema_version to 1.0.0', async () => {
+      const plan: TaskPlan = {
+        feature_id: 'FEAT-VERSION',
+        tasks: [{ id: 'T1', title: 'Task', task_type: 'code_generation' }],
+      };
+
+      await initializeQueueFromPlan(runDir, plan);
+
+      const tasks = await loadQueue(runDir);
+      const task = tasks.get('T1');
+      expect(task?.schema_version).toBe('1.0.0');
+    });
+
+    it('should set status to pending', async () => {
+      const plan: TaskPlan = {
+        feature_id: 'FEAT-STATUS',
+        tasks: [{ id: 'T1', title: 'Task', task_type: 'code_generation' }],
+      };
+
+      await initializeQueueFromPlan(runDir, plan);
+
+      const tasks = await loadQueue(runDir);
+      const task = tasks.get('T1');
+      expect(task?.status).toBe('pending');
+    });
+
+    it('should set retry_count to 0 and max_retries to 3', async () => {
+      const plan: TaskPlan = {
+        feature_id: 'FEAT-RETRY',
+        tasks: [{ id: 'T1', title: 'Task', task_type: 'code_generation' }],
+      };
+
+      await initializeQueueFromPlan(runDir, plan);
+
+      const tasks = await loadQueue(runDir);
+      const task = tasks.get('T1');
+      expect(task?.retry_count).toBe(0);
+      expect(task?.max_retries).toBe(3);
+    });
+
+    it('should set created_at and updated_at timestamps', async () => {
+      const beforeTime = new Date().toISOString();
+
+      const plan: TaskPlan = {
+        feature_id: 'FEAT-TIME',
+        tasks: [{ id: 'T1', title: 'Task', task_type: 'code_generation' }],
+      };
+
+      await initializeQueueFromPlan(runDir, plan);
+
+      const afterTime = new Date().toISOString();
+      const tasks = await loadQueue(runDir);
+      const task = tasks.get('T1');
+
+      expect(task?.created_at).toBeDefined();
+      expect(task?.updated_at).toBeDefined();
+      expect(task?.created_at).toBe(task?.updated_at);
+
+      // Verify timestamps are within reasonable range
+      expect(task!.created_at >= beforeTime).toBe(true);
+      expect(task!.created_at <= afterTime).toBe(true);
+    });
+
+    it('should omit config when undefined in PlanTask', async () => {
+      const plan: TaskPlan = {
+        feature_id: 'FEAT-NO-CONFIG',
+        tasks: [
+          {
+            id: 'T1',
+            title: 'Task without config',
+            task_type: 'code_generation',
+            metadata: { key: 'value' },
+          },
+        ],
+      };
+
+      await initializeQueueFromPlan(runDir, plan);
+
+      const tasks = await loadQueue(runDir);
+      const task = tasks.get('T1') as ExecutionTask;
+
+      expect('config' in task).toBe(false);
+      expect(task.metadata).toEqual({ key: 'value' });
+    });
+
+    it('should omit metadata when undefined in PlanTask', async () => {
+      const plan: TaskPlan = {
+        feature_id: 'FEAT-NO-META',
+        tasks: [
+          {
+            id: 'T1',
+            title: 'Task without metadata',
+            task_type: 'code_generation',
+            config: { key: 'value' },
+          },
+        ],
+      };
+
+      await initializeQueueFromPlan(runDir, plan);
+
+      const tasks = await loadQueue(runDir);
+      const task = tasks.get('T1') as ExecutionTask;
+
+      expect('metadata' in task).toBe(false);
+      expect(task.config).toEqual({ key: 'value' });
+    });
+
+    it('should default dependency_ids to empty array when undefined', async () => {
+      const plan: TaskPlan = {
+        feature_id: 'FEAT-DEP',
+        tasks: [
+          {
+            id: 'T1',
+            title: 'Task',
+            task_type: 'code_generation',
+          },
+        ],
+      };
+
+      await initializeQueueFromPlan(runDir, plan);
+
+      const tasks = await loadQueue(runDir);
+      const task = tasks.get('T1');
+      expect(task?.dependency_ids).toEqual([]);
+    });
+
+    it('should preserve empty dependency_ids array', async () => {
+      const plan: TaskPlan = {
+        feature_id: 'FEAT-EMPTY-DEP',
+        tasks: [
+          {
+            id: 'T1',
+            title: 'Task',
+            task_type: 'code_generation',
+            dependency_ids: [],
+          },
+        ],
+      };
+
+      await initializeQueueFromPlan(runDir, plan);
+
+      const tasks = await loadQueue(runDir);
+      const task = tasks.get('T1');
+      expect(task?.dependency_ids).toEqual([]);
+    });
+
+    it('should preserve populated dependency_ids', async () => {
+      const plan: TaskPlan = {
+        feature_id: 'FEAT-POP-DEP',
+        tasks: [
+          {
+            id: 'T2',
+            title: 'Dependent Task',
+            task_type: 'code_generation',
+            dependency_ids: ['T1', 'T0'],
+          },
+        ],
+      };
+
+      await initializeQueueFromPlan(runDir, plan);
+
+      const tasks = await loadQueue(runDir);
+      const task = tasks.get('T2');
+      expect(task?.dependency_ids).toEqual(['T1', 'T0']);
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should handle invalid runDir gracefully', async () => {
+      const invalidDir = '/nonexistent/directory/path';
+      const plan: TaskPlan = {
+        feature_id: 'FEAT-ERROR',
+        tasks: [{ id: 'T1', title: 'Task', task_type: 'code_generation' }],
+      };
+
+      const result = await initializeQueueFromPlan(invalidDir, plan);
+
+      expect(result.success).toBe(false);
+      expect(result.message).toBeDefined();
+      expect(result.errors).toBeDefined();
+      expect(result.errors!.length).toBeGreaterThan(0);
+    });
+
+    it('should return error details with stack trace on failure', async () => {
+      const invalidDir = '/invalid/path';
+      const plan: TaskPlan = {
+        feature_id: 'FEAT-STACK',
+        tasks: [{ id: 'T1', title: 'Task', task_type: 'code_generation' }],
+      };
+
+      const result = await initializeQueueFromPlan(invalidDir, plan);
+
+      expect(result.success).toBe(false);
+      expect(result.errors).toBeDefined();
+      expect(result.errors![0]).toBeTruthy();
+      // Should contain stack trace or error message
+      expect(typeof result.errors![0]).toBe('string');
+    });
+  });
+
+  describe('Multiple Task Types', () => {
+    it('should handle all supported task types', async () => {
+      const plan: TaskPlan = {
+        feature_id: 'FEAT-TYPES',
+        tasks: [
+          { id: 'T1', title: 'Gen', task_type: 'code_generation' },
+          { id: 'T2', title: 'Review', task_type: 'review' },
+          { id: 'T3', title: 'Test', task_type: 'testing' },
+          { id: 'T4', title: 'Docs', task_type: 'documentation' },
+          { id: 'T5', title: 'Refactor', task_type: 'refactoring' },
+        ],
+      };
+
+      const result = await initializeQueueFromPlan(runDir, plan);
+
+      expect(result.success).toBe(true);
+      expect(result.tasksAffected).toBe(5);
+
+      const tasks = await loadQueue(runDir);
+      expect(tasks.size).toBe(5);
+      expect(tasks.get('T1')?.task_type).toBe('code_generation');
+      expect(tasks.get('T2')?.task_type).toBe('review');
+      expect(tasks.get('T3')?.task_type).toBe('testing');
+      expect(tasks.get('T4')?.task_type).toBe('documentation');
+      expect(tasks.get('T5')?.task_type).toBe('refactoring');
+    });
+  });
+});


### PR DESCRIPTION
- Add TaskPlan interface for queue initialization with feature_id and tasks
- Refactor initializeQueueFromPlan to accept TaskPlan object instead of separate params
- Add comprehensive unit tests for initializeQueueFromPlan (16 tests)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Queue initialization process restructured to use a plan-based input model for improved organization and data handling.

* **Tests**
  * Added comprehensive unit test coverage for queue initialization workflows, including edge cases, error handling, and task transformation scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->