### PR TITLE
chore: add cycle 3 plan

### DIFF
--- a/CYCLE_PLAN.md
+++ b/CYCLE_PLAN.md
@@ -29,3 +29,5 @@ core telemetry and artifact capture, and raising test coverage to prevent regres
 - Security scan requirements could introduce new CI gate failures without clear remediation paths (CDMCH-5).
 - Telemetry and artifact capture can affect execution performance or introduce I/O edge cases (CDMCH-22/24/25).
 - E2E tests may be flaky if mock CLI or timing controls are not fully deterministic (CDMCH-29).
+- Unit testing `CodeMachineRunner` may be complex if it is tightly coupled to the filesystem or process spawning, leading to brittle mocks (CDMCH-26).
+- Automated dependency updates can introduce breaking changes or new vulnerabilities, requiring manual intervention (CDMCH-6).


### PR DESCRIPTION
## Summary
- add Cycle 3 plan document for execution, scope, and risks

## Testing
- not run (doc-only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Cycle 3 planning document (2026-01-16 to 2026-01-30) outlining goals, scope, implementation strategy, prioritized initiatives, and associated risks. Covers security/compliance hardening, observability, artifact capture, telemetry, unit and end-to-end testing, and automated dependency updates. No functional code changes included—planning content only.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->