### PR TITLE
fix: remove useless regex escapes

### DIFF
--- a/src/workflows/queueSnapshotManager.ts
+++ b/src/workflows/queueSnapshotManager.ts
@@ -137,7 +137,7 @@ export async function loadSnapshot(queueDir: string): Promise<QueueSnapshotV2 | 
  * @throws Error if path appears unsafe
  */
 function validateQueueDirectory(queueDir: string): void {
-  const segments = queueDir.split(/[\\\/]+/).filter(Boolean);
+  const segments = queueDir.split(/[\\/]+/).filter(Boolean);
 
   // Basic sanity checks for path traversal patterns
   if (segments.includes('..')) {

--- a/src/workflows/queueStore.ts
+++ b/src/workflows/queueStore.ts
@@ -244,7 +244,7 @@ export async function appendToQueue(
 
 /** Validate that a queue directory path is safe (defense-in-depth against path traversal). */
 function validateQueueDirectory(queueDir: string): void {
-  const segments = queueDir.split(/[\\\/]+/).filter(Boolean);
+  const segments = queueDir.split(/[\\/]+/).filter(Boolean);
 
   // Basic sanity checks for path traversal patterns
   if (segments.includes('..')) {


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes regex patterns in two queue management files by removing unnecessary escape sequences. Both changes are in `validateQueueDirectory()` functions that perform security checks against path traversal attacks.

**Changes:**
- Changed `/[\\\/]+/` to `/[\\/]+/` in path splitting regex patterns
- The double backslash (`\\`) was redundant inside character classes since backslashes don't need escaping when followed by forward slashes
- Functionality remains identical - the regex still correctly splits paths on both Windows (`\`) and Unix (`/`) separators

**Impact:**
- No behavioral changes - this is purely a code cleanup
- Path validation logic continues to work correctly
- Improves code readability and follows regex best practices

<h3>Confidence Score: 5/5</h3>

- Safe to merge - syntax-only cleanup with no functional changes
- The changes are minimal, well-understood regex syntax improvements. The escape sequences were redundant but not incorrect, so removing them has zero functional impact. Both files contain identical patterns in path validation functions used for security.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/workflows/queueSnapshotManager.ts | Removed unnecessary backslash escape in path separator regex on line 140 |
| src/workflows/queueStore.ts | Removed unnecessary backslash escape in path separator regex on line 247 |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant QSM as queueSnapshotManager.ts
    participant QS as queueStore.ts
    participant FS as File System

    Note over Dev,FS: Path Validation Flow (No functional changes)

    Dev->>QSM: validateQueueDirectory(queueDir)
    QSM->>QSM: Split path using /[\\/]+/
    Note over QSM: Previously: /[\\\/]+/<br/>Now: /[\\/]+/<br/>(Same behavior)
    QSM->>QSM: Check for '..' segments
    QSM-->>Dev: Valid or throw Error

    Dev->>QS: validateQueueDirectory(queueDir)
    QS->>QS: Split path using /[\\/]+/
    Note over QS: Previously: /[\\\/]+/<br/>Now: /[\\/]+/<br/>(Same behavior)
    QS->>QS: Check for '..' segments
    QS-->>Dev: Valid or throw Error

    Note over Dev,FS: Both functions maintain identical security behavior
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->