### PR TITLE
fix(docs): correct broken documentation links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Autonomous AI-powered feature development pipeline CLI
 - **Automatic V1→V2 migration** with integrity validation and rollback support
 - **Benchmark validation**: 0.43ms for 500 tasks, <100ms for 1000 tasks
 - **8-layer architecture**: WAL, in-memory index, snapshots, compaction, migration, unified API, types, performance monitoring
-- See [Queue V2 Operations Guide](docs/ops/queue-v2-operations.md) for details
+- See [Queue V2 Operations Guide](docs/operations/queue-v2-operations.md) for details
 
 ### Parallel Execution
 - **Configurable concurrency** (1-10 tasks) via `execution.max_parallel_tasks`
@@ -31,7 +31,7 @@ Autonomous AI-powered feature development pipeline CLI
 - **2-4x throughput improvement** for independent tasks (validated in benchmarks)
 - **Safety guarantees**: Failed prerequisites halt dependent tasks, ACID queue updates
 - **Worker pool management**: In-flight task tracking with capacity enforcement
-- See [Parallel Execution Guide](docs/ops/parallel-execution.md) for details
+- See [Parallel Execution Guide](docs/operations/parallel-execution.md) for details
 
 ### Enhanced Telemetry
 - **Execution metrics tracking**: Task lifecycle, validation results, diff statistics
@@ -47,7 +47,7 @@ Autonomous AI-powered feature development pipeline CLI
 - **Secure CLI execution**: Command injection vulnerabilities eliminated via parameterized execution
 - **Comprehensive test coverage**: >90% for critical modules (queue, execution engine, validation)
 - **Security improvements**: Path traversal prevention, input validation, safe artifact capture
-- See [Log Rotation Guide](docs/ops/log-rotation.md) for details
+- See [Log Rotation Guide](docs/operations/log-rotation.md) for details
 
 ### Developer Experience
 - **868 unit tests** with 100% pass rate across all modules

--- a/tests/unit/readme-links.spec.ts
+++ b/tests/unit/readme-links.spec.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('README.md documentation links', () => {
+  const projectRoot = path.resolve(__dirname, '../..');
+  const readmePath = path.join(projectRoot, 'README.md');
+  const readmeContent = fs.readFileSync(readmePath, 'utf-8');
+
+  // Extract all markdown links to docs/ paths
+  const linkRegex = /\[([^\]]+)\]\((docs\/[^)]+)\)/g;
+  const links: Array<{ text: string; href: string }> = [];
+  let match;
+  while ((match = linkRegex.exec(readmeContent)) !== null) {
+    links.push({ text: match[1], href: match[2] });
+  }
+
+  it('should have documentation links in README', () => {
+    expect(links.length).toBeGreaterThan(0);
+  });
+
+  it.each(links)('link "$text" -> $href should resolve to existing file', ({ href }) => {
+    const fullPath = path.join(projectRoot, href);
+    const exists = fs.existsSync(fullPath);
+    expect(exists, `File not found: ${href}`).toBe(true);
+  });
+
+  // Specific critical files that must exist
+  const criticalFiles = [
+    'docs/ops/execution_telemetry.md',
+    'docs/ops/codemachine_adapter_guide.md',
+    'docs/README.md',
+    'docs/operations/queue-v2-operations.md',
+    'docs/operations/parallel-execution.md',
+    'docs/operations/log-rotation.md',
+  ];
+
+  it.each(criticalFiles)('critical file %s should exist', (href) => {
+    const fullPath = path.join(projectRoot, href);
+    expect(fs.existsSync(fullPath), `Critical file not found: ${href}`).toBe(true);
+  });
+});


### PR DESCRIPTION
- Fix Queue V2 Operations Guide link (docs/ops → docs/operations)
- Fix Parallel Execution Guide link (docs/ops → docs/operations)
- Fix Log Rotation Guide link (docs/ops → docs/operations)
- Add link validation test (readme-links.spec.ts)

Resolves CDMCH-45

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links in README reflecting a reorganized structure for operations guides.

* **Tests**
  * Added automated test suite to validate that all documentation links in README reference existing files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->