### PR TITLE
fix: include scripts in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ COPY package*.json ./
 # Copy source code BEFORE installing (to avoid prepare script running without source)
 COPY tsconfig.json ./
 COPY src ./src
+COPY scripts ./scripts
 
 # Install all dependencies (including dev for build)
 # This will trigger prepare script which will build


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a Docker build failure by adding the `scripts` directory to the build context. 

The issue occurred because:
- The `package.json` defines a `postbuild` script that executes `node scripts/tooling/oclif_manifest.js`
- The `prepare` script runs `npm run build`, which triggers the `postbuild` script after compilation
- During `npm ci` in the builder stage, the `prepare` hook executes, attempting to run the postbuild script
- Without the `scripts` directory present, the build failed with a "Cannot find module" error

The fix adds `COPY scripts ./scripts` on line 15 of the Dockerfile, immediately after copying the `src` directory. This ensures the postbuild script is available when `npm ci` runs the prepare hook.

**Changes:**
- Added `COPY scripts ./scripts` to Dockerfile line 15

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- Single-line fix that addresses a clear build failure. The change is minimal, necessary, and follows Dockerfile best practices by copying required build dependencies. No logical issues, security concerns, or side effects.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Dockerfile | Added `COPY scripts ./scripts` to fix Docker build failure where postbuild script (`scripts/tooling/oclif_manifest.js`) was missing during `npm ci` execution |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Docker as Docker Build Process
    participant Builder as Builder Stage (node:24-alpine)
    participant NPM as npm ci
    participant PostBuild as postbuild Script
    participant OclifScript as scripts/tooling/oclif_manifest.js
    participant Production as Production Stage

    Note over Docker,Builder: Build Stage
    Docker->>Builder: FROM node:24-alpine AS builder
    Builder->>Builder: COPY package*.json ./
    Builder->>Builder: COPY tsconfig.json ./
    Builder->>Builder: COPY src ./src
    Builder->>Builder: COPY scripts ./scripts (NEW)
    
    Note over NPM,OclifScript: Build Process
    Builder->>NPM: RUN npm ci
    NPM->>NPM: Install dependencies
    NPM->>NPM: Run prepare script (npm run build)
    NPM->>NPM: Run build script (tsc)
    NPM->>PostBuild: Run postbuild script
    PostBuild->>OclifScript: node scripts/tooling/oclif_manifest.js
    
    alt Scripts directory present (AFTER FIX)
        OclifScript->>OclifScript: Check OCLIF_SKIP_MANIFEST=1
        OclifScript->>OclifScript: Skip manifest generation
        OclifScript-->>PostBuild: Exit 0 (success)
    else Scripts directory missing (BEFORE FIX)
        OclifScript-->>PostBuild: Error: Cannot find module
        PostBuild-->>NPM: Build failure
        NPM-->>Docker: Docker build failed
    end
    
    Note over Production: Production Stage
    Docker->>Production: FROM node:24-alpine
    Production->>Production: Copy built artifacts from builder
    Production->>Production: Setup non-root user
    Docker->>Docker: Image ready
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->