### PR TITLE
chore: upgrade zod to v4

### DIFF
--- a/ISSUE_RESOLUTION_PLAN.md
+++ b/ISSUE_RESOLUTION_PLAN.md
@@ -10,13 +10,13 @@
 ## Status
 - Phase 0: Selected issue
 - Phase 1: Stack plan created
-- Phase 2: In progress (layer 2)
+- Phase 2: In progress (layer 3)
 - Phase 3: Pending submission
 - Phase 4: Pending verification
 
 ## Stack Progress
 - Layer 1 (chore/eslint-9-migration): Complete
-- Layer 2 (chore/zod-4-upgrade): Pending
+- Layer 2 (chore/zod-4-upgrade): Complete
 - Layer 3 (chore/jest-30-upgrade): Pending
 
 ## Discovery Notes

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@oclif/plugin-help": "^6.2.18",
         "picomatch": "^4.0.3",
         "undici": "^7.16.0",
-        "zod": "^3.22.4"
+        "zod": "^4.3.5"
       },
       "bin": {
         "ai-feature": "bin/run.js"
@@ -6960,9 +6960,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
+      "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@oclif/plugin-help": "^6.2.18",
     "picomatch": "^4.0.3",
     "undici": "^7.16.0",
-    "zod": "^3.22.4"
+    "zod": "^4.3.5"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/src/adapters/agents/AgentAdapter.ts
+++ b/src/adapters/agents/AgentAdapter.ts
@@ -282,7 +282,7 @@ export const SessionTelemetrySchema = z
     fallbackAttempts: z.number().int().nonnegative().default(0),
     errorCategory: AgentErrorCategorySchema.optional(),
     timestamp: z.string().datetime(),
-    metadata: z.record(z.unknown()).optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
   })
   .strict();
 

--- a/src/adapters/agents/manifestLoader.ts
+++ b/src/adapters/agents/manifestLoader.ts
@@ -190,7 +190,7 @@ export const AgentManifestSchema = z
       .optional(),
     errorTaxonomy: ErrorTaxonomySchema,
     executionContexts: ExecutionContextsSchema,
-    metadata: z.record(z.unknown()).optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
   })
   .strict();
 
