### PR TITLE
fix(json): add safe JSON parsing utilities and error handling

### DIFF
--- a/src/utils/safeJson.ts
+++ b/src/utils/safeJson.ts
@@ -5,6 +5,8 @@
  * uncaught exceptions from malformed JSON content.
  */
 
+import * as fs from 'fs/promises';
+
 /**
  * Result type for JSON parse operations
  */
@@ -12,6 +14,81 @@ export interface SafeJsonResult<T> {
   success: boolean;
   data?: T;
   error?: string;
+}
+
+/**
+ * Extended result type for file-based JSON operations
+ */
+export interface SafeJsonFileResult<T> extends SafeJsonResult<T> {
+  /** Whether the error was due to file not found (vs parse error) */
+  fileNotFound?: boolean;
+}
+
+/**
+ * Check if an error is a file-not-found error (ENOENT)
+ *
+ * Centralized utility to avoid duplicating this check across the codebase.
+ *
+ * @param error - Error to check
+ * @returns True if the error is an ENOENT error
+ */
+export function isFileNotFound(error: unknown): error is NodeJS.ErrnoException {
+  return (
+    error !== null &&
+    typeof error === 'object' &&
+    'code' in error &&
+    (error as NodeJS.ErrnoException).code === 'ENOENT'
+  );
+}
+
+/**
+ * Check if an error is a JSON parse error (SyntaxError)
+ *
+ * @param error - Error to check
+ * @returns True if the error is a SyntaxError from JSON.parse
+ */
+export function isJsonParseError(error: unknown): error is SyntaxError {
+  return error instanceof SyntaxError;
+}
+
+/**
+ * Safely read and parse a JSON file
+ *
+ * Distinguishes between file-not-found errors and JSON parse errors,
+ * returning appropriate results for each case.
+ *
+ * @param filePath - Path to the JSON file
+ * @returns Result object with parsed data, or error information
+ *
+ * @example
+ * ```typescript
+ * const result = await safeJsonReadFile<Config>('/path/to/config.json');
+ * if (result.success) {
+ *   console.log(result.data);
+ * } else if (result.fileNotFound) {
+ *   console.log('Config file does not exist');
+ * } else {
+ *   console.error('Invalid JSON:', result.error);
+ * }
+ * ```
+ */
+export async function safeJsonReadFile<T>(filePath: string): Promise<SafeJsonFileResult<T>> {
+  try {
+    const content = await fs.readFile(filePath, 'utf-8');
+    const data = JSON.parse(content) as T;
+    return { success: true, data };
+  } catch (error) {
+    if (isFileNotFound(error)) {
+      return { success: false, fileNotFound: true, error: error.message };
+    }
+    if (isJsonParseError(error)) {
+      return { success: false, error: `JSON parse error: ${error.message}` };
+    }
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error reading file',
+    };
+  }
 }
 
 /**

--- a/src/workflows/specComposer.ts
+++ b/src/workflows/specComposer.ts
@@ -49,6 +49,7 @@ import {
   type ApprovalRecord,
   type ApprovalVerdict,
 } from '../core/models/ApprovalRecord';
+import { isFileNotFound } from '../utils/safeJson';
 
 // ============================================================================
 // Types
@@ -1028,8 +1029,15 @@ export async function recordSpecApproval(
     try {
       const existingIndex = await fs.readFile(approvalsIndexPath, 'utf-8');
       approvalsIndex = JSON.parse(existingIndex) as { approvals: ApprovalRecord[] };
-    } catch {
-      // Index file may not exist yet
+    } catch (error) {
+      if (!isFileNotFound(error)) {
+        // Log non-ENOENT errors (e.g., JSON parse failures) but continue with empty index
+        logger.warn('Failed to parse existing approvals.json, starting fresh', {
+          featureId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+      // Index file may not exist yet - continue with empty index
     }
 
     approvalsIndex.approvals.push(approvalRecord);

--- a/src/workflows/traceabilityMapper.ts
+++ b/src/workflows/traceabilityMapper.ts
@@ -26,6 +26,7 @@ import { loadSpecMetadata } from './specComposer';
 import type { StructuredLogger } from '../telemetry/logger';
 import type { MetricsCollector } from '../telemetry/metrics';
 import { computeFileHash } from '../persistence/hashManifest';
+import { isFileNotFound } from '../utils/safeJson';
 
 // ============================================================================
 // Types
@@ -425,8 +426,15 @@ export async function generateTraceMap(
           gaps: [],
         },
       };
-    } catch {
-      // File doesn't exist, continue with generation
+    } catch (error) {
+      if (!isFileNotFound(error)) {
+        // File exists but failed to read or parse - log warning and regenerate
+        logger.warn('Failed to read existing trace.json, regenerating', {
+          tracePath,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+      // File doesn't exist or is corrupted, continue with generation
     }
   }
 
@@ -655,7 +663,15 @@ export async function loadTraceSummary(runDir: string): Promise<TraceSummary | n
       lastUpdated: doc.updated_at,
       outstandingGaps,
     };
-  } catch {
+  } catch (error) {
+    // Return null for both file-not-found and parse errors
+    // This function is designed for graceful degradation
+    // Non-ENOENT errors (like JSON parse failures) indicate corrupted data
+    // but we still return null to allow the caller to continue
+    if (!isFileNotFound(error) && process.env.DEBUG) {
+      // Only log in debug mode to avoid noise in normal operation
+      console.warn('[traceabilityMapper] Failed to load trace.json:', error);
+    }
     return null;
   }
 }

--- a/tests/unit/safeJson.spec.ts
+++ b/tests/unit/safeJson.spec.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import {
+  safeJsonParse,
+  safeJsonParseWithResult,
+  safeJsonParseValidated,
+  isFileNotFound,
+  isJsonParseError,
+  safeJsonReadFile,
+} from '../../src/utils/safeJson';
+
+describe('safeJson utilities', () => {
+  describe('safeJsonParse', () => {
+    it('should parse valid JSON', () => {
+      const result = safeJsonParse<{ name: string }>('{"name": "test"}');
+      expect(result).toEqual({ name: 'test' });
+    });
+
+    it('should return undefined for invalid JSON', () => {
+      const result = safeJsonParse<{ name: string }>('invalid json');
+      expect(result).toBeUndefined();
+    });
+
+    it('should return default value for invalid JSON when provided', () => {
+      const defaultVal = { name: 'default' };
+      const result = safeJsonParse<{ name: string }>('invalid json', defaultVal);
+      expect(result).toEqual(defaultVal);
+    });
+
+    it('should handle empty string', () => {
+      const result = safeJsonParse('');
+      expect(result).toBeUndefined();
+    });
+
+    it('should handle truncated JSON', () => {
+      const result = safeJsonParse('{"name": "test"');
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('safeJsonParseWithResult', () => {
+    it('should return success result for valid JSON', () => {
+      const result = safeJsonParseWithResult<{ name: string }>('{"name": "test"}');
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ name: 'test' });
+      expect(result.error).toBeUndefined();
+    });
+
+    it('should return error result for invalid JSON', () => {
+      const result = safeJsonParseWithResult<{ name: string }>('invalid json');
+      expect(result.success).toBe(false);
+      expect(result.data).toBeUndefined();
+      expect(result.error).toBeDefined();
+      expect(result.error).toContain('Unexpected token');
+    });
+
+    it('should capture error message for empty input', () => {
+      const result = safeJsonParseWithResult('');
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+
+    it('should capture error message for truncated JSON', () => {
+      const result = safeJsonParseWithResult('{"key":');
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+  });
+
+  describe('safeJsonParseValidated', () => {
+    interface User {
+      name: string;
+      age: number;
+    }
+
+    const isUser = (data: unknown): data is User => {
+      return (
+        typeof data === 'object' &&
+        data !== null &&
+        'name' in data &&
+        typeof (data as User).name === 'string' &&
+        'age' in data &&
+        typeof (data as User).age === 'number'
+      );
+    };
+
+    it('should return success for valid JSON matching validator', () => {
+      const result = safeJsonParseValidated<User>(
+        '{"name": "Alice", "age": 30}',
+        isUser
+      );
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ name: 'Alice', age: 30 });
+    });
+
+    it('should return validation error for valid JSON not matching validator', () => {
+      const result = safeJsonParseValidated<User>(
+        '{"name": "Alice"}', // missing age
+        isUser,
+        'Invalid user object'
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Invalid user object');
+    });
+
+    it('should return parse error for invalid JSON', () => {
+      const result = safeJsonParseValidated<User>('invalid', isUser);
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Unexpected token');
+    });
+  });
+
+  describe('isFileNotFound', () => {
+    it('should return true for ENOENT errors', () => {
+      const error = { code: 'ENOENT', message: 'File not found' };
+      expect(isFileNotFound(error)).toBe(true);
+    });
+
+    it('should return false for other error codes', () => {
+      const error = { code: 'EACCES', message: 'Permission denied' };
+      expect(isFileNotFound(error)).toBe(false);
+    });
+
+    it('should return false for non-object errors', () => {
+      expect(isFileNotFound('error string')).toBe(false);
+      expect(isFileNotFound(null)).toBe(false);
+      expect(isFileNotFound(undefined)).toBe(false);
+    });
+
+    it('should return false for errors without code property', () => {
+      const error = new Error('Some error');
+      expect(isFileNotFound(error)).toBe(false);
+    });
+  });
+
+  describe('isJsonParseError', () => {
+    it('should return true for SyntaxError', () => {
+      try {
+        JSON.parse('invalid json');
+      } catch (error) {
+        expect(isJsonParseError(error)).toBe(true);
+      }
+    });
+
+    it('should return false for other error types', () => {
+      expect(isJsonParseError(new Error('regular error'))).toBe(false);
+      expect(isJsonParseError(new TypeError('type error'))).toBe(false);
+    });
+
+    it('should return false for non-Error values', () => {
+      expect(isJsonParseError('string')).toBe(false);
+      expect(isJsonParseError(null)).toBe(false);
+    });
+  });
+
+  describe('safeJsonReadFile', () => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+      tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'safejson-test-'));
+    });
+
+    afterEach(async () => {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    });
+
+    it('should successfully read and parse valid JSON file', async () => {
+      const filePath = path.join(tempDir, 'valid.json');
+      await fs.writeFile(filePath, '{"name": "test", "value": 42}');
+
+      const result = await safeJsonReadFile<{ name: string; value: number }>(filePath);
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({ name: 'test', value: 42 });
+      expect(result.fileNotFound).toBeUndefined();
+    });
+
+    it('should return fileNotFound for non-existent file', async () => {
+      const filePath = path.join(tempDir, 'nonexistent.json');
+
+      const result = await safeJsonReadFile(filePath);
+
+      expect(result.success).toBe(false);
+      expect(result.fileNotFound).toBe(true);
+      // Error message includes the path for better debugging
+      expect(result.error).toContain('ENOENT');
+      expect(result.error).toContain('nonexistent.json');
+    });
+
+    it('should return parse error for invalid JSON file', async () => {
+      const filePath = path.join(tempDir, 'invalid.json');
+      await fs.writeFile(filePath, 'not valid json {');
+
+      const result = await safeJsonReadFile(filePath);
+
+      expect(result.success).toBe(false);
+      expect(result.fileNotFound).toBeUndefined();
+      expect(result.error).toContain('JSON parse error');
+    });
+
+    it('should return parse error for truncated JSON', async () => {
+      const filePath = path.join(tempDir, 'truncated.json');
+      await fs.writeFile(filePath, '{"name": "test"');
+
+      const result = await safeJsonReadFile(filePath);
+
+      expect(result.success).toBe(false);
+      expect(result.fileNotFound).toBeUndefined();
+      expect(result.error).toContain('JSON parse error');
+    });
+
+    it('should handle empty file', async () => {
+      const filePath = path.join(tempDir, 'empty.json');
+      await fs.writeFile(filePath, '');
+
+      const result = await safeJsonReadFile(filePath);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('JSON parse error');
+    });
+  });
+});


### PR DESCRIPTION
- Add centralized isFileNotFound() utility to safeJson.ts
- Add isJsonParseError() utility for SyntaxError detection
- Add safeJsonReadFile() utility for file-based JSON parsing
- Fix specComposer.ts:1030 - log warning for non-ENOENT errors
- Fix traceabilityMapper.ts:407 - log warning for corrupted trace.json
- Fix traceabilityMapper.ts:666 - add debug logging for parse errors
- Add comprehensive tests for all new utilities (24 tests)

Resolves CDMCH-42

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>