### PR TITLE
feat(taskmapper): add subcommand and CommandStructure types

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -16,6 +16,7 @@ module.exports = [
       'node_modules',
       '**/*.js',
       '**/*.cjs',
+      '.claude/**',
       'test',
       'test/**',
       'vitest.config.ts',

--- a/src/workflows/codeMachineRunner.ts
+++ b/src/workflows/codeMachineRunner.ts
@@ -337,12 +337,13 @@ export async function runCodeMachine(
         : DEFAULT_MAX_BUFFER_SIZE;
 
     if (options.logPath) {
+      const logPath = options.logPath;
       const attachLogStream = (): WriteStream => {
-        const stream = createWriteStream(options.logPath!, { flags: 'a', mode: 0o600 });
+        const stream = createWriteStream(logPath, { flags: 'a', mode: 0o600 });
         stream.on('error', (err) => {
           options.logger?.warn('Log stream error, disabling file logging', {
             task_id: options.taskId,
-            logPath: options.logPath,
+            logPath,
             error: err.message,
           });
           logStream = undefined;
@@ -353,7 +354,7 @@ export async function runCodeMachine(
       logStream = attachLogStream();
 
       enqueueLogWrite = (chunk: Buffer): void => {
-        if (!options.logPath || !logStream) {
+        if (!logPath || !logStream) {
           return;
         }
 
@@ -376,7 +377,7 @@ export async function runCodeMachine(
             });
 
             await rotateLogFiles(
-              options.logPath!,
+              logPath,
               logRotationKeep,
               logRotationCompress,
               options.logger,

--- a/src/workflows/queueStore.ts
+++ b/src/workflows/queueStore.ts
@@ -829,8 +829,7 @@ export async function createQueueSnapshot(runDir: string): Promise<QueueOperatio
         // Load all tasks
         const tasks = await loadQueue(runDir);
         const snapshot = buildQueueSnapshot(manifest.feature_id, tasks);
-        const snapshotPath = path.join(queueDir, QUEUE_SNAPSHOT_FILE);
-        await writeQueueSnapshot(snapshotPath, snapshot);
+        await writeQueueSnapshot(queueDir, snapshot);
 
         // Update queue manifest
         const queueManifestPath = path.join(queueDir, QUEUE_MANIFEST_FILE);

--- a/src/workflows/taskMapper.ts
+++ b/src/workflows/taskMapper.ts
@@ -27,21 +27,92 @@ export interface TaskExecutionResult {
   artifacts?: string[];
 }
 
+/**
+ * Valid primary commands for CodeMachine CLI
+ * Used for security validation to prevent command injection
+ */
+export const ALLOWED_COMMANDS = ['start', 'run'] as const;
+export type AllowedCommand = (typeof ALLOWED_COMMANDS)[number];
+
+/**
+ * Valid subcommands for 'run' command
+ * Used for security validation to prevent command injection
+ */
+export const ALLOWED_SUBCOMMANDS = ['pr', 'review', 'docs'] as const;
+export type AllowedSubcommand = (typeof ALLOWED_SUBCOMMANDS)[number];
+
+/**
+ * Mapping from task type to workflow execution configuration
+ */
 export interface WorkflowMapping {
+  /** Full workflow name for display/logging (e.g., "codemachine run pr") */
   workflow: string;
-  command: 'start' | 'run';
+  /** Primary command to execute ('start' or 'run') */
+  command: AllowedCommand;
+  /** Optional subcommand for 'run' command (pr, review, docs) */
+  subcommand?: AllowedSubcommand;
+  /** Whether to use native engine instead of CodeMachine CLI */
   useNativeEngine: boolean;
 }
 
+/**
+ * Complete command structure for CodeMachine CLI execution
+ */
+export interface CommandStructure {
+  /** CLI executable name */
+  executable: string;
+  /** Primary command ('start' or 'run') */
+  command: string;
+  /** Optional subcommand for 'run' command */
+  subcommand?: string;
+  /** Additional command arguments (flags, options, positional args) */
+  args: string[];
+}
+
 const TASK_TYPE_TO_WORKFLOW: Record<ExecutionTaskType, WorkflowMapping> = {
-  code_generation: { workflow: 'codemachine start', command: 'start', useNativeEngine: false },
-  testing: { workflow: 'native-autofix', command: 'run', useNativeEngine: true },
-  pr_creation: { workflow: 'codemachine run pr', command: 'run', useNativeEngine: false },
-  deployment: { workflow: 'native-deployment', command: 'run', useNativeEngine: true },
-  review: { workflow: 'codemachine run review', command: 'run', useNativeEngine: false },
-  refactoring: { workflow: 'codemachine start', command: 'start', useNativeEngine: false },
-  documentation: { workflow: 'codemachine run docs', command: 'run', useNativeEngine: false },
-  other: { workflow: 'codemachine start', command: 'start', useNativeEngine: false },
+  code_generation: {
+    workflow: 'codemachine start',
+    command: 'start',
+    useNativeEngine: false,
+  },
+  testing: {
+    workflow: 'native-autofix',
+    command: 'run',
+    useNativeEngine: true,
+  },
+  pr_creation: {
+    workflow: 'codemachine run pr',
+    command: 'run',
+    subcommand: 'pr',
+    useNativeEngine: false,
+  },
+  deployment: {
+    workflow: 'native-deployment',
+    command: 'run',
+    useNativeEngine: true,
+  },
+  review: {
+    workflow: 'codemachine run review',
+    command: 'run',
+    subcommand: 'review',
+    useNativeEngine: false,
+  },
+  refactoring: {
+    workflow: 'codemachine start',
+    command: 'start',
+    useNativeEngine: false,
+  },
+  documentation: {
+    workflow: 'codemachine run docs',
+    command: 'run',
+    subcommand: 'docs',
+    useNativeEngine: false,
+  },
+  other: {
+    workflow: 'codemachine start',
+    command: 'start',
+    useNativeEngine: false,
+  },
 };
 
 // Helper to extract agent ID for backward compatibility
@@ -79,6 +150,49 @@ export function assertEngineSupported(engine: string): asserts engine is Executi
     const supportedList = SUPPORTED_ENGINES.join(', ');
     const error = new Error(`Engine '${engine}' not supported. Supported: ${supportedList}`);
     (error as { code?: string }).code = 'EC-EXEC-007';
+    throw error;
+  }
+}
+
+/**
+ * Type guard to check if a string is a valid command
+ */
+export function isValidCommand(command: string): command is AllowedCommand {
+  return ALLOWED_COMMANDS.includes(command as AllowedCommand);
+}
+
+/**
+ * Type guard to check if a string is a valid subcommand
+ */
+export function isValidSubcommand(subcommand: string): subcommand is AllowedSubcommand {
+  return ALLOWED_SUBCOMMANDS.includes(subcommand as AllowedSubcommand);
+}
+
+/**
+ * Validate command structure for security
+ * @throws Error if command or subcommand is invalid
+ */
+export function validateCommandStructure(structure: CommandStructure): void {
+  if (!isValidCommand(structure.command)) {
+    const error = new Error(
+      `Invalid command: '${structure.command}'. Allowed: ${ALLOWED_COMMANDS.join(', ')}`
+    );
+    (error as { code?: string }).code = 'EC-EXEC-008';
+    throw error;
+  }
+
+  if (structure.subcommand !== undefined && !isValidSubcommand(structure.subcommand)) {
+    const error = new Error(
+      `Invalid subcommand: '${structure.subcommand}'. Allowed: ${ALLOWED_SUBCOMMANDS.join(', ')}`
+    );
+    (error as { code?: string }).code = 'EC-EXEC-009';
+    throw error;
+  }
+
+  // Validate that 'start' command doesn't have a subcommand
+  if (structure.command === 'start' && structure.subcommand !== undefined) {
+    const error = new Error(`Command 'start' does not support subcommands`);
+    (error as { code?: string }).code = 'EC-EXEC-010';
     throw error;
   }
 }

--- a/tests/unit/taskMapper.spec.ts
+++ b/tests/unit/taskMapper.spec.ts
@@ -5,6 +5,10 @@ import {
   getSupportedEngines,
   isEngineSupported,
   assertEngineSupported,
+  isValidCommand,
+  isValidSubcommand,
+  validateCommandStructure,
+  type CommandStructure,
 } from '../../src/workflows/taskMapper';
 
 describe('taskMapper', () => {
@@ -159,6 +163,71 @@ describe('taskMapper', () => {
         const err = error as Error & { code?: string };
         expect(err.message).toContain('Engine');
         expect(err.code).toBe('EC-EXEC-007');
+      }
+    });
+  });
+
+  describe('command validation', () => {
+    it('accepts valid commands', () => {
+      expect(isValidCommand('start')).toBe(true);
+      expect(isValidCommand('run')).toBe(true);
+    });
+
+    it('rejects invalid commands', () => {
+      expect(isValidCommand('build')).toBe(false);
+      expect(isValidCommand('')).toBe(false);
+    });
+
+    it('accepts valid subcommands', () => {
+      expect(isValidSubcommand('pr')).toBe(true);
+      expect(isValidSubcommand('review')).toBe(true);
+      expect(isValidSubcommand('docs')).toBe(true);
+    });
+
+    it('rejects invalid subcommands', () => {
+      expect(isValidSubcommand('deploy')).toBe(false);
+      expect(isValidSubcommand('')).toBe(false);
+    });
+
+    it('validates command structures and error codes', () => {
+      const validStart: CommandStructure = {
+        executable: 'codemachine',
+        command: 'start',
+        args: [],
+      };
+
+      const validRun: CommandStructure = {
+        executable: 'codemachine',
+        command: 'run',
+        subcommand: 'pr',
+        args: [],
+      };
+
+      expect(() => validateCommandStructure(validStart)).not.toThrow();
+      expect(() => validateCommandStructure(validRun)).not.toThrow();
+
+      try {
+        validateCommandStructure({ ...validStart, command: 'build' });
+        expect(false).toBe(true);
+      } catch (error) {
+        const err = error as Error & { code?: string };
+        expect(err.code).toBe('EC-EXEC-008');
+      }
+
+      try {
+        validateCommandStructure({ ...validRun, subcommand: 'deploy' });
+        expect(false).toBe(true);
+      } catch (error) {
+        const err = error as Error & { code?: string };
+        expect(err.code).toBe('EC-EXEC-009');
+      }
+
+      try {
+        validateCommandStructure({ ...validStart, subcommand: 'pr' });
+        expect(false).toBe(true);
+      } catch (error) {
+        const err = error as Error & { code?: string };
+        expect(err.code).toBe('EC-EXEC-010');
       }
     });
   });


### PR DESCRIPTION
Adds support for multiple CodeMachine workflow commands (Issue #46):

Types added:
- ALLOWED_COMMANDS constant: ['start', 'run']
- ALLOWED_SUBCOMMANDS constant: ['pr', 'review', 'docs']
- AllowedCommand and AllowedSubcommand type aliases
- CommandStructure interface for CLI execution
- Extended WorkflowMapping with optional subcommand field

Type guards added:
- isValidCommand(): Check if string is valid command
- isValidSubcommand(): Check if string is valid subcommand
- validateCommandStructure(): Security validation with error codes

Updated TASK_TYPE_TO_WORKFLOW mapping:
- pr_creation → subcommand: 'pr'
- review → subcommand: 'review'
- documentation → subcommand: 'docs'

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal logging path handling for more reliable log creation and rotation.
  * Simplified queue snapshot persistence and updated manifest to record last snapshot time.

* **New Features**
  * Added explicit command/subcommand support and runtime validation for CLI-style task invocation.

* **Tests**
  * Added tests covering command/subcommand validation and related error conditions.

* **Chores**
  * ESLint configured to ignore a local tooling directory.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->