### PR TITLE
feat(queue): integrate V2 WAL components into queueStore

### DIFF
--- a/src/workflows/queueStore.ts
+++ b/src/workflows/queueStore.ts
@@ -10,6 +10,25 @@ import {
 } from '../core/models/ExecutionTask';
 import { readManifest, writeManifest, withLock } from '../persistence/runDirectoryManager';
 
+// V2 WAL Components
+import { ensureV2Format } from './queueMigration.js';
+import {
+  hydrateIndex,
+  getTask,
+  updateTask as updateTaskInIndex,
+  getReadyTasks as getReadyTasksFromIndex,
+  getCounts,
+  exportIndexState,
+  addTask as addTaskToIndex,
+  areDependenciesCompleted as v2AreDependenciesCompleted,
+} from './queueMemoryIndex.js';
+import {
+  appendOperation,
+  appendOperationsBatch,
+} from './queueOperationsLog.js';
+import { shouldCompact, compactWithState, compact } from './queueCompactionEngine.js';
+import type { QueueIndexState, QueueOperation, ExecutionTaskData } from './queueTypes.js';
+
 /**
  * Queue Store
  *
@@ -140,6 +159,122 @@ interface QueueCache {
 }
 
 const queueCache = new Map<string, QueueCache>();
+
+// ============================================================================
+// V2 Index State Management
+// ============================================================================
+
+/**
+ * V2 Index cache entry with state and metadata.
+ * Maintains hydrated index state per run directory.
+ */
+interface V2IndexCache {
+  /** Hydrated index state */
+  state: QueueIndexState;
+  /** Queue directory path */
+  queueDir: string;
+  /** Feature ID for this queue */
+  featureId: string;
+  /** Last hydration timestamp */
+  hydratedAt: number;
+  /** Whether V2 migration has been checked */
+  migrationChecked: boolean;
+}
+
+/**
+ * V2 index state cache, keyed by runDir.
+ * Stores hydrated index state for O(1) task lookups.
+ */
+const v2IndexCache = new Map<string, V2IndexCache>();
+
+/**
+ * Get or create V2 index cache entry.
+ * Performs auto-migration if needed and hydrates index state.
+ *
+ * @param runDir - Run directory path
+ * @returns V2 index cache entry with hydrated state
+ */
+async function getV2IndexCache(runDir: string): Promise<V2IndexCache> {
+  const manifest = await readManifest(runDir);
+  const queueDir = path.join(runDir, manifest.queue.queue_dir);
+  const featureId = manifest.feature_id;
+
+  const existing = v2IndexCache.get(runDir);
+
+  // Return existing cache if available and fresh
+  if (existing && existing.queueDir === queueDir && existing.migrationChecked) {
+    return existing;
+  }
+
+  // Ensure V2 format (auto-migrates from V1 if needed)
+  const migrationResult = await ensureV2Format(queueDir, featureId);
+  if (migrationResult.migrated && migrationResult.result) {
+    console.log(`[QueueStore] Migrated queue to V2 format: ${migrationResult.result.tasksConverted} tasks`);
+  }
+
+  // Hydrate index from snapshot + WAL
+  const state = await hydrateIndex(queueDir);
+
+  const cache: V2IndexCache = {
+    state,
+    queueDir,
+    featureId,
+    hydratedAt: Date.now(),
+    migrationChecked: true,
+  };
+
+  v2IndexCache.set(runDir, cache);
+  return cache;
+}
+
+/**
+ * Build dependency graph from tasks in index state.
+ *
+ * @param state - Index state with tasks
+ * @returns Dependency graph mapping taskId -> dependency taskIds
+ */
+function buildDependencyGraph(state: QueueIndexState): Record<string, string[]> {
+  const graph: Record<string, string[]> = {};
+
+  for (const [taskId, task] of state.tasks) {
+    if (task.dependency_ids && task.dependency_ids.length > 0) {
+      graph[taskId] = [...task.dependency_ids];
+    }
+  }
+
+  return graph;
+}
+
+/**
+ * Convert ExecutionTaskData to ExecutionTask (readonly).
+ * V2 index uses mutable data internally.
+ *
+ * @param data - Mutable task data from index
+ * @returns Readonly ExecutionTask
+ */
+function toExecutionTask(data: ExecutionTaskData): ExecutionTask {
+  return data as ExecutionTask;
+}
+
+/**
+ * Convert ExecutionTask to ExecutionTaskData (mutable).
+ *
+ * @param task - Readonly ExecutionTask
+ * @returns Mutable task data for index operations
+ */
+function toExecutionTaskData(task: ExecutionTask): ExecutionTaskData {
+  return { ...task } as ExecutionTaskData;
+}
+
+/**
+ * Invalidate V2 cache for a run directory.
+ * Forces re-hydration on next access.
+ *
+ * @param runDir - Run directory to invalidate
+ */
+export function invalidateV2Cache(runDir: string): void {
+  v2IndexCache.delete(runDir);
+}
 
 // ============================================================================
 // Queue Initialization
