### PR TITLE
refactor: extract HTTP types/enums/constants to companion module (CDMCH-55)

### DIFF
--- a/src/adapters/http/client.ts
+++ b/src/adapters/http/client.ts
@@ -1,13 +1,29 @@
-import type { RequestInit, Response, HeadersInit, Headers } from 'undici-types';
+import type { Response, HeadersInit, Headers } from 'undici-types';
 import type { LogContext } from '../../core/sharedTypes';
 import * as crypto from 'node:crypto';
 import { RateLimitLedger, RateLimitEnvelope } from '../../telemetry/rateLimitLedger';
 import {
   createLogger,
   type StructuredLogger,
-  type LoggerInterface,
   LogLevel,
 } from '../../telemetry/logger';
+import {
+  ErrorType,
+  Provider,
+  DEFAULT_TIMEOUT,
+  DEFAULT_MAX_RETRIES,
+  DEFAULT_INITIAL_BACKOFF,
+  DEFAULT_MAX_BACKOFF,
+  JITTER_FACTOR,
+  ACCEPT_HEADER,
+  GITHUB_API_VERSION,
+} from './httpTypes.js';
+import type {
+  HttpClientConfig,
+  HttpRequestOptions,
+  HttpResponse,
+  LoggerInterface,
+} from './httpTypes.js';
 
 /**
  * HTTP Client Module
@@ -22,21 +38,9 @@ import {
  * Implements Technology Stack requirements and Rate Limit Discipline from the Rulebook.
  */
 
-// ============================================================================
-// Types & Constants
-// ============================================================================
-
-/**
- * Error taxonomy for structured error handling
- */
-export enum ErrorType {
-  /** Transient errors that should trigger retries (429, 503, network resets) */
-  TRANSIENT = 'transient',
-  /** Permanent errors that fail fast (validation, missing config, 404) */
-  PERMANENT = 'permanent',
-  /** Errors requiring human intervention (approval needed, token expired) */
-  HUMAN_ACTION_REQUIRED = 'human_action_required',
-}
+// Re-export types and enums for backward compatibility
+export { ErrorType, Provider } from './httpTypes.js';
+export type { HttpClientConfig, HttpRequestOptions, HttpResponse, LoggerInterface } from './httpTypes.js';
 
 /**
  * Structured HTTP error with metadata
@@ -72,89 +76,6 @@ export class HttpError extends Error {
     };
   }
 }
-
-/**
- * HTTP provider type (GitHub, Linear, etc.)
- */
-export enum Provider {
-  GITHUB = 'github',
-  LINEAR = 'linear',
-  GRAPHITE = 'graphite',
-  CODEMACHINE = 'codemachine',
-  CUSTOM = 'custom',
-}
-
-/**
- * HTTP client configuration
- */
-export interface HttpClientConfig {
-  /** Base URL for API requests */
-  baseUrl: string;
-  /** Provider type for rate limit tracking */
-  provider: Provider;
-  /** Authorization token (will be injected as Bearer token) */
-  token?: string;
-  /** Run directory path for ledger persistence */
-  runDir?: string;
-  /** Custom headers to inject on every request */
-  defaultHeaders?: Record<string, string>;
-  /** Request timeout in milliseconds */
-  timeout?: number;
-  /** Maximum retry attempts */
-  maxRetries?: number;
-  /** Initial backoff delay in milliseconds */
-  initialBackoff?: number;
-  /** Maximum backoff delay in milliseconds */
-  maxBackoff?: number;
-  /** Logger interface for observability */
-  logger?: LoggerInterface;
-}
-
-export type { LoggerInterface };
-
-/**
- * HTTP request options
- */
-export interface HttpRequestOptions extends Omit<RequestInit, 'headers'> {
-  /** Custom headers for this request */
-  headers?: Record<string, string>;
-  /** Whether to generate an idempotency key */
-  idempotent?: boolean;
-  /** Override retry behavior for this request */
-  retry?: {
-    enabled: boolean;
-    maxAttempts?: number;
-  };
-  /** Request metadata for logging */
-  metadata?: Record<string, unknown>;
-}
-
-/**
- * HTTP response wrapper
- */
-export interface HttpResponse<T = unknown> {
-  /** Response status code */
-  status: number;
-  /** Response headers */
-  headers: Record<string, string>;
-  /** Parsed response body */
-  data: T;
-  /** Request ID for tracing */
-  requestId: string;
-  /** Rate limit envelope if applicable */
-  rateLimitEnvelope?: RateLimitEnvelope;
-}
-
-// Default configuration values
-const DEFAULT_TIMEOUT = 30000; // 30 seconds
-const DEFAULT_MAX_RETRIES = 3;
-const DEFAULT_INITIAL_BACKOFF = 1000; // 1 second
-const DEFAULT_MAX_BACKOFF = 32000; // 32 seconds
-const JITTER_FACTOR = 0.1; // 10% jitter
-
-// Standard headers
-const ACCEPT_HEADER = 'application/vnd.github+json';
-const GITHUB_API_VERSION = '2022-11-28';
 
 // ============================================================================
 // HTTP Client

