### PR TITLE
feat(cli): add health command for runtime checks

### DIFF
--- a/src/cli/commands/health.ts
+++ b/src/cli/commands/health.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 import { loadRepoConfig } from '../../core/config/repo_config';
 
 const CONFIG_RELATIVE_PATH = path.join('.ai-feature-pipeline', 'config.json');
+const MIN_FREE_DISK_MB = 100;
 
 /**
  * Health check result
@@ -106,7 +107,7 @@ export default class Health extends Command {
       JSON.parse(content);
 
       // Attempt full config validation
-      loadRepoConfig(process.cwd());
+      loadRepoConfig(configPath);
 
       return {
         name: 'config',
@@ -133,8 +134,11 @@ export default class Health extends Command {
 
       // Probe writability with a temp file
       const probePath = path.join(runsDir, `.health_probe_${process.pid}`);
-      fs.writeFileSync(probePath, 'probe', 'utf-8');
-      fs.unlinkSync(probePath);
+      try {
+        fs.writeFileSync(probePath, 'probe', 'utf-8');
+      } finally {
+        try { fs.unlinkSync(probePath); } catch { /* probe may not exist */ }
+      }
 
       return {
         name: 'run_dir',
@@ -155,13 +159,12 @@ export default class Health extends Command {
       const stats = fs.statfsSync(process.cwd());
       const freeBytes = stats.bavail * stats.bsize;
       const freeMB = Math.round(freeBytes / (1024 * 1024));
-      const minFreeMB = 100;
 
-      if (freeMB < minFreeMB) {
+      if (freeMB < MIN_FREE_DISK_MB) {
         return {
           name: 'disk_space',
           status: 'fail',
-          message: `Low disk space: ${freeMB}MB free (minimum ${minFreeMB}MB)`,
+          message: `Low disk space: ${freeMB}MB free (minimum ${MIN_FREE_DISK_MB}MB)`,
         };
       }
 

--- a/tests/unit/commands/health.spec.ts
+++ b/tests/unit/commands/health.spec.ts
@@ -2,8 +2,9 @@
  * Unit tests for src/cli/commands/health.ts (CDMCH-77)
  */
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 
 describe('Health command', () => {
@@ -53,7 +54,7 @@ describe('Health command', () => {
     let tempDir: string;
 
     beforeEach(() => {
-      tempDir = fs.mkdtempSync(path.join(require('os').tmpdir(), 'health-test-'));
+      tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'health-test-'));
     });
 
     afterEach(() => {


### PR DESCRIPTION
### **User description**
Quick runtime health probe (<1s target) checking:
- Configuration file validity
- Run directory writability
- Disk space availability

Supports --json flag for machine-readable output.
Exit 0 (healthy) / 1 (unhealthy).

Closes CDMCH-77

Co-Authored-By: claude-flow <ruv@ruv.net>


___

### **PR Type**
Enhancement


___

### **Description**
- Add new `health` command for quick runtime health checks

- Validates configuration file, run directory writability, disk space

- Supports `--json` flag for machine-readable output with timestamps

- Includes comprehensive unit tests for all health check scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  HC["Health Command"]
  HC -- "checks config validity" --> CC["Config Check"]
  HC -- "checks directory writable" --> RDC["Run Dir Check"]
  HC -- "checks disk space" --> DSC["Disk Space Check"]
  CC --> JSON["JSON Output"]
  RDC --> JSON
  DSC --> JSON
  JSON --> EXIT["Exit 0/1"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>health.ts</strong><dd><code>Health command implementation with three checks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/cli/commands/health.ts

<ul><li>Implements Health command class extending oclif Command<br> <li> Performs three runtime checks: config validity, run directory <br>writability, disk space availability<br> <li> Supports <code>--json</code> flag for structured output with timestamp<br> <li> Returns exit code 0 (healthy) or 1 (unhealthy) based on check results</ul>


</details>


  </td>
  <td><a href="https://github.com/KingInYellows/codemachine-pipeline/pull/304/files#diff-1f0e8b5689cadb0a0a6bcf3150f2cb8c02f4b7b85b3e2408b2adf836641c4ad6">+181/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>health.spec.ts</strong><dd><code>Unit tests for health command functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/commands/health.spec.ts

<ul><li>Tests Health command module structure and flag definitions<br> <li> Validates config file detection and JSON parsing logic<br> <li> Tests disk space reading via statfsSync<br> <li> Tests run directory writability detection with temporary directories<br> <li> Validates JSON payload structure and exit code logic</ul>


</details>


  </td>
  <td><a href="https://github.com/KingInYellows/codemachine-pipeline/pull/304/files#diff-a7d492843def09bab77779a01d1b88cf59a406a1c7a851e84010ffe62b38b0c5">+119/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Added lightweight `health` command for quick runtime checks (<1s target) with three validations: config file validity, run directory writability, and disk space availability. Supports `--json` flag for machine-readable output and exits with code 0 (healthy) or 1 (unhealthy).

**Changes:**
- Implemented Health command class extending oclif Command with three synchronous health checks
- Config check validates JSON parsing and loads full config via `loadRepoConfig`
- Run directory check creates probe file to verify write permissions
- Disk space check uses `statfsSync` with 100MB minimum threshold
- JSON output includes structured payload with timestamp and exit code
- Comprehensive unit tests covering command structure and check logic

**Notes:**
- Intentionally lightweight without telemetry (aligns with <1s target)
- Uses synchronous fs operations appropriate for quick checks
- Follows oclif command patterns and exit code conventions
- Tests verify behavior but lack end-to-end integration tests

<h3>Confidence Score: 4/5</h3>

- Safe to merge - well-structured health command with appropriate scope and testing
- Simple, focused implementation with good test coverage. No telemetry is appropriate for lightweight health checks. Minor point: could benefit from integration tests.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/cli/commands/health.ts | Implements lightweight health command with three checks (config, run dir, disk space) following oclif patterns |
| tests/unit/commands/health.spec.ts | Unit tests cover command structure and check logic, lacks integration tests |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant HealthCmd as Health Command
    participant ConfigCheck as Config Check
    participant RunDirCheck as Run Dir Check
    participant DiskCheck as Disk Space Check
    participant Output as Output Handler

    User->>HealthCmd: Execute health command
    HealthCmd->>ConfigCheck: checkConfig()
    ConfigCheck->>ConfigCheck: Check file exists
    ConfigCheck->>ConfigCheck: Parse JSON
    ConfigCheck->>ConfigCheck: Load & validate config
    ConfigCheck-->>HealthCmd: HealthCheck result
    
    HealthCmd->>RunDirCheck: checkRunDirWritable()
    RunDirCheck->>RunDirCheck: Ensure dir exists
    RunDirCheck->>RunDirCheck: Write probe file
    RunDirCheck->>RunDirCheck: Delete probe file
    RunDirCheck-->>HealthCmd: HealthCheck result
    
    HealthCmd->>DiskCheck: checkDiskSpace()
    DiskCheck->>DiskCheck: statfsSync(cwd)
    DiskCheck->>DiskCheck: Calculate free MB
    DiskCheck->>DiskCheck: Compare to threshold
    DiskCheck-->>HealthCmd: HealthCheck result
    
    HealthCmd->>Output: Format output
    alt JSON flag
        Output->>User: JSON with timestamp
    else Human-readable
        Output->>User: Formatted text output
    end
    
    alt All checks pass
        HealthCmd->>User: Exit 0 (healthy)
    else Any check fails
        HealthCmd->>User: Exit 1 (unhealthy)
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->