### PR TITLE
fix: resolve 4 pre-existing eslint errors

### DIFF
--- a/src/adapters/agents/AgentAdapter.ts
+++ b/src/adapters/agents/AgentAdapter.ts
@@ -267,8 +267,7 @@ export type ProviderInvoker = (
  * Session telemetry record for audit trails
  * Schema is used for type inference only; runtime validation is not required for internal telemetry
  */
-// Note: Schema appears unused but is required for type inference via z.infer
-const SessionTelemetrySchema = z
+export const SessionTelemetrySchema = z
   .object({
     sessionId: z.string().min(1),
     taskId: z.string().min(1),

--- a/src/validation/errors.ts
+++ b/src/validation/errors.ts
@@ -83,7 +83,8 @@ function mapZodIssue(issue: ZodIssue): ValidationIssue {
     base.expected = typeof issue.expected === 'string' ? issue.expected : String(issue.expected);
   }
   if ('received' in issue && issue.received !== undefined) {
-    base.received = typeof issue.received === 'string' ? issue.received : String(issue.received);
+    base.received =
+      typeof issue.received === 'string' ? issue.received : JSON.stringify(issue.received);
   }
 
   return base;

--- a/tests/unit/validationHelpers.spec.ts
+++ b/tests/unit/validationHelpers.spec.ts
@@ -189,8 +189,8 @@ describe('fromZodError', () => {
       expect(nameIssue).toBeDefined();
       expect(nameIssue!.code).toBeDefined();
       // The mapper preserves expected/received when present; only assert when present
-      if ('expected' in nameIssue! && nameIssue!.expected !== undefined) {
-        expect(nameIssue!.expected).toBeDefined();
+      if (nameIssue && 'expected' in nameIssue && nameIssue.expected !== undefined) {
+        expect(nameIssue.expected).toBeDefined();
       }
     }
   });


### PR DESCRIPTION
- Export SessionTelemetrySchema (was only used as type via z.infer)
- Use JSON.stringify instead of String() for non-base-to-string safety
- Remove unnecessary non-null assertions in validation test

Co-Authored-By: claude-flow <ruv@ruv.net>