@@ -237,7 +237,7 @@ export function parseAgentManifest(json: unknown): ManifestValidationResult {
 
   return {
     success: false,
-    errors: result.error.errors.map((err) => ({
+    errors: result.error.issues.map((err) => ({
       path: err.path.join('.') || 'root',
       message: err.message,
     })),

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -609,7 +609,7 @@ export default class Init extends Command {
     const parseResult = RepoConfigSchema.safeParse(config);
 
     if (!parseResult.success) {
-      const errors: ValidationError[] = parseResult.error.errors.map((issue: ZodIssue) => ({
+      const errors: ValidationError[] = parseResult.error.issues.map((issue: ZodIssue) => ({
         path: issue.path.join('.') || 'root',
         message: issue.message,
       }));

--- a/src/core/config/RepoConfig.test.ts
+++ b/src/core/config/RepoConfig.test.ts
@@ -60,7 +60,7 @@ describe('RepoConfigSchema', () => {
     const result = RepoConfigSchema.safeParse(config);
     expect(result.success).toBe(false);
     if (!result.success) {
-      expect(result.error.errors[0].path).toContain('schema_version');
+      expect(result.error.issues[0].path).toContain('schema_version');
     }
   });
 

--- a/src/core/config/RepoConfig.ts
+++ b/src/core/config/RepoConfig.ts
@@ -204,7 +204,7 @@ export type FeatureFlags = z.infer<typeof FeatureFlagsSchema>;
 
 const ValidationSettingsSchema = z.object({
   commands: z.array(ValidationCommandConfigSchema).min(1),
-  template_context: z.record(z.string()).optional(),
+  template_context: z.record(z.string(), z.string()).optional(),
 });
 
 export type ValidationSettings = z.infer<typeof ValidationSettingsSchema>;
@@ -348,7 +348,7 @@ export function loadRepoConfig(configPath: string): ValidationResult {
     const parseResult = RepoConfigSchema.safeParse(rawConfig);
 
     if (!parseResult.success) {
-      const errors: ValidationError[] = parseResult.error.errors.map((err) => {
+      const errors: ValidationError[] = parseResult.error.issues.map((err) => {
         const path = err.path.join('.');
         const suggestion = generateSuggestion(path, err.message);
 

--- a/src/core/models/AgentProviderCapability.ts
+++ b/src/core/models/AgentProviderCapability.ts
@@ -29,7 +29,7 @@ export const AgentProviderCapabilitySchema = z
         output_cost_per_1k_tokens: z.number().nonnegative(),
       })
       .optional(),
-    metadata: z.record(z.unknown()).optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
   })
   .strict();
 
@@ -42,7 +42,7 @@ export function parseAgentProviderCapability(json: unknown) {
   }
   return {
     success: false as const,
-    errors: result.error.errors.map((err) => ({
+    errors: result.error.issues.map((err) => ({
       path: err.path.join('.') || 'root',
       message: err.message,
     })),

--- a/src/core/models/ApprovalRecord.ts
+++ b/src/core/models/ApprovalRecord.ts
@@ -68,7 +68,7 @@ export const ApprovalRecordSchema = z
     /** Rationale or comments for approval decision */
     rationale: z.string().optional(),
     /** Optional approval metadata */
-    metadata: z.record(z.unknown()).optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
   })
   .strict();
 
@@ -101,7 +101,7 @@ export function parseApprovalRecord(json: unknown):
 
   return {
     success: false,
-    errors: result.error.errors.map((err) => ({
+    errors: result.error.issues.map((err) => ({
       path: err.path.join('.') || 'root',
       message: err.message,
     })),

--- a/src/core/models/ArtifactBundle.ts
+++ b/src/core/models/ArtifactBundle.ts
@@ -26,7 +26,7 @@ export const ArtifactBundleSchema = z
     delivery_target: z.string().optional(),
     cli_version: z.string().regex(/^[0-9]+\.[0-9]+\.[0-9]+$/, 'Invalid semver format'),
     created_at: z.string().datetime(),
-    metadata: z.record(z.unknown()).optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
   })
   .strict();
 
@@ -39,7 +39,7 @@ export function parseArtifactBundle(json: unknown) {
   }
   return {
     success: false as const,
-    errors: result.error.errors.map((err) => ({
+    errors: result.error.issues.map((err) => ({
       path: err.path.join('.') || 'root',
       message: err.message,
     })),

--- a/src/core/models/ContextDocument.ts
+++ b/src/core/models/ContextDocument.ts
@@ -81,7 +81,7 @@ const ProvenanceDataSchema = z.object({
   /** Branch name if applicable */
   branch: z.string().optional(),
   /** Additional provenance metadata */
-  metadata: z.record(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
 export type ProvenanceData = z.infer<typeof ProvenanceDataSchema>;
@@ -101,7 +101,7 @@ export const ContextDocumentSchema = z
     /** ISO 8601 timestamp when context was last updated */
     updated_at: z.string().datetime(),
     /** Map of file paths to context file records */
-    files: z.record(ContextFileRecordSchema),
+    files: z.record(z.string(), ContextFileRecordSchema),
     /** Context summaries */
     summaries: z.array(ContextSummarySchema).default([]),
     /** Total token cost for all context */
@@ -109,7 +109,7 @@ export const ContextDocumentSchema = z
     /** Provenance information */
     provenance: ProvenanceDataSchema,
     /** Optional context-level metadata */
-    metadata: z.record(z.unknown()).optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
   })
   .strict();
 
@@ -142,7 +142,7 @@ export function parseContextDocument(json: unknown):
 
   return {
     success: false,
-    errors: result.error.errors.map((err) => ({
+    errors: result.error.issues.map((err) => ({
       path: err.path.join('.') || 'root',
       message: err.message,
     })),

--- a/src/core/models/DeploymentRecord.ts
+++ b/src/core/models/DeploymentRecord.ts
@@ -103,7 +103,7 @@ export const DeploymentRecordSchema = z
     /** ISO 8601 timestamp when deployment completed */
     completed_at: z.string().datetime().nullable().optional(),
     /** Optional deployment metadata */
-    metadata: z.record(z.unknown()).optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
   })
   .strict();
 
@@ -136,7 +136,7 @@ export function parseDeploymentRecord(json: unknown):
 
   return {
     success: false,
-    errors: result.error.errors.map((err) => ({
+    errors: result.error.issues.map((err) => ({
       path: err.path.join('.') || 'root',
       message: err.message,
     })),

--- a/src/core/models/ExecutionTask.ts
+++ b/src/core/models/ExecutionTask.ts
@@ -73,7 +73,7 @@ const CostTrackingSchema = z.object({
   /** Total cost in USD */
   total_usd: z.number().nonnegative().default(0),
   /** Provider-specific cost breakdown */
-  breakdown: z.record(z.number().nonnegative()).optional(),
+  breakdown: z.record(z.string(), z.number().nonnegative()).optional(),
   /** Number of API calls made */
   api_calls: z.number().int().nonnegative().default(0),
   /** Tokens consumed (input + output) */
@@ -120,7 +120,7 @@ export const ExecutionTaskSchema = z
     /** Current task status */
     status: ExecutionTaskStatusSchema,
     /** Task-specific configuration or parameters */
-    config: z.record(z.unknown()).optional(),
+    config: z.record(z.string(), z.unknown()).optional(),
     /** Assigned agent or executor identifier */
     assigned_agent: z.string().optional(),
     /** Task dependency IDs (must complete before this task starts) */
@@ -148,7 +148,7 @@ export const ExecutionTaskSchema = z
     /** ISO 8601 timestamp when task completed */
     completed_at: z.string().datetime().nullable().optional(),
     /** Optional task metadata */
-    metadata: z.record(z.unknown()).optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
   })
   .strict();
 
@@ -184,7 +184,7 @@ export function parseExecutionTask(json: unknown):
 
   return {
     success: false,
-    errors: result.error.errors.map((err) => ({
+    errors: result.error.issues.map((err) => ({
       path: err.path.join('.') || 'root',
       message: err.message,
     })),

--- a/src/core/models/Feature.ts
+++ b/src/core/models/Feature.ts
@@ -184,7 +184,7 @@ export const FeatureSchema = z
     /** Rate limit tracking references */
     rate_limits: RateLimitReferencesSchema.optional(),
     /** Extensible metadata for custom fields */
-    metadata: z.record(z.unknown()).optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
   })
   .strict();
 
@@ -220,7 +220,7 @@ export function parseFeature(json: unknown):
 
   return {
     success: false,
-    errors: result.error.errors.map((err) => ({
+    errors: result.error.issues.map((err) => ({
       path: err.path.join('.') || 'root',
       message: err.message,
     })),

--- a/src/core/models/IntegrationCredential.ts
+++ b/src/core/models/IntegrationCredential.ts
@@ -20,7 +20,7 @@ export const IntegrationCredentialSchema = z
     redaction_token: z.string().optional(),
     created_at: z.string().datetime(),
     updated_at: z.string().datetime(),
-    metadata: z.record(z.unknown()).optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
   })
   .strict();
 
@@ -33,7 +33,7 @@ export function parseIntegrationCredential(json: unknown) {
   }
   return {
     success: false as const,
-    errors: result.error.errors.map((err) => ({
+    errors: result.error.issues.map((err) => ({
       path: err.path.join('.') || 'root',
       message: err.message,
     })),

--- a/src/core/models/NotificationEvent.ts
+++ b/src/core/models/NotificationEvent.ts
@@ -22,7 +22,7 @@ export const NotificationEventSchema = z
     delivered_at: z.string().datetime().nullable().optional(),
     error_message: z.string().optional(),
     created_at: z.string().datetime(),
-    metadata: z.record(z.unknown()).optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
   })
   .strict();
 
@@ -35,7 +35,7 @@ export function parseNotificationEvent(json: unknown) {
   }
   return {
     success: false as const,
-    errors: result.error.errors.map((err) => ({
+    errors: result.error.issues.map((err) => ({
       path: err.path.join('.') || 'root',
       message: err.message,
     })),

--- a/src/core/models/PlanArtifact.ts
+++ b/src/core/models/PlanArtifact.ts
@@ -43,7 +43,7 @@ const TaskNodeSchema = z.object({
   /** Estimated execution time in minutes */
   estimated_duration_minutes: z.number().int().nonnegative().optional(),
   /** Task-specific configuration */
-  config: z.record(z.unknown()).optional(),
+  config: z.record(z.string(), z.unknown()).optional(),
 });
 
 export type TaskNode = z.infer<typeof TaskNodeSchema>;
@@ -91,7 +91,7 @@ export const PlanArtifactSchema = z
       .regex(/^[a-f0-9]{64}$/, 'Invalid SHA-256 hash format')
       .optional(),
     /** Optional plan-level metadata */
-    metadata: z.record(z.unknown()).optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
   })
   .strict();
 
@@ -127,7 +127,7 @@ export function parsePlanArtifact(json: unknown):
 
   return {
     success: false,
-    errors: result.error.errors.map((err) => ({
+    errors: result.error.issues.map((err) => ({
       path: err.path.join('.') || 'root',
       message: err.message,
     })),

--- a/src/core/models/RateLimitEnvelope.ts
+++ b/src/core/models/RateLimitEnvelope.ts
@@ -41,7 +41,7 @@ export const RateLimitEnvelopeSchema = z
     /** ISO 8601 timestamp when envelope was last updated */
     updated_at: z.string().datetime(),
     /** Optional envelope metadata */
-    metadata: z.record(z.unknown()).optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
   })
   .strict();
 
@@ -74,7 +74,7 @@ export function parseRateLimitEnvelope(json: unknown):
 
   return {
     success: false,
-    errors: result.error.errors.map((err) => ({
+    errors: result.error.issues.map((err) => ({
       path: err.path.join('.') || 'root',
       message: err.message,
     })),

--- a/src/core/models/ResearchTask.ts
+++ b/src/core/models/ResearchTask.ts
@@ -59,7 +59,7 @@ const ResearchResultSchema = z.object({
   /** Sources consulted for this result */
   sources_consulted: z.array(ResearchSourceSchema).default([]),
   /** Optional result metadata */
-  metadata: z.record(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
 export type ResearchResult = z.infer<typeof ResearchResultSchema>;
@@ -112,7 +112,7 @@ export const ResearchTaskSchema = z
     /** ISO 8601 timestamp when task completed */
     completed_at: z.string().datetime().nullable().optional(),
     /** Optional task metadata */
-    metadata: z.record(z.unknown()).optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
   })
   .strict();
 
@@ -148,7 +148,7 @@ export function parseResearchTask(json: unknown):
 
   return {
     success: false,
-    errors: result.error.errors.map((err) => ({
+    errors: result.error.issues.map((err) => ({
       path: err.path.join('.') || 'root',
       message: err.message,
     })),

--- a/src/core/models/RunArtifact.ts
+++ b/src/core/models/RunArtifact.ts
@@ -48,7 +48,7 @@ const ArtifactRecordSchema = z.object({
   /** ISO 8601 timestamp when artifact was created */
   timestamp: z.string().datetime(),
   /** Optional artifact-specific metadata */
-  metadata: z.record(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
 export type ArtifactRecord = z.infer<typeof ArtifactRecordSchema>;
@@ -68,9 +68,9 @@ export const RunArtifactSchema = z
     /** ISO 8601 timestamp when collection was last updated */
     updated_at: z.string().datetime(),
     /** Map of artifact IDs to artifact records */
-    artifacts: z.record(ArtifactRecordSchema),
+    artifacts: z.record(z.string(), ArtifactRecordSchema),
     /** Optional collection-level metadata */
-    metadata: z.record(z.unknown()).optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
   })
   .strict();
 
@@ -106,7 +106,7 @@ export function parseRunArtifact(json: unknown):
 
   return {
     success: false,
-    errors: result.error.errors.map((err) => ({
+    errors: result.error.issues.map((err) => ({
       path: err.path.join('.') || 'root',
       message: err.message,
     })),

--- a/src/core/models/Specification.ts
+++ b/src/core/models/Specification.ts
@@ -163,7 +163,7 @@ export const SpecificationSchema = z
     /** ISO 8601 timestamp when specification was approved */
     approved_at: z.string().datetime().nullable().optional(),
     /** Optional specification metadata */
-    metadata: z.record(z.unknown()).optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
   })
   .strict();
 
@@ -199,7 +199,7 @@ export function parseSpecification(json: unknown):
 
   return {
     success: false,
-    errors: result.error.errors.map((err) => ({
+    errors: result.error.issues.map((err) => ({
       path: err.path.join('.') || 'root',
       message: err.message,
     })),

--- a/src/core/models/TraceLink.ts
+++ b/src/core/models/TraceLink.ts
@@ -20,7 +20,7 @@ export const TraceLinkSchema = z
     target_id: z.string().min(1),
     relationship: z.enum(['implements', 'tests', 'depends_on', 'derived_from', 'validates']),
     created_at: z.string().datetime(),
-    metadata: z.record(z.unknown()).optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
   })
   .strict();
 
@@ -33,7 +33,7 @@ export function parseTraceLink(json: unknown) {
   }
   return {
     success: false as const,
-    errors: result.error.errors.map((err) => ({
+    errors: result.error.issues.map((err) => ({
       path: err.path.join('.') || 'root',
       message: err.message,
     })),

--- a/src/core/validation/validationCommandConfig.ts
+++ b/src/core/validation/validationCommandConfig.ts
@@ -9,7 +9,7 @@ export type ValidationCommandType = z.infer<typeof ValidationCommandTypeSchema>;
 /**
  * Optional template context applied when rendering validation commands.
  */
-const TemplateContextSchema = z.record(z.string());
+const TemplateContextSchema = z.record(z.string(), z.string());
 export type ValidationTemplateContext = z.infer<typeof TemplateContextSchema>;
 
 /**
@@ -19,7 +19,7 @@ export const ValidationCommandConfigSchema = z.object({
   type: ValidationCommandTypeSchema,
   command: z.string().min(1),
   cwd: z.string().default('.'),
-  env: z.record(z.string()).optional(),
+  env: z.record(z.string(), z.string()).optional(),
   required: z.boolean().default(true),
   timeout_ms: z.number().int().min(1000).max(600000).default(120000),
   max_retries: z.number().int().min(0).max(10).default(3),

--- a/src/workflows/deploymentTrigger.ts
+++ b/src/workflows/deploymentTrigger.ts
@@ -184,13 +184,13 @@ export const DeploymentOutcomeSchema = z.object({
   merge_sha: z.string().optional(),
   workflow_run_id: z.string().optional(),
   workflow_url: z.string().optional(),
-  github_response: z.record(z.unknown()).optional(),
+  github_response: z.record(z.string(), z.unknown()).optional(),
   blockers: z.array(
     z.object({
       type: z.string(),
       message: z.string(),
       recommended_action: z.string(),
-      metadata: z.record(z.unknown()).optional(),
+      metadata: z.record(z.string(), z.unknown()).optional(),
     })
   ),
   metadata: z.object({

--- a/src/workflows/validationRegistry.ts
+++ b/src/workflows/validationRegistry.ts
@@ -85,7 +85,7 @@ export const ValidationAttemptSchema = z.object({
   /** Error summary (extracted from stderr) */
   error_summary: z.string().optional(),
   /** Additional metadata */
-  metadata: z.record(z.unknown()).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
 });
 
 export type ValidationAttempt = z.infer<typeof ValidationAttemptSchema>;
@@ -217,7 +217,7 @@ export async function loadValidationRegistry(
 
     if (!result.success) {
       throw new Error(
-        `Invalid registry schema: ${result.error.errors.map((e) => `${e.path.join('.')}: ${e.message}`).join('; ')}`
+        `Invalid registry schema: ${result.error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join('; ')}`
       );
     }
 
@@ -472,7 +472,7 @@ async function loadValidationLedger(runDir: string): Promise<ValidationLedger> {
 
     if (!result.success) {
       throw new Error(
-        `Invalid ledger schema: ${result.error.errors.map((e) => `${e.path.join('.')}: ${e.message}`).join('; ')}`
+        `Invalid ledger schema: ${result.error.issues.map((e) => `${e.path.join('.')}: ${e.message}`).join('; ')}`
       );
     }
 


### PR DESCRIPTION
## Summary
- upgrade zod to v4 and update record schemas to specify key types
- swap ZodError .errors usage to .issues
- keep model error formatting consistent with v3 behavior

## Testing
- npm run build