### PR TITLE
fix: add missing await to async validateRepoConfig calls in smoke tests

### DIFF
--- a/tests/integration/smoke_no_credentials_fixed.spec.ts
+++ b/tests/integration/smoke_no_credentials_fixed.spec.ts
@@ -76,7 +76,7 @@ describe('Smoke Tests: No Credentials Required', () => {
       config.linear.enabled = false;
       await fs.writeFile(configPath, JSON.stringify(config, null, 2));
 
-      const result = validateRepoConfig(configPath, {
+      const result = await validateRepoConfig(configPath, {
         checkCredentials: false,
         checkDirectories: false,
         enforceGovernance: false,
@@ -94,7 +94,7 @@ describe('Smoke Tests: No Credentials Required', () => {
       config.linear.enabled = true;
       await fs.writeFile(configPath, JSON.stringify(config, null, 2));
 
-      const result = validateRepoConfig(configPath, {
+      const result = await validateRepoConfig(configPath, {
         checkCredentials: false,
         checkDirectories: false,
       });
@@ -145,7 +145,7 @@ describe('Smoke Tests: No Credentials Required', () => {
       config.linear.enabled = false;
       await fs.writeFile(configPath, JSON.stringify(config, null, 2));
 
-      const result = validateRepoConfig(configPath, {
+      const result = await validateRepoConfig(configPath, {
         checkCredentials: false,
         checkDirectories: false,
         enforceGovernance: true,
@@ -163,7 +163,7 @@ describe('Smoke Tests: No Credentials Required', () => {
       config.github.enabled = false;
       await fs.writeFile(configPath, JSON.stringify(config, null, 2));
 
-      const result = validateRepoConfig(configPath, {
+      const result = await validateRepoConfig(configPath, {
         checkCredentials: false,
         checkDirectories: false,
         enforceGovernance: true,


### PR DESCRIPTION
The 4 failing tests in smoke_no_credentials_fixed.spec.ts were calling
the async validateRepoConfig() without await, causing all assertions
to check properties on a Promise object (always undefined).

Co-Authored-By: claude-flow <ruv@ruv.net>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Fixed a critical bug where 4 test cases were calling the async `validateRepoConfig()` function without `await`, causing the tests to assert against a Promise object rather than the resolved validation result. This resulted in all assertions checking `undefined` properties and the tests incorrectly passing or failing.

**Changed lines:**
- Line 79: Added `await` before `validateRepoConfig()`
- Line 97: Added `await` before `validateRepoConfig()`
- Line 148: Added `await` before `validateRepoConfig()`
- Line 166: Added `await` before `validateRepoConfig()`

**Impact:** These 4 tests now properly wait for validation to complete and check actual result properties (`result.success`, `result.checks`, `result.errors`) instead of attempting to access properties on a Promise object.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no risk
- The fix is straightforward and correct: it adds the missing `await` keyword to 4 async function calls. This is a textbook async/await bug fix with no side effects, no logic changes, and no new code introduced. The change ensures tests actually validate the resolved values rather than Promise objects.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tests/integration/smoke_no_credentials_fixed.spec.ts | Fixed missing `await` on 4 async `validateRepoConfig()` calls that were returning Promise objects instead of resolved values, causing all assertions to fail |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as Test Suite
    participant FS as File System
    participant Validator as validateRepoConfig()
    
    Note over Test,Validator: Before Fix: Missing await
    Test->>FS: writeFile(config)
    FS-->>Test: Success
    Test->>Validator: validateRepoConfig(configPath, options)
    Note over Test,Validator: ❌ Returns Promise (not awaited)
    Validator-->>Test: Promise<ExtendedValidationResult>
    Test->>Test: expect(result.success)
    Note over Test: ❌ Accessing property on Promise object<br/>result = Promise {}, result.success = undefined
    
    Note over Test,Validator: After Fix: Added await
    Test->>FS: writeFile(config)
    FS-->>Test: Success
    Test->>Validator: await validateRepoConfig(configPath, options)
    Note over Validator: Async validation logic executes
    Validator->>FS: Read config file
    FS-->>Validator: Config contents
    Validator->>Validator: Parse and validate
    Validator-->>Test: ✅ ExtendedValidationResult object
    Test->>Test: expect(result.success)
    Note over Test: ✅ Accessing actual result properties<br/>result = {success: true, checks: {...}}
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->