### PR TITLE
feat(queue): implement initializeQueueFromPlan with PlanArtifact

### DIFF
--- a/src/workflows/queueStore.ts
+++ b/src/workflows/queueStore.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 import {
   type ExecutionTask,
   type ExecutionTaskType,
+  ExecutionTaskTypeSchema,
   parseExecutionTask,
   serializeExecutionTask,
   canRetry,
@@ -778,20 +779,9 @@ function transformTaskNodeToExecutionTask(
   // Flatten dependencies: extract task_id from each TaskDependency
   const dependencyIds = taskNode.dependencies.map(dep => dep.task_id);
 
-  // Map task_type string to ExecutionTaskType (default to 'other' if not recognized)
-  const validTaskTypes = [
-    'code_generation',
-    'testing',
-    'pr_creation',
-    'deployment',
-    'review',
-    'refactoring',
-    'documentation',
-    'other',
-  ] as const;
-  const taskType: ExecutionTaskType = validTaskTypes.includes(taskNode.task_type as ExecutionTaskType)
-    ? (taskNode.task_type as ExecutionTaskType)
-    : 'other';
+  // Map task_type string to ExecutionTaskType using Zod schema (default to 'other' if not recognized)
+  const parseResult = ExecutionTaskTypeSchema.safeParse(taskNode.task_type);
+  const taskType: ExecutionTaskType = parseResult.success ? parseResult.data : 'other';
 
   return {
     schema_version: '1.0.0',
@@ -870,13 +860,12 @@ export async function initializeQueueFromPlan(
 
   // Transform all tasks before appending (atomic: fail fast if transformation fails)
   const timestamp = new Date().toISOString();
-  const executionTasks: ExecutionTask[] = [];
+  let executionTasks: ExecutionTask[];
 
   try {
-    for (const taskNode of planTasks) {
-      const executionTask = transformTaskNodeToExecutionTask(taskNode, plan.feature_id, timestamp);
-      executionTasks.push(executionTask);
-    }
+    executionTasks = planTasks.map(taskNode =>
+      transformTaskNodeToExecutionTask(taskNode, plan.feature_id, timestamp)
+    );
     console.log(`[initializeQueueFromPlan] Transformed ${executionTasks.length} task(s)`);
   } catch (error) {
     return {


### PR DESCRIPTION
## Summary

Implements the `initializeQueueFromPlan` function for ticket CDMCH-19. This function accepts a `PlanArtifact` (instead of the non-existent `TaskPlan` model referenced in the ticket) and transforms its `TaskNode[]` into `ExecutionTask[]` for queue initialization.

Key implementation details:
- Flattens `TaskDependency[]` to `string[]` by extracting only `task_id` (ignoring the `type` field per requirements)
- Maps `task_type` to `ExecutionTaskType` using `ExecutionTaskTypeSchema.safeParse()`, defaulting to `'other'` for unrecognized types
- Handles empty plans per EC-EXEC-011: logs "No tasks to execute" and returns success without calling `appendToQueue`
- Uses a single timestamp for `created_at` and `updated_at` across all tasks in a batch
- Initializes all tasks with `status: 'pending'`, `retry_count: 0`, `max_retries: 3`, `schema_version: '1.0.0'`

### Updates since last revision
- Refactored task type validation to use `ExecutionTaskTypeSchema.safeParse()` instead of a hardcoded array (addresses bot review feedback for maintainability)
- Refactored task transformation loop to use `Array.map()` for more idiomatic TypeScript

## Review & Testing Checklist for Human

- [ ] **Missing unit tests**: This function has no test coverage. Consider adding tests for task transformation, dependency flattening, empty plan handling, and error paths before merging
- [ ] **Confirm EC-EXEC-011 compliance**: The exact log message "No tasks to execute" is required - verify this matches the specification exactly
- [ ] **Review atomicity guarantee**: If `initializeQueue` succeeds but transformation fails, the queue exists but is empty. Verify this is acceptable behavior
- [ ] **Test with real PlanArtifact data**: Run the function with actual plan data to verify dependency flattening and task transformation work correctly end-to-end

**Suggested test plan**: Create a test PlanArtifact with multiple tasks including dependencies, call `initializeQueueFromPlan`, then verify the resulting queue contains correctly transformed ExecutionTasks with proper `dependency_ids`.

### Notes

Fixes CDMCH-19

Link to Devin run: https://app.devin.ai/sessions/fd4a1ad49d2d4c718e2f8822a99b36b9
Requested by: @KingInYellow18