### PR TITLE
docs: add homelab quickstart guide (CDMCH-78)

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,253 @@
+# Homelab Quickstart Guide
+
+**Get codepipe running in under 5 minutes.**
+
+This guide walks you through installing and running your first AI-assisted feature pipeline on a local homelab environment. No GitHub or Linear accounts required.
+
+---
+
+## Prerequisites
+
+Before starting, ensure you have:
+
+- **Node.js 24+** - Check with `node --version`
+- **Git** - Check with `git --version`
+- **A code editor** (VS Code, Neovim, etc.)
+
+---
+
+## Step 1: Install codepipe
+
+Install globally via npm:
+
+```bash
+npm install -g codemachine-pipeline
+```
+
+Verify the installation:
+
+```bash
+codepipe --version
+```
+
+---
+
+## Step 2: Initialize Your Repository
+
+Navigate to your project directory (or create a new one):
+
+```bash
+mkdir my-project && cd my-project
+git init
+```
+
+Run the initialization wizard:
+
+```bash
+codepipe init
+```
+
+This scaffolds a schema-validated RepoConfig at:
+
+```
+.codepipe/config.json
+```
+
+For homelab/offline-friendly usage, make sure GitHub and Linear are disabled in that file:
+
+```json
+{
+  "github": { "enabled": false },
+  "linear": { "enabled": false }
+}
+```
+
+To actually run pipelines, you also need an agent endpoint configured via:
+
+```bash
+export AGENT_ENDPOINT="https://your-agent-service.example.com/v1"
+```
+
+Or by setting `runtime.agent_endpoint` in `.codepipe/config.json`. See `docs/requirements/RepoConfig_schema.md`.
+
+---
+
+## Step 3: Start a Feature Run
+
+Create your first AI-assisted feature:
+
+```bash
+codepipe start --prompt "Add a utility function to validate email addresses"
+```
+
+This provisions a run directory at `.codepipe/runs/<feature-id>/` containing:
+
+- `manifest.json` - Feature metadata and status
+- `artifacts/` - Generated PRD/spec/plan artifacts
+- `queue/` - Task queue state (e.g., `queue_snapshot.json`, `queue_operations.log`)
+- `logs/` and `telemetry/` - Execution logs and observability data
+
+For the authoritative structure, see `docs/requirements/run_directory_schema.md` and `docs/operations/queue-v2-operations.md`.
+
+---
+
+## Step 4: Check Status
+
+Monitor progress with:
+
+```bash
+codepipe status
+```
+
+For detailed output including task breakdown:
+
+```bash
+codepipe status --verbose
+```
+
+For machine-readable JSON:
+
+```bash
+codepipe status --json
+```
+
+---
+
+## Step 5: Approve and Execute
+
+When the pipeline pauses for approval:
+
+```bash
+codepipe approve prd --approve --signer "you@example.com"
+```
+
+Then resume execution:
+
+```bash
+codepipe resume
+```
+
+Review generated artifacts in `.codepipe/runs/<feature-id>/artifacts/`.
+
+---
+
+## Docker Alternative
+
+Run codepipe in a container without installing Node.js:
+
+```yaml
+# docker-compose.yml
+version: '3.8'
+services:
+  codepipe:
+    image: node:24-alpine
+    working_dir: /app
+    volumes:
+      - .:/app
+    command: >
+      sh -c "apk add --no-cache git &&
+             npm install -g codemachine-pipeline &&
+             codepipe init --yes &&
+             codepipe status"
+```
+
+Start with:
+
+```bash
+docker compose run codepipe
+```
+
+For interactive use:
+
+```bash
+docker compose run codepipe sh
+# Inside container:
+codepipe start --prompt "Your feature description"
+```
+
+---
+
+## Common Commands
+
+| Command | Description |
+|---------|-------------|
+| `codepipe init` | Initialize repository configuration |
+| `codepipe start --prompt "..."` | Start a new feature run |
+| `codepipe status` | Show current run status |
+| `codepipe status --json` | Machine-readable status output |
+| `codepipe approve prd --approve --signer "you@example.com"` | Approve the PRD gate (example) |
+| `codepipe resume` | Resume a paused or failed run |
+| `codepipe doctor` | Diagnose environment issues |
+
+---
+
+## Troubleshooting
+
+### `command not found: codepipe`
+
+Ensure npm global bin is in your PATH:
+
+```bash
+export PATH="$(npm config get prefix)/bin:$PATH"
+```
+
+Add this to your `~/.bashrc` or `~/.zshrc` for persistence.
+
+### Permission Denied Errors
+
+If npm install fails with EACCES:
+
+```bash
+# Option 1: Use a Node version manager (recommended)
+nvm install 24
+nvm use 24
+
+# Option 2: Configure npm for user-level installs
+mkdir -p "$HOME/.npm-global"
+npm config set prefix "$HOME/.npm-global"
+export PATH="$HOME/.npm-global/bin:$PATH"
+```
+
+### Node Version Too Old
+
+codepipe requires Node.js 24+. Upgrade with nvm:
+
+```bash
+nvm install 24
+nvm alias default 24
+```
+
+Or download directly from [nodejs.org](https://nodejs.org/).
+
+### Config File Not Found
+
+Run `codepipe init` first to generate `.codepipe/config.json`.
+
+---
+
+## Offline Mode
+
+codepipe works without GitHub/Linear when those integrations are disabled, but you still need an agent endpoint to generate PRDs/plans/code.
+
+For true offline operation, point `AGENT_ENDPOINT` at a local agent service (for example, a homelab-hosted OpenAI-compatible gateway):
+
+```bash
+export AGENT_ENDPOINT="http://localhost:8080/v1"
+```
+
+---
+
+## Next Steps
+
+- [Init Playbook](ops/init_playbook.md) - Detailed initialization options
+- [Doctor Reference](ops/doctor_reference.md) - Environment diagnostics
+- [CLI Reference](ops/cli-reference.md) - Full command reference
+- [RepoConfig Schema](requirements/RepoConfig_schema.md) - Configuration options
+
+---
+
+## Getting Help
+
+- Run `codepipe doctor` to diagnose common issues
+- Check logs in `.codepipe/runs/<feature-id>/telemetry/`
+- File issues at the project repository


### PR DESCRIPTION
- Create docs/quickstart.md with <5 min getting started guide
- Add Docker Compose alternative for containerized usage
- Include troubleshooting for PATH, permissions, Node version
- Add Quickstart and Testing links to docs/README.md

Co-Authored-By: claude-flow <ruv@ruv.net>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Homelab Quickstart guide covering local installation, setup, configuration examples, running features, Docker alternative, common commands, troubleshooting, and offline considerations.
  * Added a Testing Practices guide describing test organization, recommended tools and patterns, CI check commands, and guidelines for deterministic tests.
  * Updated documentation navigation with a new Quick Links entry for the Quickstart.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Adds a new `docs/quickstart.md` “Homelab Quickstart Guide” and links it from `docs/README.md`, plus adds a new “Testing Practices” link in the docs index.

Key issues to address before merge are documentation correctness: the quickstart’s config template describes a root `config.json` with fields (`version`, `integrations`, etc.) that don’t match the repo’s actual `.codepipe/config.json` RepoConfig schema, and one troubleshooting PATH export uses a quoted `~` that won’t expand in shells. Also, the newly-added Testing Practices link currently points to a non-existent file (`docs/development/testing.md`).

<h3>Confidence Score: 2/5</h3>

- This PR is not safe to merge as-is because the quickstart contains actionable steps that won’t work for new users (config schema/path, PATH export) and introduces a broken docs link.
- The changes are docs-only, but they introduce multiple concrete correctness issues that will mislead users and cause command failures/404s when following the guide.
- docs/quickstart.md, docs/README.md

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| docs/README.md | Adds Quickstart and Testing links; Testing link currently points to a non-existent file (docs/development/testing.md). |
| docs/quickstart.md | Adds a homelab quickstart; config example doesn’t match actual RepoConfig schema/path, and PATH troubleshooting uses quoted ~ which won’t expand. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant User
  participant NPM as npm registry
  participant Codepipe as codepipe CLI
  participant FS as Local filesystem
  participant Docker as docker compose (optional)

  User->>NPM: "npm install -g ai-feature-pipeline"
  User->>Codepipe: "codepipe --version"

  User->>FS: "mkdir my-project"
  User->>FS: "git init"
  User->>Codepipe: "codepipe init"
  Codepipe->>FS: "create .codepipe/ directories"
  Codepipe->>FS: "write .codepipe/config.json"

  User->>Codepipe: "codepipe start --prompt ..."
  Codepipe->>FS: "create .codepipe/runs/<feature-id>/"
  Codepipe->>FS: "write manifest.json"
  Codepipe->>FS: "write queue.wal"
  Codepipe->>FS: "write artifacts"

  User->>Codepipe: "codepipe status (--verbose|--json)"
  Codepipe->>FS: "read run state + telemetry"

  User->>Codepipe: "codepipe approve"
  Codepipe->>FS: "update approvals + run state"

  opt Containerized quickstart
    User->>Docker: "docker compose run codepipe"
    Docker->>NPM: "npm install -g ai-feature-pipeline"
    Docker->>Codepipe: "codepipe init"
    Docker->>Codepipe: "codepipe status"
    Codepipe->>FS: "write config + run data via bind mount"
  end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->