### PR TITLE
feat: add max parallel execution config

### DIFF
--- a/src/core/config/RepoConfig.ts
+++ b/src/core/config/RepoConfig.ts
@@ -240,6 +240,7 @@ const ExecutionConfigSchema = z.object({
   default_engine: ExecutionEngineType.default('claude'),
   workspace_dir: z.string().optional(),
   task_timeout_ms: z.number().int().min(60000).max(7200000).default(1800000), // 30 min, max 2h
+  max_parallel_tasks: z.number().int().min(1).max(10).default(1),
   max_retries: z.number().int().min(0).max(10).default(3),
   retry_backoff_ms: z.number().int().min(1000).default(5000),
   log_rotation_mb: z.number().int().min(1).max(10240).default(100),
@@ -636,6 +637,7 @@ export function createDefaultConfig(
       codemachine_cli_path: 'codemachine',
       default_engine: 'claude',
       task_timeout_ms: 1800000,
+      max_parallel_tasks: 1,
       max_retries: 3,
       retry_backoff_ms: 5000,
       log_rotation_mb: 100,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added `max_parallel_tasks` configuration option to set concurrent task execution limits (default: 1, configurable range: 1-10). Independent tasks can now run in parallel when configured to do so.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->