--- a/src/adapters/http/httpTypes.ts
+++ b/src/adapters/http/httpTypes.ts
@@ -1,0 +1,120 @@
+/**
+ * HTTP Client Types
+ *
+ * Type definitions, enums, and constants for the HTTP client module.
+ * Extracted from client.ts for single-responsibility.
+ */
+
+import type { RequestInit } from 'undici-types';
+import type { LoggerInterface } from '../../telemetry/logger';
+
+// ============================================================================
+// Enums
+// ============================================================================
+
+/**
+ * Error taxonomy for structured error handling
+ */
+export enum ErrorType {
+  /** Transient errors that should trigger retries (429, 503, network resets) */
+  TRANSIENT = 'transient',
+  /** Permanent errors that fail fast (validation, missing config, 404) */
+  PERMANENT = 'permanent',
+  /** Errors requiring human intervention (approval needed, token expired) */
+  HUMAN_ACTION_REQUIRED = 'human_action_required',
+}
+
+/**
+ * HTTP provider type (GitHub, Linear, etc.)
+ */
+export enum Provider {
+  GITHUB = 'github',
+  LINEAR = 'linear',
+  GRAPHITE = 'graphite',
+  CODEMACHINE = 'codemachine',
+  CUSTOM = 'custom',
+}
+
+// ============================================================================
+// Interfaces
+// ============================================================================
+
+/**
+ * HTTP client configuration
+ */
+export interface HttpClientConfig {
+  /** Base URL for API requests */
+  baseUrl: string;
+  /** Provider type for rate limit tracking */
+  provider: Provider;
+  /** Authorization token (will be injected as Bearer token) */
+  token?: string;
+  /** Run directory path for ledger persistence */
+  runDir?: string;
+  /** Custom headers to inject on every request */
+  defaultHeaders?: Record<string, string>;
+  /** Request timeout in milliseconds */
+  timeout?: number;
+  /** Maximum retry attempts */
+  maxRetries?: number;
+  /** Initial backoff delay in milliseconds */
+  initialBackoff?: number;
+  /** Maximum backoff delay in milliseconds */
+  maxBackoff?: number;
+  /** Logger interface for observability */
+  logger?: LoggerInterface;
+}
+
+export type { LoggerInterface };
+
+/**
+ * HTTP request options
+ */
+export interface HttpRequestOptions extends Omit<RequestInit, 'headers'> {
+  /** Custom headers for this request */
+  headers?: Record<string, string>;
+  /** Whether to generate an idempotency key */
+  idempotent?: boolean;
+  /** Override retry behavior for this request */
+  retry?: {
+    enabled: boolean;
+    maxAttempts?: number;
+  };
+  /** Request metadata for logging */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * HTTP response wrapper
+ */
+export interface HttpResponse<T = unknown> {
+  /** Response status code */
+  status: number;
+  /** Response headers */
+  headers: Record<string, string>;
+  /** Parsed response body */
+  data: T;
+  /** Request ID for tracing */
+  requestId: string;
+  /** Rate limit envelope if applicable */
+  rateLimitEnvelope?: import('../../telemetry/rateLimitLedger').RateLimitEnvelope;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Default request timeout (30 seconds) */
+export const DEFAULT_TIMEOUT = 30000;
+/** Default maximum retry attempts */
+export const DEFAULT_MAX_RETRIES = 3;
+/** Default initial backoff delay (1 second) */
+export const DEFAULT_INITIAL_BACKOFF = 1000;
+/** Default maximum backoff delay (32 seconds) */
+export const DEFAULT_MAX_BACKOFF = 32000;
+/** Jitter factor for backoff (10%) */
+export const JITTER_FACTOR = 0.1;
+/** Standard Accept header for GitHub API */
+export const ACCEPT_HEADER = 'application/vnd.github+json';
+/** GitHub API version header value */
+export const GITHUB_API_VERSION = '2022-11-28';

--- a/tests/unit/codeMachineRunner.runner.spec.ts
+++ b/tests/unit/codeMachineRunner.runner.spec.ts
@@ -97,7 +97,12 @@ describe('CodeMachineRunner', () => {
   const mockCreateWriteStream = vi.mocked(createWriteStream);
 
   beforeEach(() => {
+    // Avoid leaking `mock*Once()` queues / implementations across tests without replacing the
+    // mocked module function identities (which would break our cached `vi.mocked(...)` refs).
     vi.clearAllMocks();
+    mockSpawn.mockReset();
+    mockFsAccess.mockReset();
+    mockCreateWriteStream.mockReset();
     vi.useRealTimers();
   });
 
@@ -1098,13 +1103,24 @@ describe('CodeMachineRunner', () => {
 
       const promise = runCodeMachine(config, options);
 
-      setTimeout(() => {
-        const stdoutChunk = Buffer.from('stdout line\n');
-        const stderrChunk = Buffer.from('stderr line\n');
-        childProcess.stdout?.emit('data', stdoutChunk);
-        childProcess.stderr?.emit('data', stderrChunk);
-        childProcess.emit('close', 0);
-      }, 10);
+      // `runCodeMachine` awaits `fs.stat(logPath)` before calling `spawn`, so make sure the
+      // spawn call (and event handlers) are attached before emitting process events.
+      await new Promise<void>((resolve) => {
+        const poll = (): void => {
+          if (mockSpawn.mock.calls.length > 0) {
+            resolve();
+            return;
+          }
+          setTimeout(poll, 0);
+        };
+        poll();
+      });
+
+      const stdoutChunk = Buffer.from('stdout line\n');
+      const stderrChunk = Buffer.from('stderr line\n');
+      childProcess.stdout?.emit('data', stdoutChunk);
+      childProcess.stderr?.emit('data', stderrChunk);
+      childProcess.emit('close', 0);
 
       await promise;
 
@@ -1146,10 +1162,19 @@ describe('CodeMachineRunner', () => {
 
       const promise = runCodeMachine(config, options);
 
-      setTimeout(() => {
-        mockStream.emit('error', new Error('Disk full'));
-        childProcess.emit('close', 0);
-      }, 10);
+      await new Promise<void>((resolve) => {
+        const poll = (): void => {
+          if (mockSpawn.mock.calls.length > 0) {
+            resolve();
+            return;
+          }
+          setTimeout(poll, 0);
+        };
+        poll();
+      });
+
+      mockStream.emit('error', new Error('Disk full'));
+      childProcess.emit('close', 0);
 
       const result = await promise;
 
@@ -1206,14 +1231,25 @@ describe('CodeMachineRunner', () => {
 
       const promise = runCodeMachine(config, options);
 
-      setTimeout(() => {
-        const largeChunk = Buffer.alloc(1024 * 1024 + 1, 'a');
-        childProcess.stdout?.emit('data', largeChunk);
-        childProcess.emit('close', 0);
-      }, 10);
+      // `runCodeMachine` awaits an initial `fs.stat(logPath)` before calling `spawn`,
+      // so wait until the spawn call is observed before emitting process events.
+      await new Promise<void>((resolve) => {
+        const poll = (): void => {
+          if (mockSpawn.mock.calls.length > 0) {
+            resolve();
+            return;
+          }
+          setTimeout(poll, 0);
+        };
+        poll();
+      });
+
+      const spawnedProcess = mockSpawn.mock.results[0]?.value as ChildProcess;
+      const largeChunk = Buffer.alloc(1024 * 1024 + 1, 'a');
+      spawnedProcess.stdout?.emit('data', largeChunk);
+      spawnedProcess.emit('close', 0);
 
       await promise;
-      await new Promise((resolve) => setTimeout(resolve, 0));
 
       expect(mockCreateWriteStream).toHaveBeenCalledTimes(2);
       expect(renameSpy).toHaveBeenCalledWith('/tmp/test.log', '/tmp/test.log.1');


### PR DESCRIPTION
Move ErrorType, Provider enums, config interfaces, and constants from
client.ts to httpTypes.ts. Original module re-exports for backward compat.

Co-Authored-By: claude-flow <ruv@ruv.net>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Refactored HTTP client module to extract type definitions, enums (`ErrorType`, `Provider`), interfaces (`HttpClientConfig`, `HttpRequestOptions`, `HttpResponse`), and constants to a companion module `httpTypes.ts`. The original `client.ts` re-exports all moved types for backward compatibility.

Key changes:
- Created `src/adapters/http/httpTypes.ts` with all type definitions, enums, and constants
- Updated `src/adapters/http/client.ts` to import from `httpTypes.ts` and re-export for backward compatibility
- Maintained single-responsibility principle: `httpTypes.ts` defines types, `client.ts` implements behavior
- Verified backward compatibility: all 13 importing files continue to work without changes
- All imports use `.js` extension as required by Node16 module resolution

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Clean refactoring that extracts types to a companion module while maintaining full backward compatibility through re-exports. No logic changes, all existing imports verified working, follows TypeScript/Node16 module conventions with .js extensions, and adheres to single-responsibility principle
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/adapters/http/client.ts | Extracted types/enums/constants to httpTypes.ts while maintaining backward compatibility through re-exports |
| src/adapters/http/httpTypes.ts | New companion module containing HTTP type definitions, enums (ErrorType, Provider), interfaces, and constants |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Consumer as Consumer Code
    participant Client as client.ts
    participant Types as httpTypes.ts
    participant Logger as telemetry/logger
    
    Note over Consumer,Types: Type Extraction Refactoring
    
    Consumer->>Client: import { ErrorType, Provider, HttpClient }
    Client->>Types: re-export ErrorType, Provider
    Types-->>Client: return enums
    Client-->>Consumer: provide types (backward compatible)
    
    Consumer->>Client: import { HttpClientConfig }
    Client->>Types: re-export interface
    Types-->>Client: return interface
    Client-->>Consumer: provide interface
    
    Consumer->>Client: new HttpClient(config)
    Client->>Types: use DEFAULT_TIMEOUT, constants
    Client->>Logger: import LoggerInterface
    Types->>Logger: import LoggerInterface (re-exported)
    Client-->>Consumer: return HttpClient instance
    
    Note over Client,Types: All type definitions now in httpTypes.ts
    Note over Client: client.ts focuses on HttpClient implementation
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->