@@ -635,6 +770,9 @@ async function maybeCompactQueue(
 /**
  * Append tasks to queue
  *
+ * Uses V2 WAL for atomic task creation with batch support.
+ * Falls back to V1 JSONL append if V2 fails.
+ *
  * @param runDir - Run directory path
  * @param tasks - Tasks to append
  * @returns Operation result
@@ -646,6 +784,68 @@ export async function appendToQueue(
   return withLock(
     runDir,
     async () => {
+      // Try V2 WAL first (preferred path)
+      try {
+        const v2Cache = await getV2IndexCache(runDir);
+
+        if (tasks.length === 0) {
+          return {
+            success: true,
+            message: 'No tasks to append',
+            tasksAffected: 0,
+          };
+        }
+
+        // Build create operations for batch append
+        const ops: Array<Omit<QueueOperation, 'seq' | 'checksum'>> = tasks.map((task) => ({
+          op: 'create' as const,
+          ts: new Date().toISOString(),
+          taskId: task.task_id,
+          task: toExecutionTaskData(task),
+        }));
+
+        // Batch append to WAL (non-locked, we're already inside withLock)
+        const appendedOps = await appendOperationsBatch(v2Cache.queueDir, ops);
+        const lastOp = appendedOps[appendedOps.length - 1];
+        if (lastOp) {
+          v2Cache.state.lastSeq = lastOp.seq;
+        }
+
+        // Update in-memory index
+        for (const task of tasks) {
+          addTaskToIndex(v2Cache.state, toExecutionTaskData(task));
+        }
+
+        // Update run manifest
+        const manifest = await readManifest(runDir);
+        const counts = getCounts(v2Cache.state);
+
+        const updatedManifest = {
+          ...manifest,
+          queue: {
+            ...manifest.queue,
+            pending_count: counts.pending,
+          },
+          timestamps: {
+            ...manifest.timestamps,
+            updated_at: new Date().toISOString(),
+          },
+        };
+
+        await writeManifest(runDir, updatedManifest);
+
+        return {
+          success: true,
+          message: `Successfully appended ${tasks.length} task(s) to queue (V2 WAL)`,
+          tasksAffected: tasks.length,
+        };
+      } catch (v2Error) {
+        invalidateV2Cache(runDir);
+        // Log warning and fall back to V1
+        console.warn(`[QueueStore] V2 appendToQueue failed, falling back to V1: ${v2Error instanceof Error ? v2Error.message : String(v2Error)}`);
+      }
+
+      // Fallback to V1 implementation
       try {
         const manifest = await readManifest(runDir);
         const queueDir = path.join(runDir, manifest.queue.queue_dir);
@@ -767,12 +967,50 @@ async function computeFileChecksum(filePath: string): Promise<string> {
 /**
  * Load all tasks from queue
  *
+ * Uses V2 WAL-based index for O(1) task lookups.
+ * Automatically migrates from V1 format if needed.
+ *
  * @param runDir - Run directory path
  * @returns Map of task_id to ExecutionTask
  */
 export async function loadQueue(runDir: string): Promise<Map<string, ExecutionTask>> {
+  // Try V2 index first (preferred path)
+  try {
+    const v2Cache = await getV2IndexCache(runDir);
+    const tasks = new Map<string, ExecutionTask>();
+
+    for (const [taskId, taskData] of v2Cache.state.tasks) {
+      tasks.set(taskId, toExecutionTask(taskData));
+    }
+
+    return tasks;
+  } catch (error) {
+    // Log warning but fall back to V1 cache for resilience
+    console.warn(`[QueueStore] V2 index load failed, falling back to V1: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  // Fallback to V1 cache (backward compatibility)
   const cache = await getQueueCache(runDir);
   return cache.tasks;
+}
+
+/**
+ * Load queue using V2 index only (no fallback).
+ * Use when V2 format is required.
+ *
+ * @param runDir - Run directory path
+ * @returns Map of task_id to ExecutionTask
+ * @throws If V2 index cannot be loaded
+ */
+export async function loadQueueV2(runDir: string): Promise<Map<string, ExecutionTask>> {
+  const v2Cache = await getV2IndexCache(runDir);
+  const tasks = new Map<string, ExecutionTask>();
+
+  for (const [taskId, taskData] of v2Cache.state.tasks) {
+    tasks.set(taskId, toExecutionTask(taskData));
+  }
+
+  return tasks;
 }
 
 /**
@@ -966,10 +1204,57 @@ export async function validateQueue(runDir: string): Promise<QueueValidationResu
 /**
  * Get next executable task from queue
  *
+ * Uses V2 memory index for efficient task selection.
+ * Priority order: running tasks (crash recovery) > pending tasks > retryable failures
+ *
  * @param runDir - Run directory path
  * @returns Next task to execute, or null if none available
  */
 export async function getNextTask(runDir: string): Promise<ExecutionTask | null> {
+  // Try V2 index first (preferred path)
+  try {
+    const v2Cache = await getV2IndexCache(runDir);
+    const dependencyGraph = buildDependencyGraph(v2Cache.state);
+    const seen = new Set<string>();
+
+    // 1. Retry tasks that were running when crash occurred
+    for (const [, taskData] of v2Cache.state.tasks) {
+      if (taskData.status === 'running') {
+        if (v2AreDependenciesCompleted(v2Cache.state, taskData.task_id, dependencyGraph)) {
+          if (!seen.has(taskData.task_id)) {
+            return toExecutionTask(taskData);
+          }
+        }
+      }
+    }
+
+    // 2. Pending tasks with completed dependencies
+    const readyTasks = getReadyTasksFromIndex(v2Cache.state, dependencyGraph);
+    for (const taskData of readyTasks) {
+      if (!seen.has(taskData.task_id)) {
+        return toExecutionTask(taskData);
+      }
+    }
+
+    // 3. Retryable failures with completed dependencies
+    for (const [, taskData] of v2Cache.state.tasks) {
+      const task = toExecutionTask(taskData);
+      if (canRetry(task)) {
+        if (v2AreDependenciesCompleted(v2Cache.state, taskData.task_id, dependencyGraph)) {
+          if (!seen.has(taskData.task_id)) {
+            return task;
+          }
+        }
+      }
+    }
+
+    return null;
+  } catch (error) {
+    // Log warning but fall back to V1 for resilience
+    console.warn(`[QueueStore] V2 getNextTask failed, falling back to V1: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  // Fallback to V1 implementation
   const tasks = await loadQueue(runDir);
   const seen = new Set<string>();
 
@@ -1028,11 +1313,28 @@ export async function getFailedTasks(runDir: string): Promise<ExecutionTask[]> {
 /**
  * Get task by ID
  *
+ * Uses V2 memory index for O(1) lookup.
+ *
  * @param runDir - Run directory path
  * @param taskId - Task ID
  * @returns Task or null if not found
  */
 export async function getTaskById(runDir: string, taskId: string): Promise<ExecutionTask | null> {
+  // Try V2 index first (O(1) lookup)
+  try {
+    const v2Cache = await getV2IndexCache(runDir);
+    const taskData = getTask(v2Cache.state, taskId);
+
+    if (taskData) {
+      return toExecutionTask(taskData);
+    }
+    return null;
+  } catch (error) {
+    // Log warning but fall back to V1 for resilience
+    console.warn(`[QueueStore] V2 getTaskById failed, falling back to V1: ${error instanceof Error ? error.message : String(error)}`);
+  }
+
+  // Fallback to V1 implementation
   const tasks = await loadQueue(runDir);
   return tasks.get(taskId) || null;
 }
@@ -1040,8 +1342,8 @@ export async function getTaskById(runDir: string, taskId: string): Promise<Execu
 /**
  * Update task status in queue
  *
- * Note: This is a simplified implementation. In production, you'd want to
- * implement proper JSONL updating or use SQLite for mutable operations.
+ * Uses V2 WAL for atomic updates with O(1) appends.
+ * Falls back to V1 implementation if V2 fails.
  *
  * @param runDir - Run directory path
  * @param taskId - Task ID to update
@@ -1056,6 +1358,87 @@ export async function updateTaskInQueue(
   return withLock(
     runDir,
     async () => {
+      // Try V2 WAL first (preferred path)
+      try {
+        const v2Cache = await getV2IndexCache(runDir);
+        const existingTask = getTask(v2Cache.state, taskId);
+
+        if (!existingTask) {
+          return {
+            success: false,
+            message: `Task ${taskId} not found in queue`,
+          };
+        }
+
+        // Build patch with updated_at timestamp
+        const patch: Partial<ExecutionTaskData> = {
+          ...updates,
+          updated_at: new Date().toISOString(),
+        } as Partial<ExecutionTaskData>;
+
+        // Append update operation to WAL
+        const op: Omit<QueueOperation, 'seq' | 'checksum'> = {
+          op: 'update',
+          ts: new Date().toISOString(),
+          taskId,
+          patch,
+        };
+
+  const appendedOp = await appendOperation(v2Cache.queueDir, op);
+  v2Cache.state.lastSeq = appendedOp.seq;
+
+        // Update in-memory index
+        updateTaskInIndex(v2Cache.state, taskId, patch);
+
+        // Build dependency graph for compaction
+        const dependencyGraph = buildDependencyGraph(v2Cache.state);
+
+  // Check if compaction is needed (avoid nested locks)
+  const compactionCheck = await shouldCompact(v2Cache.queueDir);
+  if (compactionCheck.needed) {
+    await compactWithState(
+      runDir,
+      v2Cache.queueDir,
+      v2Cache.featureId,
+      v2Cache.state,
+      dependencyGraph
+    );
+  }
+
+        // Update run manifest if status changed
+        if (updates.status) {
+          const manifest = await readManifest(runDir);
+          const counts = getCounts(v2Cache.state);
+
+          const updatedManifest = {
+            ...manifest,
+            queue: {
+              ...manifest.queue,
+              pending_count: counts.pending,
+              completed_count: counts.completed,
+              failed_count: counts.failed,
+            },
+            timestamps: {
+              ...manifest.timestamps,
+              updated_at: new Date().toISOString(),
+            },
+          };
+
+          await writeManifest(runDir, updatedManifest);
+        }
+
+        return {
+          success: true,
+          message: `Task ${taskId} updated successfully (V2 WAL)`,
+          tasksAffected: 1,
+        };
+      } catch (v2Error) {
+        invalidateV2Cache(runDir);
+        // Log warning and fall back to V1
+        console.warn(`[QueueStore] V2 updateTaskInQueue failed, falling back to V1: ${v2Error instanceof Error ? v2Error.message : String(v2Error)}`);
+      }
+
+      // Fallback to V1 implementation
       try {
         const cache = await getQueueCache(runDir);
         const task = cache.tasks.get(taskId);
@@ -1122,4 +1505,186 @@ export async function updateTaskInQueue(
     },
     { operation: 'update_task_in_queue' }
   );
+}
+
+/**
+ * Update task in queue using V2 WAL only (no fallback).
+ * Use when V2 format is required.
+ *
+ * @param runDir - Run directory path
+ * @param taskId - Task ID to update
+ * @param updates - Partial task updates
+ * @returns Operation result
+ * @throws If V2 update fails
+ */
+export async function updateTaskInQueueV2(
+  runDir: string,
+  taskId: string,
+  updates: Partial<ExecutionTask>
+): Promise<QueueOperationResult> {
+  return withLock(
+    runDir,
+    async () => {
+      const v2Cache = await getV2IndexCache(runDir);
+      const existingTask = getTask(v2Cache.state, taskId);
+
+      if (!existingTask) {
+        return {
+          success: false,
+          message: `Task ${taskId} not found in queue`,
+        };
+      }
+
+      // Build patch with updated_at timestamp
+      const patch: Partial<ExecutionTaskData> = {
+        ...updates,
+        updated_at: new Date().toISOString(),
+      } as Partial<ExecutionTaskData>;
+
+      // Append update operation to WAL
+      const op: Omit<QueueOperation, 'seq' | 'checksum'> = {
+        op: 'update',
+        ts: new Date().toISOString(),
+        taskId,
+        patch,
+      };
+
+      await appendOperation(v2Cache.queueDir, op);
+
+      // Update in-memory index
+      updateTaskInIndex(v2Cache.state, taskId, patch);
+
+      // Build dependency graph for compaction
+      const dependencyGraph = buildDependencyGraph(v2Cache.state);
+
+      // Check if compaction is needed
+      const compactionResult = await maybeCompact(
+        runDir,
+        v2Cache.queueDir,
+        v2Cache.featureId,
+        dependencyGraph
+      );
+
+      if (compactionResult.compacted) {
+        v2Cache.state.snapshotSeq = compactionResult.snapshotSeq;
+        v2Cache.state.dirty = false;
+      }
+
+      // Update run manifest if status changed
+      if (updates.status) {
+        const manifest = await readManifest(runDir);
+        const counts = getCounts(v2Cache.state);
+
+        const updatedManifest = {
+          ...manifest,
+          queue: {
+            ...manifest.queue,
+            pending_count: counts.pending,
+            completed_count: counts.completed,
+            failed_count: counts.failed,
+          },
+          timestamps: {
+            ...manifest.timestamps,
+            updated_at: new Date().toISOString(),
+          },
+        };
+
+        await writeManifest(runDir, updatedManifest);
+      }
+
+      return {
+        success: true,
+        message: `Task ${taskId} updated successfully (V2 WAL)`,
+        tasksAffected: 1,
+      };
+    },
+    { operation: 'update_task_in_queue_v2' }
+  );
+}
+
+// ============================================================================
+// V2 Queue API (Direct Access)
+// ============================================================================
+
+/**
+ * Get queue counts using V2 index.
+ * Returns O(1) counts from the in-memory index.
+ *
+ * @param runDir - Run directory path
+ * @returns Queue counts by status
+ */
+export async function getQueueCountsV2(runDir: string): Promise<QueueCounts> {
+  const v2Cache = await getV2IndexCache(runDir);
+  return getCounts(v2Cache.state);
+}
+
+/**
+ * Get all ready tasks using V2 index.
+ * Returns pending tasks with all dependencies completed.
+ *
+ * @param runDir - Run directory path
+ * @returns Array of ready-to-execute tasks
+ */
+export async function getReadyTasksV2(runDir: string): Promise<ExecutionTask[]> {
+  const v2Cache = await getV2IndexCache(runDir);
+  const dependencyGraph = buildDependencyGraph(v2Cache.state);
+  const readyTasksData = getReadyTasksFromIndex(v2Cache.state, dependencyGraph);
+
+  return readyTasksData.map(toExecutionTask);
+}
+
+/**
+ * Get the V2 index state for advanced operations.
+ * Use with caution - modifying state directly may cause inconsistencies.
+ *
+ * @param runDir - Run directory path
+ * @returns V2 index state
+ */
+export async function getV2IndexState(runDir: string): Promise<QueueIndexState> {
+  const v2Cache = await getV2IndexCache(runDir);
+  return v2Cache.state;
+}
+
+/**
+ * Force compaction of the V2 queue.
+ * Creates a new snapshot and truncates the WAL.
+ *
+ * @param runDir - Run directory path
+ * @returns Compaction result
+ */
+export async function forceCompactV2(runDir: string): Promise<{ compacted: boolean; snapshotSeq: number }> {
+  const v2Cache = await getV2IndexCache(runDir);
+  const dependencyGraph = buildDependencyGraph(v2Cache.state);
+
+  const result = await compact(
+    runDir,
+    v2Cache.queueDir,
+    v2Cache.featureId,
+    dependencyGraph
+  );
+
+  if (result.compacted) {
+    v2Cache.state.snapshotSeq = result.snapshotSeq;
+    v2Cache.state.dirty = false;
+  }
+
+  return {
+    compacted: result.compacted,
+    snapshotSeq: result.snapshotSeq,
+  };
+}
+
+/**
+ * Export V2 queue state for debugging or backup.
+ *
+ * @param runDir - Run directory path
+ * @returns Exported index state
+ */
+export async function exportV2State(runDir: string): Promise<{
+  tasks: Record<string, ExecutionTaskData>;
+  counts: QueueCounts;
+  lastSeq: number;
+}> {
+  const v2Cache = await getV2IndexCache(runDir);
+  return exportIndexState(v2Cache.state);
 }

--- a/tests/unit/queueStore.v2.spec.ts
+++ b/tests/unit/queueStore.v2.spec.ts
@@ -1,0 +1,359 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  initializeQueueFromPlan,
+  type TaskPlan,
+  loadQueue,
+  updateTaskInQueue,
+  getNextTask,
+  invalidateV2Cache,
+} from '../../src/workflows/queueStore.js';
+import { createRunDirectory } from '../../src/persistence/runDirectoryManager.js';
+import type { ExecutionTask } from '../../src/core/models/ExecutionTask.js';
+
+/**
+ * V2-Specific Queue Store Tests
+ *
+ * Tests Issue #45: Queue Store V2 Integration (Layer 7)
+ *
+ * Verifies:
+ * - V2 format detection and auto-migration
+ * - WAL (Write-Ahead Log) integration
+ * - Compaction triggers and snapshot updates
+ * - Backward compatibility with existing APIs
+ */
+describe('queueStore V2 Integration', () => {
+  let tempDir: string;
+  let runDir: string;
+
+  // Helper to create a task plan
+  const createPlan = (tasks: Array<{ id: string; deps?: string[] }>): TaskPlan => ({
+    feature_id: 'FEAT-V2-TEST',
+    tasks: tasks.map((t) => ({
+      id: t.id,
+      title: `Task ${t.id}`,
+      task_type: 'code_generation' as const,
+      dependency_ids: t.deps ?? [],
+    })),
+  });
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'queuestore-v2-test-'));
+    runDir = await createRunDirectory(tempDir, 'FEATURE-V2-TEST', {
+      title: 'V2 Test Feature',
+      repo: {
+        url: 'https://github.com/test/repo',
+        default_branch: 'main',
+      },
+    });
+  });
+
+  afterEach(async () => {
+    // Invalidate cache to prevent cross-test pollution
+    invalidateV2Cache(runDir);
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  // ==========================================================================
+  // V2 Format Detection and Auto-Migration
+  // ==========================================================================
+
+  describe('V2 Format Detection', () => {
+    it('should load V2 format correctly when snapshot exists', async () => {
+      // Initialize queue - this creates V1 format initially
+      const plan = createPlan([{ id: 'task-1' }, { id: 'task-2' }]);
+      await initializeQueueFromPlan(runDir, plan);
+
+      // Load queue - should work regardless of format
+      const tasks = await loadQueue(runDir);
+      expect(tasks.size).toBe(2);
+      expect(tasks.get('task-1')).toBeDefined();
+      expect(tasks.get('task-2')).toBeDefined();
+    });
+
+    it('should auto-migrate V1 to V2 on first access', async () => {
+      // Create V1 format queue
+      const plan = createPlan([{ id: 'task-1' }]);
+      await initializeQueueFromPlan(runDir, plan);
+
+      // Invalidate cache to force re-hydration
+      invalidateV2Cache(runDir);
+
+      // Access queue - triggers auto-migration if needed
+      const tasks = await loadQueue(runDir);
+      expect(tasks.size).toBe(1);
+
+      // Subsequent access should use cached V2 state
+      const tasksAgain = await loadQueue(runDir);
+      expect(tasksAgain.size).toBe(1);
+    });
+  });
+
+  // ==========================================================================
+  // WAL (Write-Ahead Log) Integration
+  // ==========================================================================
+
+  describe('WAL Integration', () => {
+    it('should append updates to WAL file (queue_operations.log)', async () => {
+      const plan = createPlan([{ id: 'task-1' }]);
+      await initializeQueueFromPlan(runDir, plan);
+
+      // Update task - should append to WAL
+      const result = await updateTaskInQueue(runDir, 'task-1', {
+        status: 'running',
+      });
+
+      expect(result.success).toBe(true);
+
+      // Verify WAL file exists and contains the update
+      const queueDir = path.join(runDir, 'queue');
+      const walPath = path.join(queueDir, 'queue_operations.log');
+
+      const walExists = await fs.access(walPath).then(() => true).catch(() => false);
+      expect(walExists).toBe(true);
+
+      const walContent = await fs.readFile(walPath, 'utf-8');
+      expect(walContent.length).toBeGreaterThan(0);
+
+      // Parse the WAL entry and verify it has the update operation
+      const lines = walContent.trim().split('\n').filter((l) => l.length > 0);
+      expect(lines.length).toBeGreaterThanOrEqual(1);
+
+      // V2 WAL format: {op, seq, ts, taskId, patch, checksum}
+      const lastEntry = JSON.parse(lines[lines.length - 1]) as { op: string; taskId: string; patch?: { status?: string } };
+      expect(lastEntry.taskId).toBe('task-1');
+      expect(lastEntry.op).toBe('update');
+      expect(lastEntry.patch?.status).toBe('running');
+    });
+
+    it('should track updates count in cache', async () => {
+      const plan = createPlan([{ id: 'task-1' }, { id: 'task-2' }]);
+      await initializeQueueFromPlan(runDir, plan);
+
+      // Perform multiple updates
+      await updateTaskInQueue(runDir, 'task-1', { status: 'running' });
+      await updateTaskInQueue(runDir, 'task-1', { status: 'completed' });
+      await updateTaskInQueue(runDir, 'task-2', { status: 'running' });
+
+      // Verify tasks reflect latest state
+      const tasks = await loadQueue(runDir);
+      const task1 = tasks.get('task-1');
+      const task2 = tasks.get('task-2');
+
+      expect(task1?.status).toBe('completed');
+      expect(task2?.status).toBe('running');
+    });
+
+    it('should preserve task updates after cache invalidation', async () => {
+      const plan = createPlan([{ id: 'task-1' }]);
+      await initializeQueueFromPlan(runDir, plan);
+
+      // Update task
+      await updateTaskInQueue(runDir, 'task-1', { status: 'completed' });
+
+      // Invalidate cache
+      invalidateV2Cache(runDir);
+
+      // Reload queue - should read from persisted WAL
+      const tasks = await loadQueue(runDir);
+      const task = tasks.get('task-1');
+
+      expect(task?.status).toBe('completed');
+    });
+  });
+
+  // ==========================================================================
+  // Compaction Trigger Tests
+  // ==========================================================================
+
+  describe('Compaction Trigger', () => {
+    it('should update manifest counts after operations', async () => {
+      const plan = createPlan([{ id: 'task-1' }, { id: 'task-2' }, { id: 'task-3' }]);
+      await initializeQueueFromPlan(runDir, plan);
+
+      // Update tasks
+      await updateTaskInQueue(runDir, 'task-1', { status: 'completed' });
+      await updateTaskInQueue(runDir, 'task-2', { status: 'failed' });
+
+      // Read run manifest to verify counts (V2 updates run manifest, not queue manifest)
+      const manifestPath = path.join(runDir, 'manifest.json');
+      const manifestContent = await fs.readFile(manifestPath, 'utf-8');
+      const manifest = JSON.parse(manifestContent);
+
+      // V2 stores counts in manifest.queue
+      expect(manifest.queue.completed_count).toBe(1);
+      expect(manifest.queue.failed_count).toBe(1);
+      expect(manifest.queue.pending_count).toBe(1);
+    });
+
+    it('should handle compaction gracefully when triggered', async () => {
+      // Create a larger queue to test compaction scenarios
+      const tasks = Array.from({ length: 20 }, (_, i) => ({
+        id: `task-${i}`,
+        deps: i > 0 ? [`task-${i - 1}`] : [],
+      }));
+      const plan = createPlan(tasks);
+      await initializeQueueFromPlan(runDir, plan);
+
+      // Complete multiple tasks to trigger potential compaction
+      for (let i = 0; i < 10; i++) {
+        await updateTaskInQueue(runDir, `task-${i}`, { status: 'completed' });
+      }
+
+      // Verify queue state is consistent
+      const loadedTasks = await loadQueue(runDir);
+      expect(loadedTasks.size).toBe(20);
+
+      let completedCount = 0;
+      for (const task of loadedTasks.values()) {
+        if (task.status === 'completed') completedCount++;
+      }
+      expect(completedCount).toBe(10);
+    });
+  });
+
+  // ==========================================================================
+  // Backward Compatibility
+  // ==========================================================================
+
+  describe('Backward Compatibility', () => {
+    it('should return Map<string, ExecutionTask> from loadQueue', async () => {
+      const plan = createPlan([{ id: 'task-1' }, { id: 'task-2' }]);
+      await initializeQueueFromPlan(runDir, plan);
+
+      const tasks = await loadQueue(runDir);
+
+      // Verify return type is Map
+      expect(tasks instanceof Map).toBe(true);
+      expect(tasks.size).toBe(2);
+
+      // Verify Map API works
+      expect(tasks.has('task-1')).toBe(true);
+      expect(tasks.has('task-2')).toBe(true);
+      expect(tasks.has('nonexistent')).toBe(false);
+
+      // Verify iteration works
+      const ids: string[] = [];
+      for (const [taskId] of tasks) {
+        ids.push(taskId);
+      }
+      expect(ids).toContain('task-1');
+      expect(ids).toContain('task-2');
+    });
+
+    it('should work with getNextTask using V2 internals', async () => {
+      const plan = createPlan([
+        { id: 'task-1' },
+        { id: 'task-2', deps: ['task-1'] },
+        { id: 'task-3', deps: ['task-2'] },
+      ]);
+      await initializeQueueFromPlan(runDir, plan);
+
+      // First task should be task-1 (no deps)
+      const first = await getNextTask(runDir);
+      expect(first?.task_id).toBe('task-1');
+
+      // Complete task-1
+      await updateTaskInQueue(runDir, 'task-1', { status: 'completed' });
+
+      // Next should be task-2 (deps now satisfied)
+      const second = await getNextTask(runDir);
+      expect(second?.task_id).toBe('task-2');
+    });
+
+    it('should maintain ExecutionTask schema compatibility', async () => {
+      const plan: TaskPlan = {
+        feature_id: 'FEAT-COMPAT',
+        tasks: [{
+          id: 'task-full',
+          title: 'Full Task',
+          task_type: 'code_generation',
+          dependency_ids: ['dep-1'],
+          config: { key: 'value' },
+          metadata: { priority: 'high' },
+        }],
+      };
+      await initializeQueueFromPlan(runDir, plan);
+
+      const tasks = await loadQueue(runDir);
+      const task = tasks.get('task-full') as ExecutionTask;
+
+      // Verify all ExecutionTask fields are present
+      expect(task.schema_version).toBe('1.0.0');
+      expect(task.task_id).toBe('task-full');
+      expect(task.feature_id).toBe('FEAT-COMPAT');
+      expect(task.title).toBe('Full Task');
+      expect(task.task_type).toBe('code_generation');
+      expect(task.status).toBe('pending');
+      expect(task.dependency_ids).toEqual(['dep-1']);
+      expect(task.retry_count).toBe(0);
+      expect(task.max_retries).toBe(3);
+      expect(task.created_at).toBeDefined();
+      expect(task.updated_at).toBeDefined();
+      expect(task.config).toEqual({ key: 'value' });
+      expect(task.metadata).toEqual({ priority: 'high' });
+    });
+
+    it('should handle concurrent read/write operations', async () => {
+      const plan = createPlan([{ id: 'task-1' }]);
+      await initializeQueueFromPlan(runDir, plan);
+
+      // Simulate concurrent operations
+      const operations = [
+        updateTaskInQueue(runDir, 'task-1', { status: 'running' }),
+        loadQueue(runDir),
+        updateTaskInQueue(runDir, 'task-1', { retry_count: 1 }),
+      ];
+
+      const results = await Promise.all(operations);
+
+      // All operations should succeed
+      expect((results[0] as { success: boolean }).success).toBe(true);
+      expect(results[1] instanceof Map).toBe(true);
+      expect((results[2] as { success: boolean }).success).toBe(true);
+
+      // Final state should be consistent
+      const finalTasks = await loadQueue(runDir);
+      const task = finalTasks.get('task-1');
+      expect(task).toBeDefined();
+    });
+  });
+
+  // ==========================================================================
+  // Error Handling
+  // ==========================================================================
+
+  describe('Error Handling', () => {
+    it('should return error for non-existent task update', async () => {
+      const plan = createPlan([{ id: 'task-1' }]);
+      await initializeQueueFromPlan(runDir, plan);
+
+      const result = await updateTaskInQueue(runDir, 'nonexistent-task', {
+        status: 'running',
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('not found');
+    });
+
+    it('should handle updates with unchanged status gracefully', async () => {
+      const plan = createPlan([{ id: 'task-1' }]);
+      await initializeQueueFromPlan(runDir, plan);
+
+      // Update status
+      await updateTaskInQueue(runDir, 'task-1', { status: 'running' });
+
+      // Update same status again
+      const result = await updateTaskInQueue(runDir, 'task-1', {
+        status: 'running',
+      });
+
+      expect(result.success).toBe(true);
+
+      const tasks = await loadQueue(runDir);
+      expect(tasks.get('task-1')?.status).toBe('running');
+    });
+  });
+});


### PR DESCRIPTION
Implements Layer 7 of Issue #45: Queue Store V2 Integration

Changes:
- Add V2 index cache with auto-migration from V1
- Integrate WAL operations (appendOperation, appendOperationsBatch)
- Wire up compaction engine with threshold triggers
- Update loadQueue, updateTaskInQueue, appendToQueue to use V2
- Add getV2IndexCache for hydrating index from snapshot + WAL
- Add helper functions for ExecutionTask/ExecutionTaskData conversion
- Add V2-specific exports for advanced usage
- Fix nested lock deadlock (use non-locked versions inside withLock)

V2 benefits:
- O(1) task updates via WAL append
- O(1) task lookups via in-memory index
- Automatic compaction when thresholds reached
- Backward compatible with V1 format (auto-migration)

Test coverage: 198 queue tests passing (13 new V2 tests)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>