### PR TITLE
fix: address review issues in #421 integration tests

### DIFF
--- a/tests/integration/commands_approve_resume_ratelimits.spec.ts
+++ b/tests/integration/commands_approve_resume_ratelimits.spec.ts
@@ -243,7 +243,6 @@ describe('Resume Command Integration Tests', () => {
     });
 
     expect(analysis.featureId).toBe(featureId);
-    expect(analysis.canResume).toBe(true);
     expect(analysis.pendingApprovals).toHaveLength(0);
     expect(analysis.queueState.pending).toBe(0);
     expect(analysis.canResume).toBe(true);

--- a/tests/integration/commands_pr_create_reviewers_automerge.spec.ts
+++ b/tests/integration/commands_pr_create_reviewers_automerge.spec.ts
@@ -144,8 +144,6 @@ function buildPRMetadata(overrides: Partial<PRMetadata> = {}): PRMetadata {
 
 let testRootDir: string;
 let baseDir: string;
-let savedGithubToken: string | undefined;
-let savedJsonOutput: string | undefined;
 
 async function setupRunDir(
   manifestOverrides: Partial<RunManifest> = {},
@@ -176,10 +174,13 @@ async function setupRunDir(
 }
 
 // =============================================================================
-// pr create command tests
+// PR command tests
 // =============================================================================
 
-describe('PR Create Command Integration Tests', () => {
+describe('PR Commands Integration Tests', () => {
+  let savedGithubToken: string | undefined;
+  let savedJsonOutput: string | undefined;
+
   beforeEach(async () => {
     testRootDir = await fs.mkdtemp(path.join(os.tmpdir(), TEST_RUN_DIR_PREFIX));
     baseDir = path.join(testRootDir, 'runs');
@@ -206,6 +207,12 @@ describe('PR Create Command Integration Tests', () => {
       vi.restoreAllMocks();
     }
   });
+
+// =============================================================================
+// pr create command tests
+// =============================================================================
+
+describe('PR Create Command', () => {
 
   it('should reject when code approval gate is missing', async () => {
     await setupRunDir({
@@ -326,33 +333,7 @@ describe('PR Create Command Integration Tests', () => {
 // pr disable-auto-merge command tests
 // =============================================================================
 
-describe('PR Disable-Auto-Merge Command Integration Tests', () => {
-  beforeEach(async () => {
-    testRootDir = await fs.mkdtemp(path.join(os.tmpdir(), TEST_RUN_DIR_PREFIX));
-    baseDir = path.join(testRootDir, 'runs');
-    savedGithubToken = process.env.GITHUB_TOKEN;
-    savedJsonOutput = process.env.JSON_OUTPUT;
-    process.env.GITHUB_TOKEN = 'mock-token';
-    delete process.env.JSON_OUTPUT;
-  });
-
-  afterEach(async () => {
-    try {
-      await fs.rm(testRootDir, { recursive: true, force: true });
-    } finally {
-      if (savedGithubToken !== undefined) {
-        process.env.GITHUB_TOKEN = savedGithubToken;
-      } else {
-        delete process.env.GITHUB_TOKEN;
-      }
-      if (savedJsonOutput !== undefined) {
-        process.env.JSON_OUTPUT = savedJsonOutput;
-      } else {
-        delete process.env.JSON_OUTPUT;
-      }
-      vi.restoreAllMocks();
-    }
-  });
+describe('PR Disable-Auto-Merge Command', () => {
 
   it('should detect when no PR exists', async () => {
     await setupRunDir();
@@ -464,33 +445,7 @@ describe('PR Disable-Auto-Merge Command Integration Tests', () => {
 // pr reviewers command tests
 // =============================================================================
 
-describe('PR Reviewers Command Integration Tests', () => {
-  beforeEach(async () => {
-    testRootDir = await fs.mkdtemp(path.join(os.tmpdir(), TEST_RUN_DIR_PREFIX));
-    baseDir = path.join(testRootDir, 'runs');
-    savedGithubToken = process.env.GITHUB_TOKEN;
-    savedJsonOutput = process.env.JSON_OUTPUT;
-    process.env.GITHUB_TOKEN = 'mock-token';
-    delete process.env.JSON_OUTPUT;
-  });
-
-  afterEach(async () => {
-    try {
-      await fs.rm(testRootDir, { recursive: true, force: true });
-    } finally {
-      if (savedGithubToken !== undefined) {
-        process.env.GITHUB_TOKEN = savedGithubToken;
-      } else {
-        delete process.env.GITHUB_TOKEN;
-      }
-      if (savedJsonOutput !== undefined) {
-        process.env.JSON_OUTPUT = savedJsonOutput;
-      } else {
-        delete process.env.JSON_OUTPUT;
-      }
-      vi.restoreAllMocks();
-    }
-  });
+describe('PR Reviewers Command', () => {
 
   it('should detect when no PR exists for reviewer requests', async () => {
     await setupRunDir();
@@ -602,3 +557,6 @@ describe('PR Reviewers Command Integration Tests', () => {
     expect(output).toContain('Reviewers: alice, bob');
   });
 });
+
+});
+


### PR DESCRIPTION
- Fix env var pollution: process.env.JSON_OUTPUT = undefined sets string
  "undefined" (truthy); use delete instead. Save/restore GITHUB_TOKEN
  and JSON_OUTPUT in afterEach to prevent cross-test leakage.
- Add missing canResume assertion to "should allow resume when no
  blockers present" test — the test name promised this but never
  verified it.
- Fix buildManifest() to include required RunManifest fields: repo,
  queue.queue_dir, execution.completed_steps, timestamps.updated_at,
  artifacts. Previous fixture bypassed TypeScript via JSON serialization.
- Wrap afterEach cleanup in try/finally so vi.restoreAllMocks() always
  runs even if fs.rm throws.

Co-Authored-By: claude-flow <ruv@ruv.net>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/425" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

These changes tighten up the Vitest integration tests added in #421 by (1) asserting `canResume` on the resume happy-path test, and (2) hardening the PR command integration test fixtures/cleanup: avoiding `process.env.JSON_OUTPUT = undefined`, restoring `GITHUB_TOKEN`/`JSON_OUTPUT` after each test, ensuring `vi.restoreAllMocks()` runs even if temp-dir cleanup fails, and updating the manifest fixture to include required `RunManifest` fields so the tests don’t rely on JSON-serialization type loopholes.

The PR primarily affects test reliability/isolation, and the manifest fixture aligns more closely with the `RunManifest` contract used by `loadPRContext`/run-directory persistence.

<h3>Confidence Score: 3/5</h3>

- Moderate risk: changes are test-only but there is a credible cross-test env leakage issue under concurrent execution.
- Most changes improve test correctness and isolation, but the env save/restore state is stored in module-level variables shared across multiple describe blocks, which can restore the wrong env values if suites run concurrently in the same file. Fixing that would make this PR low risk.
- tests/integration/commands_pr_create_reviewers_automerge.spec.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| tests/integration/commands_approve_resume_ratelimits.spec.ts | Adds missing assertion that `analysis.canResume` is true in the no-blockers resume test. |
| tests/integration/commands_pr_create_reviewers_automerge.spec.ts | Adjusts integration-test fixtures/cleanup (env var restore, manifest fields). Potentially breaks tests if `artifacts` must contain strings (not `{}`) and env restore state is shared across describes. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  autonumber
  participant T as Vitest test
  participant H as beforeEach/afterEach
  participant E as process.env
  participant FS as fs/promises
  participant S as pr/shared

  T->>H: beforeEach()
  H->>FS: mkdtemp() + set baseDir
  H->>E: save env vars
  H->>E: set token env var
  H->>E: delete JSON_OUTPUT

  T->>FS: write manifest.json/validation.json[/pr.json]
  T->>S: loadPRContext(baseDir, featureId, config)
  S->>E: read JSON_OUTPUT (logger mirroring)
  S->>FS: read manifest.json + optional pr.json

  T->>H: afterEach()
  H->>FS: rm(testRootDir)
  H-->>E: restore env vars
  H-->>T: vi.restoreAllMocks()
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=bb24fbaf-5846-45c8-a308-366870e3fe9b))
- Context from `dashboard` - AGENTS.md ([source](https://app.greptile.com/review/custom-context?memory=9f5b54f1-ca31-4019-9f81-b3d231c69850))

<!-- /greptile_comment -->