### PR TITLE
fix: resolve 14 new eslint 10 rule violations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "codepipe": "bin/run.js"
       },
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "@types/node": "^25.2.2",
         "@types/picomatch": "^4.0.2",
         "@typescript-eslint/eslint-plugin": "^8.54.0",
@@ -659,6 +660,27 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/object-schema": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@types/node": "^25.2.2",
     "@types/picomatch": "^4.0.2",
     "@typescript-eslint/eslint-plugin": "^8.54.0",

--- a/src/cli/pr/shared.ts
+++ b/src/cli/pr/shared.ts
@@ -108,7 +108,8 @@ export async function loadPRContext(
       error: getErrorMessage(error),
     });
     throw new Error(
-      `Failed to read manifest for feature ${featureId}: ${getErrorMessage(error)}`
+      `Failed to read manifest for feature ${featureId}: ${getErrorMessage(error)}`,
+      { cause: error }
     );
   }
 
@@ -256,7 +257,8 @@ export async function persistPRData(context: PRContext, prMetadata: PRMetadata):
       error: getErrorMessage(error),
     });
     throw new Error(
-      `Failed to persist PR metadata: ${getErrorMessage(error)}`
+      `Failed to persist PR metadata: ${getErrorMessage(error)}`,
+      { cause: error }
     );
   }
 }

--- a/src/cli/status/data.ts
+++ b/src/cli/status/data.ts
@@ -116,7 +116,6 @@ export async function loadContextStatus(
     };
   }
 
-  let docPayload: StatusContextPayload = {};
   const jsonData = safeJsonParse<unknown>(content);
   if (!jsonData) {
     return {
@@ -132,7 +131,7 @@ export async function loadContextStatus(
   }
 
   const contextDoc = parsed.data;
-  docPayload = {
+  const docPayload: StatusContextPayload = {
     files: Object.keys(contextDoc.files).length,
     total_tokens: contextDoc.total_token_count,
     summaries: contextDoc.summaries.length,

--- a/src/persistence/hashManifest.ts
+++ b/src/persistence/hashManifest.ts
@@ -114,9 +114,9 @@ export async function computeFileHash(filePath: string): Promise<string> {
     return hash.digest('hex');
   } catch (error) {
     if (error instanceof Error) {
-      throw new Error(`Failed to compute hash for ${filePath}: ${error.message}`);
+      throw new Error(`Failed to compute hash for ${filePath}: ${error.message}`, { cause: error });
     }
-    throw new Error(`Failed to compute hash for ${filePath}: Unknown error`);
+    throw new Error(`Failed to compute hash for ${filePath}: Unknown error`, { cause: error });
   }
 }
 
@@ -403,9 +403,9 @@ export async function loadHashManifest(manifestPath: string): Promise<HashManife
     return manifest;
   } catch (error) {
     if (error instanceof Error) {
-      throw new Error(`Failed to load hash manifest: ${error.message}`);
+      throw new Error(`Failed to load hash manifest: ${error.message}`, { cause: error });
     }
-    throw new Error('Failed to load hash manifest: Unknown error');
+    throw new Error('Failed to load hash manifest: Unknown error', { cause: error });
   }
 }
 

--- a/src/workflows/deploymentTriggerContext.ts
+++ b/src/workflows/deploymentTriggerContext.ts
@@ -79,7 +79,8 @@ export async function loadDeploymentContext(
       error: getErrorMessage(error),
     });
     throw new Error(
-      `Run manifest not found. Ensure the feature run directory exists and is initialized (run directory: ${runDirectory})`
+      `Run manifest not found. Ensure the feature run directory exists and is initialized (run directory: ${runDirectory})`,
+      { cause: error }
     );
   }
 
@@ -96,7 +97,8 @@ export async function loadDeploymentContext(
       error: getErrorMessage(error),
     });
     throw new Error(
-      `PR metadata not found. Ensure PR has been created first (run directory: ${runDirectory})`
+      `PR metadata not found. Ensure PR has been created first (run directory: ${runDirectory})`,
+      { cause: error }
     );
   }
 

--- a/src/workflows/patchManager.ts
+++ b/src/workflows/patchManager.ts
@@ -275,7 +275,8 @@ export async function isWorkingTreeClean(workingDir: string): Promise<boolean> {
     return stdout.trim().length === 0;
   } catch (error) {
     throw new Error(
-      `Failed to check git working tree status: ${error instanceof Error ? error.message : 'Unknown error'}`
+      `Failed to check git working tree status: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      { cause: error }
     );
   }
 }
@@ -300,7 +301,8 @@ export async function getCurrentGitRef(workingDir: string): Promise<{ ref: strin
     };
   } catch (error) {
     throw new Error(
-      `Failed to get current git ref: ${error instanceof Error ? error.message : 'Unknown error'}`
+      `Failed to get current git ref: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      { cause: error }
     );
   }
 }

