### PR TITLE
fix(config): add specific migration warnings for all deprecated fields

### DIFF
--- a/src/core/config/validator.test.ts
+++ b/src/core/config/validator.test.ts
@@ -325,58 +325,38 @@ describe('checkSchemaCompatibility', () => {
   });
 
   describe('deprecated field detection', () => {
-    it('should detect safety.require_approval_for_prd and suggest migration', () => {
+    const testCases = [
+      {
+        field: 'require_approval_for_prd',
+        newPath: 'governance.approval_workflow.require_approval_for_prd',
+      },
+      {
+        field: 'require_approval_for_plan',
+        newPath: 'governance.approval_workflow.require_approval_for_plan',
+      },
+      {
+        field: 'require_approval_for_pr',
+        newPath: 'governance.approval_workflow.require_approval_for_pr',
+      },
+      {
+        field: 'prevent_force_push',
+        newPath: 'governance.risk_controls.prevent_force_push',
+      },
+    ];
+
+    it.each(testCases)('should detect safety.$field and suggest migration', ({ field, newPath }) => {
       const config = createDefaultConfig('https://github.com/org/repo.git');
-      config.safety.require_approval_for_prd = true;
-      const result = checkSchemaCompatibility(config, '1.1.0');
+      const rawConfig = {
+        schema_version: '1.0.0',
+        safety: {
+          [field]: true,
+        },
+      };
+      const result = checkSchemaCompatibility(config, '1.1.0', rawConfig);
 
       expect(
         result.migration_notes.some(
-          (note) =>
-            note.includes('safety.require_approval_for_prd') &&
-            note.includes('governance.approval_workflow.require_approval_for_prd')
-        )
-      ).toBe(true);
-    });
-
-    it('should detect safety.require_approval_for_plan and suggest migration', () => {
-      const config = createDefaultConfig('https://github.com/org/repo.git');
-      config.safety.require_approval_for_plan = true;
-      const result = checkSchemaCompatibility(config, '1.1.0');
-
-      expect(
-        result.migration_notes.some(
-          (note) =>
-            note.includes('safety.require_approval_for_plan') &&
-            note.includes('governance.approval_workflow.require_approval_for_plan')
-        )
-      ).toBe(true);
-    });
-
-    it('should detect safety.require_approval_for_pr and suggest migration', () => {
-      const config = createDefaultConfig('https://github.com/org/repo.git');
-      config.safety.require_approval_for_pr = true;
-      const result = checkSchemaCompatibility(config, '1.1.0');
-
-      expect(
-        result.migration_notes.some(
-          (note) =>
-            note.includes('safety.require_approval_for_pr') &&
-            note.includes('governance.approval_workflow.require_approval_for_pr')
-        )
-      ).toBe(true);
-    });
-
-    it('should detect safety.prevent_force_push and suggest migration', () => {
-      const config = createDefaultConfig('https://github.com/org/repo.git');
-      config.safety.prevent_force_push = true;
-      const result = checkSchemaCompatibility(config, '1.1.0');
-
-      expect(
-        result.migration_notes.some(
-          (note) =>
-            note.includes('safety.prevent_force_push') &&
-            note.includes('governance.risk_controls.prevent_force_push')
+          (note) => note.includes(`safety.${field}`) && note.includes(newPath)
         )
       ).toBe(true);
     });
@@ -400,11 +380,17 @@ describe('checkSchemaCompatibility', () => {
       const config = createDefaultConfig('https://github.com/org/repo.git', {
         includeGovernance: false,
       });
-      config.safety.require_approval_for_prd = true;
-      config.safety.require_approval_for_plan = true;
-      config.safety.prevent_force_push = true;
       config.governance_notes = 'Notes';
-      const result = checkSchemaCompatibility(config, '1.1.0');
+      const rawConfig = {
+        schema_version: '1.0.0',
+        safety: {
+          require_approval_for_prd: true,
+          require_approval_for_plan: true,
+          prevent_force_push: true,
+        },
+        governance_notes: 'Notes',
+      };
+      const result = checkSchemaCompatibility(config, '1.1.0', rawConfig);
 
       // Should have migration notes for each deprecated field
       expect(result.migration_notes.length).toBeGreaterThanOrEqual(4);
@@ -420,9 +406,22 @@ describe('checkSchemaCompatibility', () => {
       const config = createDefaultConfig('https://github.com/org/repo.git', {
         includeGovernance: true,
       });
-      // Don't explicitly set deprecated fields - they'll have defaults but should be migrated
-      const result = checkSchemaCompatibility(config, '1.1.0');
+      // Don't explicitly set deprecated fields in raw config
+      const rawConfig = {
+        schema_version: '1.0.0',
+        safety: {}, // Empty safety object - no deprecated fields explicitly set
+      };
+      const result = checkSchemaCompatibility(config, '1.1.0', rawConfig);
 
+      // Should not have migration notes for safety.* fields since they weren't explicitly set
+      expect(result.migration_notes.some((n) => n.includes('require_approval_for_prd'))).toBe(
+        false
+      );
+      expect(result.migration_notes.some((n) => n.includes('require_approval_for_plan'))).toBe(
+        false
+      );
+      expect(result.migration_notes.some((n) => n.includes('require_approval_for_pr'))).toBe(false);
+      expect(result.migration_notes.some((n) => n.includes('prevent_force_push'))).toBe(false);
       // When governance is included and no root governance_notes, no migration needed for that
       expect(result.migration_notes.some((n) => n.includes('governance_notes'))).toBe(false);
     });

--- a/src/core/config/validator.ts
+++ b/src/core/config/validator.ts
@@ -355,11 +355,13 @@ export function validateEnvironmentVariables(
  * Check if config can be safely migrated to a new schema version
  * @param config Current config
  * @param targetVersion Target schema version
+ * @param rawConfig Optional raw config (before Zod parsing) to detect explicitly set fields
  * @returns Compatibility result with migration notes
  */
 export function checkSchemaCompatibility(
   config: RepoConfig,
-  targetVersion: string
+  targetVersion: string,
+  rawConfig?: unknown
 ): {
   compatible: boolean;
   current_version: string;
@@ -385,38 +387,45 @@ export function checkSchemaCompatibility(
   }
 
   // Check for deprecated fields and provide specific migration paths
+  // Use rawConfig if provided to detect explicitly set fields (avoids false positives from defaults)
+  const raw = rawConfig as Record<string, unknown> | undefined;
 
   // Deprecated: governance_notes at root level
   if (config.governance_notes && !config.governance?.governance_notes) {
     migrationNotes.push('Migrate "governance_notes" to "governance.governance_notes"');
   }
 
-  // Deprecated: safety.require_approval_for_prd → governance.approval_workflow
-  if (config.safety.require_approval_for_prd !== undefined) {
-    migrationNotes.push(
-      'Migrate "safety.require_approval_for_prd" to "governance.approval_workflow.require_approval_for_prd"'
-    );
-  }
+  // Check safety.* fields only if we have raw config to detect explicit settings
+  if (raw?.safety && typeof raw.safety === 'object') {
+    const rawSafety = raw.safety as Record<string, unknown>;
 
-  // Deprecated: safety.require_approval_for_plan → governance.approval_workflow
-  if (config.safety.require_approval_for_plan !== undefined) {
-    migrationNotes.push(
-      'Migrate "safety.require_approval_for_plan" to "governance.approval_workflow.require_approval_for_plan"'
-    );
-  }
+    // Deprecated: safety.require_approval_for_prd → governance.approval_workflow
+    if ('require_approval_for_prd' in rawSafety) {
+      migrationNotes.push(
+        'Migrate "safety.require_approval_for_prd" to "governance.approval_workflow.require_approval_for_prd"'
+      );
+    }
 
-  // Deprecated: safety.require_approval_for_pr → governance.approval_workflow
-  if (config.safety.require_approval_for_pr !== undefined) {
-    migrationNotes.push(
-      'Migrate "safety.require_approval_for_pr" to "governance.approval_workflow.require_approval_for_pr"'
-    );
-  }
+    // Deprecated: safety.require_approval_for_plan → governance.approval_workflow
+    if ('require_approval_for_plan' in rawSafety) {
+      migrationNotes.push(
+        'Migrate "safety.require_approval_for_plan" to "governance.approval_workflow.require_approval_for_plan"'
+      );
+    }
 
-  // Deprecated: safety.prevent_force_push → governance.risk_controls
-  if (config.safety.prevent_force_push !== undefined) {
-    migrationNotes.push(
-      'Migrate "safety.prevent_force_push" to "governance.risk_controls.prevent_force_push"'
-    );
+    // Deprecated: safety.require_approval_for_pr → governance.approval_workflow
+    if ('require_approval_for_pr' in rawSafety) {
+      migrationNotes.push(
+        'Migrate "safety.require_approval_for_pr" to "governance.approval_workflow.require_approval_for_pr"'
+      );
+    }
+
+    // Deprecated: safety.prevent_force_push → governance.risk_controls
+    if ('prevent_force_push' in rawSafety) {
+      migrationNotes.push(
+        'Migrate "safety.prevent_force_push" to "governance.risk_controls.prevent_force_push"'
+      );
+    }
   }
 
   return {


### PR DESCRIPTION
- Add migration notes for safety.require_approval_for_prd -> governance.approval_workflow.require_approval_for_prd
- Add migration notes for safety.require_approval_for_plan -> governance.approval_workflow.require_approval_for_plan
- Add migration notes for safety.require_approval_for_pr -> governance.approval_workflow.require_approval_for_pr
- Add migration notes for safety.prevent_force_push -> governance.risk_controls.prevent_force_push
- Add tests for each deprecated field detection
- Add test for multiple deprecated fields migration

Closes CDMCH-47

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Replaced a generic migration warning with specific, actionable migration notes for each deprecated configuration field. The `checkSchemaCompatibility` function now provides individual migration paths for:

- `safety.require_approval_for_prd` → `governance.approval_workflow.require_approval_for_prd`
- `safety.require_approval_for_plan` → `governance.approval_workflow.require_approval_for_plan`
- `safety.require_approval_for_pr` → `governance.approval_workflow.require_approval_for_pr`
- `safety.prevent_force_push` → `governance.risk_controls.prevent_force_push`

**Implementation Details:**
- Uses `!== undefined` checks to detect when deprecated fields are explicitly set (important since fields have default values)
- Each field generates its own migration note with exact source and target paths
- Added 7 comprehensive test cases covering individual fields, multiple fields, and edge cases

**Testing Coverage:**
- Individual detection for each of the 4 deprecated `safety.*` fields
- Detection of root-level `governance_notes`
- Multiple deprecated fields in a single config
- Validation that no false positives occur when fields aren't set

<h3>Confidence Score: 5/5</h3>

- Safe to merge - well-tested improvement to user-facing migration warnings
- Code is straightforward and improves user experience by providing specific migration paths. All deprecated fields are properly detected with `!== undefined` checks. Comprehensive test coverage validates each field individually and together. No logic errors or edge cases identified.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/core/config/validator.ts | Replaced generic migration warning with specific warnings for each of 4 deprecated fields (`require_approval_for_prd`, `require_approval_for_plan`, `require_approval_for_pr`, `prevent_force_push`), providing clear migration paths |
| src/core/config/validator.test.ts | Added comprehensive test suite covering each deprecated field individually, multiple fields together, and edge cases where fields are not set |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant checkSchemaCompatibility
    participant RepoConfig
    participant migrationNotes

    User->>checkSchemaCompatibility: checkSchemaCompatibility(config, targetVersion)
    checkSchemaCompatibility->>RepoConfig: Parse schema_version
    checkSchemaCompatibility->>checkSchemaCompatibility: Compare versions
    
    alt Major version change
        checkSchemaCompatibility->>migrationNotes: Add breaking change warning
        checkSchemaCompatibility->>migrationNotes: Add documentation reference
        checkSchemaCompatibility->>migrationNotes: Add backup recommendation
    end
    
    checkSchemaCompatibility->>RepoConfig: Check config.governance_notes
    alt governance_notes at root
        checkSchemaCompatibility->>migrationNotes: Add governance_notes migration
    end
    
    checkSchemaCompatibility->>RepoConfig: Check config.safety.require_approval_for_prd
    alt require_approval_for_prd !== undefined
        checkSchemaCompatibility->>migrationNotes: Add specific migration for require_approval_for_prd
    end
    
    checkSchemaCompatibility->>RepoConfig: Check config.safety.require_approval_for_plan
    alt require_approval_for_plan !== undefined
        checkSchemaCompatibility->>migrationNotes: Add specific migration for require_approval_for_plan
    end
    
    checkSchemaCompatibility->>RepoConfig: Check config.safety.require_approval_for_pr
    alt require_approval_for_pr !== undefined
        checkSchemaCompatibility->>migrationNotes: Add specific migration for require_approval_for_pr
    end
    
    checkSchemaCompatibility->>RepoConfig: Check config.safety.prevent_force_push
    alt prevent_force_push !== undefined
        checkSchemaCompatibility->>migrationNotes: Add specific migration for prevent_force_push
    end
    
    checkSchemaCompatibility->>User: Return compatibility result with all migration notes
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->