### PR TITLE
fix: resolve TypeScript build errors from merged PRs (CDMCH-79)

### DIFF
--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -190,9 +190,6 @@ export default class Start extends Command {
 
     const startTime = Date.now();
     let currentStepLabel: string | undefined;
-        this.warn(warn);
-      }
-    }
 
     const repoConfig = settings.config;
     const repoRoot = this.findGitRoot();
@@ -797,7 +794,7 @@ export default class Start extends Command {
             'Initialize a new repo with "git init"',
             'Check that .git directory exists in parent directories',
           ],
-          cause: error instanceof Error ? error : undefined,
+          ...(error instanceof Error && { cause: error }),
         }
       );
     }
@@ -865,7 +862,7 @@ export default class Start extends Command {
             'Check that LINEAR_API_KEY has not expired',
             'Ensure network connectivity to api.linear.app',
           ],
-          cause: error instanceof Error ? error : undefined,
+          ...(error instanceof Error && { cause: error }),
         }
       );
     }

--- a/src/workflows/queueTypes.ts
+++ b/src/workflows/queueTypes.ts
@@ -351,7 +351,9 @@ export class QueueIntegrityError extends Error {
     this.name = 'QueueIntegrityError';
     this.kind = options.kind;
     this.location = options.location;
-    this.sequenceRange = options.sequenceRange;
+    if (options.sequenceRange) {
+      this.sequenceRange = options.sequenceRange;
+    }
     this.recoveryGuidance = options.recoveryGuidance;
   }
 }


### PR DESCRIPTION
- Remove orphaned code fragment in start.ts (dangling this.warn/braces)
- Fix exactOptionalPropertyTypes issues in start.ts (cause property)
- Fix exactOptionalPropertyTypes issue in queueTypes.ts (sequenceRange)

These issues were introduced by the merge of PRs #367 and #368.

Co-Authored-By: claude-flow <ruv@ruv.net>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes TypeScript build failures introduced by earlier merges by removing a stray orphaned fragment in `src/cli/commands/start.ts` and adjusting optional properties to comply with `exactOptionalPropertyTypes`.

In `start.ts`, `CliError` construction now only includes the `cause` field when the caught value is an actual `Error`, avoiding explicit `cause: undefined`. In `queueTypes.ts`, `QueueIntegrityError` now only assigns `sequenceRange` when provided so the optional field is not set to `undefined`.

These changes are small, localized, and align with existing error/typing patterns in the codebase.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Changes are narrowly scoped to removing invalid code and fixing optional-property typing (`exactOptionalPropertyTypes`) without altering runtime control flow beyond omitting undefined fields.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/cli/commands/start.ts | Removes a dangling orphaned brace/warn fragment and updates CliError construction to omit `cause` unless an Error is present, fixing exactOptionalPropertyTypes issues. |
| src/workflows/queueTypes.ts | Updates QueueIntegrityError to only assign optional `sequenceRange` when provided, aligning with exactOptionalPropertyTypes. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant User
  participant StartCmd as src/cli/commands/start.ts (Start)
  participant Git as git (rev-parse)
  participant Linear as LinearAdapter
  participant QueueTypes as src/workflows/queueTypes.ts

  User->>StartCmd: run `codepipe start`
  StartCmd->>Git: execSync('git rev-parse --show-toplevel')
  alt git command throws
    StartCmd-->>StartCmd: throw CliError({... , cause only if Error})
  end

  StartCmd->>Linear: fetchIssueSnapshot(issueId)
  alt Linear fetch throws
    StartCmd-->>StartCmd: throw CliError({... , cause only if Error})
  end

  Note over QueueTypes: QueueIntegrityError now
  Note over QueueTypes: only sets sequenceRange when provided
  StartCmd-->>User: exit with structured error (json or text)
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=bb24fbaf-5846-45c8-a308-366870e3fe9b))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=9f5b54f1-ca31-4019-9f81-b3d231c69850))

<!-- /greptile_comment -->