--- a/src/workflows/prdAuthoringEngine.ts
+++ b/src/workflows/prdAuthoringEngine.ts
@@ -200,7 +200,8 @@ async function loadTemplate(customPath?: string): Promise<string> {
     return content;
   } catch (error) {
     throw new Error(
-      `Failed to load PRD template from ${templatePath}: ${error instanceof Error ? error.message : 'Unknown error'}`
+      `Failed to load PRD template from ${templatePath}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      { cause: error }
     );
   }
 }
@@ -529,7 +530,8 @@ export async function recordPRDApproval(
       metadata = parsedMetadata as PRDMetadata;
     } catch (error) {
       throw new Error(
-        `Failed to load PRD metadata: ${error instanceof Error ? error.message : 'Unknown error'}`
+        `Failed to load PRD metadata: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        { cause: error }
       );
     }
 

--- a/src/workflows/specComposer.ts
+++ b/src/workflows/specComposer.ts
@@ -386,7 +386,8 @@ export async function recordSpecApproval(
       metadata = JSON.parse(metadataContent) as SpecMetadata;
     } catch (error) {
       throw new Error(
-        `Failed to load spec metadata: ${error instanceof Error ? error.message : 'Unknown error'}`
+        `Failed to load spec metadata: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        { cause: error }
       );
     }
 


### PR DESCRIPTION
- Add { cause: error } to 12 re-thrown errors (preserve-caught-error)
- Remove useless assignment in status/data.ts (no-useless-assignment)
- Promote to const after removing dead initializer (prefer-const)
- Install @eslint/js as explicit devDependency for ESLint 10

Co-Authored-By: claude-flow <ruv@ruv.net>

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR primarily addresses ESLint 10 migration fallout by updating error rethrow sites to include `Error(..., { cause })`, removing a dead assignment in `src/cli/status/data.ts`, and adding `@eslint/js` as an explicit devDependency (required by the flat config usage).

Most code paths are unchanged functionally; the main behavioral effect is improved error chaining for debugging/telemetry.

One merge-blocking concern is in `src/persistence/hashManifest.ts`, where the non-`Error` catch branch now attaches `{ cause: error }` even though `error` can be a primitive or arbitrary object. Elsewhere in the codebase, error serialization only treats causes recursively when they are `Error`/`HttpError`, so this can lead to inconsistent logging/telemetry and loss of context compared to wrapping the non-Error into an `Error` first.

<h3>Confidence Score: 4/5</h3>

- Safe to merge after addressing the one error-cause consistency issue in hashManifest error wrapping.
- Changes are mechanical (ESLint rule compliance) and mostly improve error chaining without altering control flow; the only concrete issue is attaching non-Error `cause` values in hashManifest, which can degrade downstream error serialization/telemetry consistency.
- src/persistence/hashManifest.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| package.json | Adds @eslint/js as an explicit devDependency for ESLint 10 flat config usage. |
| package-lock.json | Lockfile updates to include @eslint/js@10.0.1 as a dev dependency; changes are minimal and consistent with package.json. |
| src/cli/pr/shared.ts | Wraps rethrown errors with `{ cause: error }` to preserve the caught error context when failing to read manifest or persist PR metadata. |
| src/cli/status/data.ts | Removes dead initializer and promotes `docPayload` to `const` at point of initialization (no behavior change). |
| src/persistence/hashManifest.ts | Adds `{ cause: error }` to rethrown errors; non-Error branch now attaches arbitrary `unknown` as cause which can reduce error serialization fidelity. |
| src/workflows/deploymentTriggerContext.ts | Adds `{ cause }` when rethrowing missing manifest / missing pr.json errors; improves debuggability without changing control flow. |
| src/workflows/patchManager.ts | Adds `{ cause }` to git command failure rethrows; no change in success path or error message formatting. |
| src/workflows/prdAuthoringEngine.ts | Adds `{ cause }` to template/metadata load error rethrows; preserves original exception context. |
| src/workflows/specComposer.ts | Adds `{ cause }` to spec metadata load error rethrow; improves error chaining without changing behavior. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  autonumber
  participant Caller as Workflow/CLI caller
  participant PR as src/cli/pr/shared.ts
  participant DeployCtx as src/workflows/deploymentTriggerContext.ts
  participant Patch as src/workflows/patchManager.ts
  participant PRD as src/workflows/prdAuthoringEngine.ts
  participant Spec as src/workflows/specComposer.ts
  participant Hash as src/persistence/hashManifest.ts

  Caller->>PR: loadPRContext()
  PR->>PR: readManifest()
  PR-->>Caller: throw new Error(msg, { cause: error }) on failure

  Caller->>DeployCtx: loadDeploymentContext()
  DeployCtx->>DeployCtx: readManifest() / read pr.json
  DeployCtx-->>Caller: throw new Error(msg, { cause: error }) on failure

  Caller->>Patch: isWorkingTreeClean() / getCurrentGitRef()
  Patch-->>Caller: throw new Error(msg, { cause: error }) on failure

  Caller->>PRD: loadTemplate() / recordPRDApproval()
  PRD->>Hash: computeFileHash(prdPath)
  Hash-->>PRD: hash | throw new Error(msg, { cause }) on failure

  Caller->>Spec: recordSpecApproval()
  Spec->>Hash: computeFileHash(specPath)
  Hash-->>Spec: hash | throw new Error(msg, { cause }) on failure
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->