### PR TITLE
test: include cliexecutionengine integration spec in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:config:watch": "vitest watch src/core/config",
     "test:config:coverage": "vitest run src/core/config --coverage",
     "test:http": "vitest run tests/unit",
-    "test:integration": "vitest run tests/integration/resume_flow.spec.ts tests/integration/cli_status_plan.spec.ts",
+    "test:integration": "vitest run tests/integration/resume_flow.spec.ts tests/integration/cli_status_plan.spec.ts tests/integration/cliExecutionEngine.spec.ts",
     "test:smoke": "vitest run tests/integration/smoke_execution.spec.ts",
     "test:telemetry": "vitest run tests/unit/logger.spec.ts",
     "test:jest": "jest --runInBand",


### PR DESCRIPTION
## Summary
- include CLIExecutionEngine integration spec in npm test:integration so CI runs it

## Testing
- npm run test:integration