### PR TITLE
fix: migrate all exec() calls to execFile() for injection prevention (#433)

### DIFF
--- a/src/cli/commands/approve.ts
+++ b/src/cli/commands/approve.ts
@@ -1,6 +1,6 @@
 import { Args, Command, Flags } from '@oclif/core';
 import * as path from 'node:path';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import * as os from 'node:os';
 import { createCliLogger, LogLevel, type StructuredLogger } from '../../telemetry/logger';
 import {
@@ -444,7 +444,7 @@ export default class Approve extends Command {
 
   private getGitUser(): string {
     try {
-      const email = execSync('git config user.email', {
+      const email = execFileSync('git', ['config', 'user.email'], {
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'pipe'],
       }).trim();

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -1,7 +1,7 @@
 import { Command, Flags } from '@oclif/core';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { execSync, spawnSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { loadRepoConfig } from '../../core/config/repo_config';
 import { createCliLogger, LogLevel } from '../../telemetry/logger';
 import { createRunMetricsCollector, StandardMetrics } from '../../telemetry/metrics';
@@ -451,7 +451,7 @@ export default class Doctor extends Command {
    */
   private checkGitRepository(): DiagnosticCheck {
     try {
-      const gitRoot = execSync('git rev-parse --show-toplevel', {
+      const gitRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], {
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'pipe'],
       }).trim();

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -1,7 +1,7 @@
 import { Command, Flags } from '@oclif/core';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { createInterface } from 'node:readline/promises';
 import { stdin as input, stdout as output } from 'node:process';
 import {
@@ -501,7 +501,7 @@ export default class Init extends Command {
    */
   private findGitRoot(): string {
     try {
-      const gitRoot = execSync('git rev-parse --show-toplevel', {
+      const gitRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], {
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'pipe'],
       }).trim();
@@ -525,7 +525,7 @@ export default class Init extends Command {
    */
   private getRepositoryUrl(gitRoot: string): string {
     try {
-      const remoteUrl = execSync('git config --get remote.origin.url', {
+      const remoteUrl = execFileSync('git', ['config', '--get', 'remote.origin.url'], {
         cwd: gitRoot,
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'pipe'],

--- a/src/cli/commands/pr/create.ts
+++ b/src/cli/commands/pr/create.ts
@@ -400,12 +400,12 @@ export default class PRCreate extends Command {
   }
 
   private async getCurrentBranch(): Promise<string | null> {
-    const { exec } = await import('node:child_process');
+    const { execFile } = await import('node:child_process');
     const { promisify } = await import('node:util');
-    const execAsync = promisify(exec);
+    const execFileAsync = promisify(execFile);
 
     try {
-      const { stdout } = await execAsync('git rev-parse --abbrev-ref HEAD', {
+      const { stdout } = await execFileAsync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
         cwd: process.cwd(),
       });
       return stdout.trim();

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -1,7 +1,7 @@
 import { Command, Flags } from '@oclif/core';
 import * as path from 'node:path';
 import * as fs from 'node:fs/promises';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import type { StructuredLogger } from '../../telemetry/logger';
 import { createCliLogger, LogLevel } from '../../telemetry/logger';
@@ -786,7 +786,7 @@ export default class Start extends Command {
 
   private findGitRoot(): string {
     try {
-      return execSync('git rev-parse --show-toplevel', {
+      return execFileSync('git', ['rev-parse', '--show-toplevel'], {
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'pipe'],
       }).trim();

--- a/src/workflows/branchManager.ts
+++ b/src/workflows/branchManager.ts
@@ -20,7 +20,7 @@
 
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
-import { exec } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { wrapError } from '../utils/errors';
 import { withLock, getSubdirectoryPath, updateManifest } from '../persistence/runDirectoryManager';
@@ -28,7 +28,7 @@ import type { RepoConfig } from '../core/config/RepoConfig';
 import type { StructuredLogger } from '../telemetry/logger';
 import type { MetricsCollector } from '../telemetry/metrics';
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 // ============================================================================
 // Types
@@ -187,7 +187,7 @@ export function validateBranchName(branchName: string): { valid: boolean; error?
  */
 export async function getCurrentBranch(workingDir: string): Promise<string> {
   try {
-    const { stdout } = await execAsync('git rev-parse --abbrev-ref HEAD', { cwd: workingDir });
+    const { stdout } = await execFileAsync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd: workingDir });
     return stdout.trim();
   } catch (error) {
     throw wrapError(error, 'get current branch');
@@ -199,7 +199,7 @@ export async function getCurrentBranch(workingDir: string): Promise<string> {
  */
 export async function branchExists(branchName: string, workingDir: string): Promise<boolean> {
   try {
-    await execAsync(`git rev-parse --verify "${branchName}"`, { cwd: workingDir });
+    await execFileAsync('git', ['rev-parse', '--verify', branchName], { cwd: workingDir });
     return true;
   } catch {
     return false;
@@ -211,7 +211,7 @@ export async function branchExists(branchName: string, workingDir: string): Prom
  */
 export async function getCommitSha(ref: string, workingDir: string): Promise<string> {
   try {
-    const { stdout } = await execAsync(`git rev-parse "${ref}"`, { cwd: workingDir });
+    const { stdout } = await execFileAsync('git', ['rev-parse', ref], { cwd: workingDir });
     return stdout.trim();
   } catch (error) {
     throw wrapError(error, `get commit SHA for ${ref}`);
@@ -223,7 +223,7 @@ export async function getCommitSha(ref: string, workingDir: string): Promise<str
  */
 export async function getRemoteUrl(remoteName: string, workingDir: string): Promise<string | null> {
   try {
-    const { stdout } = await execAsync(`git remote get-url "${remoteName}"`, { cwd: workingDir });
+    const { stdout } = await execFileAsync('git', ['remote', 'get-url', remoteName], { cwd: workingDir });
     return stdout.trim();
   } catch {
     return null;
@@ -235,7 +235,7 @@ export async function getRemoteUrl(remoteName: string, workingDir: string): Prom
  */
 export async function getTrackingBranch(workingDir: string): Promise<string | null> {
   try {
-    const { stdout } = await execAsync('git rev-parse --abbrev-ref --symbolic-full-name @{u}', {
+    const { stdout } = await execFileAsync('git', ['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}'], {
       cwd: workingDir,
     });
     return stdout.trim();
@@ -251,7 +251,7 @@ export async function getAheadBehindCounts(
   workingDir: string
 ): Promise<{ ahead: number; behind: number }> {
   try {
-    const { stdout } = await execAsync('git rev-list --left-right --count @{u}...HEAD', {
+    const { stdout } = await execFileAsync('git', ['rev-list', '--left-right', '--count', '@{u}...HEAD'], {
       cwd: workingDir,
     });
     const parts = stdout.trim().split(/\s+/);
@@ -327,7 +327,7 @@ export async function createBranch(
     const currentBranch = await getCurrentBranch(config.workingDir);
     if (currentBranch !== baseBranch) {
       logger.info('Switching to base branch', { baseBranch });
-      await execAsync(`git checkout "${baseBranch}"`, { cwd: config.workingDir });
+      await execFileAsync('git', ['checkout', baseBranch], { cwd: config.workingDir });
     }
 
     // Step 5: Get base commit SHA
@@ -336,7 +336,7 @@ export async function createBranch(
 
     // Step 6: Create the branch
     logger.info('Creating branch', { branchName, baseBranch, baseSha });
-    await execAsync(`git checkout -b "${branchName}"`, { cwd: config.workingDir });
+    await execFileAsync('git', ['checkout', '-b', branchName], { cwd: config.workingDir });
 
     result.branchName = branchName;
     result.success = true;
@@ -431,7 +431,7 @@ export async function pushBranch(
 
     // Step 3: Push with upstream tracking
     logger.info('Pushing branch to remote', { branchName, remoteName, remoteUrl });
-    await execAsync(`git push -u "${remoteName}" "${branchName}"`, { cwd: config.workingDir });
+    await execFileAsync('git', ['push', '-u', remoteName, branchName], { cwd: config.workingDir });
 
     result.trackingBranch = `${remoteName}/${branchName}`;
     result.success = true;
@@ -662,7 +662,7 @@ export async function createSafeCommit(
     // Create commit with metadata tags
     const commitMessage = `${message}\n\n[task_id: ${taskId}]\n[feature_id: ${config.featureId}]`;
 
-    await execAsync(`git commit -m "${commitMessage.replace(/"/g, '\\"')}"`, {
+    await execFileAsync('git', ['commit', '-m', commitMessage], {
       cwd: config.workingDir,
     });
 

--- a/src/workflows/patchManager.ts
+++ b/src/workflows/patchManager.ts
@@ -21,7 +21,7 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import * as crypto from 'node:crypto';
-import { exec, execFile } from 'node:child_process';
+import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import picomatch from 'picomatch';
 import { withLock, getSubdirectoryPath, updateManifest } from '../persistence/runDirectoryManager';
@@ -32,21 +32,7 @@ import type { ExecutionTelemetry } from '../telemetry/executionTelemetry';
 import type { DiffStats } from '../telemetry/executionMetrics';
 import { getErrorMessage } from '../utils/errors.js';
 
-const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
-
-type ExecCommandResult = { stdout?: string; stderr?: string } | string;
-
-function normalizeExecResult(result: ExecCommandResult): { stdout: string; stderr: string } {
-  if (typeof result === 'string') {
-    return { stdout: result, stderr: '' };
-  }
-
-  return {
-    stdout: result?.stdout ?? '',
-    stderr: result?.stderr ?? '',
-  };
-}
 
 /**
  * Validate that a patchId contains only safe characters for use in file paths.
@@ -310,9 +296,7 @@ function summarizeLineChanges(patchContent: string): { insertions: number; delet
  */
 export async function isWorkingTreeClean(workingDir: string): Promise<boolean> {
   try {
-    const { stdout } = normalizeExecResult(
-      await execAsync('git status --porcelain', { cwd: workingDir })
-    );
+    const { stdout } = await execFileAsync('git', ['status', '--porcelain'], { cwd: workingDir });
     return stdout.trim().length === 0;
   } catch (error) {
     throw new Error(
@@ -331,14 +315,15 @@ export async function isWorkingTreeClean(workingDir: string): Promise<boolean> {
  */
 export async function getCurrentGitRef(workingDir: string): Promise<{ ref: string; sha: string }> {
   try {
-    const { stdout: ref } = normalizeExecResult(
-      await execAsync('git symbolic-ref -q HEAD || git rev-parse HEAD', {
-        cwd: workingDir,
-      })
-    );
-    const { stdout: sha } = normalizeExecResult(
-      await execAsync('git rev-parse HEAD', { cwd: workingDir })
-    );
+    let ref: string;
+    try {
+      const result = await execFileAsync('git', ['symbolic-ref', '-q', 'HEAD'], { cwd: workingDir });
+      ref = result.stdout;
+    } catch {
+      const result = await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: workingDir });
+      ref = result.stdout;
+    }
+    const { stdout: sha } = await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: workingDir });
 
     return {
       ref: ref.trim(),
@@ -484,11 +469,9 @@ export async function createRollbackSnapshot(
 
   // Capture current git state
   const gitRef = await getCurrentGitRef(config.workingDir);
-  const { stdout: workingTreeStatus } = normalizeExecResult(
-    await execAsync('git status --porcelain', {
-      cwd: config.workingDir,
-    })
-  );
+  const { stdout: workingTreeStatus } = await execFileAsync('git', ['status', '--porcelain'], {
+    cwd: config.workingDir,
+  });
 
   const metadata: SnapshotMetadata = {
     schema_version: '1.0.0',

--- a/tests/unit/patchManager.spec.ts
+++ b/tests/unit/patchManager.spec.ts
@@ -39,29 +39,10 @@ import { updateManifest } from '../../src/persistence/runDirectoryManager';
 // ============================================================================
 
 vi.mock('node:fs/promises');
-vi.mock('node:child_process', () => ({
-  exec: vi.fn(
-    (
-      command: string | Buffer,
-      optionsOrCallback?: ExecOptionsArg,
-      callbackMaybe?: ExecCallbackArg
-    ) => {
-      const callback = isExecCallback(optionsOrCallback)
-        ? optionsOrCallback
-        : isExecCallback(callbackMaybe)
-          ? callbackMaybe
-          : undefined;
+vi.mock('node:child_process', () => {
+  const kCustomPromisify = Symbol.for('nodejs.util.promisify.custom');
 
-      if (!callback) {
-        throw new Error('exec callback missing');
-      }
-
-      const commandText = typeof command === 'string' ? command : command.toString('utf-8');
-      currentExecHandler(commandText, callback);
-      return childProcessStub;
-    }
-  ),
-  execFile: vi.fn((...args: unknown[]) => {
+  const execFileMock = vi.fn((...args: unknown[]) => {
     const callback = args.find((a) => typeof a === 'function') as ExecCallback | undefined;
     if (!callback) {
       throw new Error('execFile callback missing');
@@ -71,8 +52,52 @@ vi.mock('node:child_process', () => ({
     const commandText = [file, ...fileArgs].join(' ');
     currentExecHandler(commandText, callback);
     return childProcessStub;
-  }),
-}));
+  });
+
+  // Support promisify(execFile) returning { stdout, stderr } like the real implementation
+  (execFileMock as unknown as Record<symbol, unknown>)[kCustomPromisify] = (
+    file: string,
+    fileArgs?: string[],
+    _options?: unknown
+  ) => {
+    return new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+      const args = Array.isArray(fileArgs) ? fileArgs : [];
+      const commandText = [file, ...args].join(' ');
+      currentExecHandler(commandText, (error, stdout, stderr) => {
+        if (error) {
+          reject(Object.assign(error, { stdout: stdout || '', stderr: stderr || '' }));
+        } else {
+          resolve({ stdout: stdout || '', stderr: stderr || '' });
+        }
+      });
+    });
+  };
+
+  return {
+    exec: vi.fn(
+      (
+        command: string | Buffer,
+        optionsOrCallback?: ExecOptionsArg,
+        callbackMaybe?: ExecCallbackArg
+      ) => {
+        const callback = isExecCallback(optionsOrCallback)
+          ? optionsOrCallback
+          : isExecCallback(callbackMaybe)
+            ? callbackMaybe
+            : undefined;
+
+        if (!callback) {
+          throw new Error('exec callback missing');
+        }
+
+        const commandText = typeof command === 'string' ? command : command.toString('utf-8');
+        currentExecHandler(commandText, callback);
+        return childProcessStub;
+      }
+    ),
+    execFile: execFileMock,
+  };
+});
 vi.mock('../../src/persistence/runDirectoryManager', () => ({
   withLock: vi.fn(async (_runDir: string, fn: () => Promise<unknown>) => await fn()),
   getSubdirectoryPath: vi.fn((runDir: string, subdir: string) => `${runDir}/${subdir}`),


### PR DESCRIPTION
## Summary

- Migrate all `exec()` / `execSync()` / `promisify(exec)` calls to `execFile()` / `execFileSync()` / `promisify(execFile)` across all `src/` files
- Eliminates shell invocation entirely — prevents command injection by using parameterized argument arrays
- Resolves GitHub issue #433

## Changes (8 files, 19 call sites)

| File | Calls Migrated | Notes |
|------|---------------|-------|
| `src/workflows/branchManager.ts` | 10 `execAsync` → `execFileAsync` | Removes manual `"` escaping for commit messages (line 665) |
| `src/workflows/patchManager.ts` | 4 `execAsync` → `execFileAsync` | Shell `\|\|` pipe → JS try/catch fallback; removed dead `normalizeExecResult` |
| `src/cli/commands/pr/create.ts` | 1 dynamic import | `exec` → `execFile` |
| `src/cli/commands/approve.ts` | 1 `execSync` → `execFileSync` | |
| `src/cli/commands/start.ts` | 1 `execSync` → `execFileSync` | |
| `src/cli/commands/init.ts` | 2 `execSync` → `execFileSync` | |
| `src/cli/commands/doctor.ts` | 1 `execSync` → `execFileSync` | |
| `tests/unit/patchManager.spec.ts` | Mock update | Added `customPromisify` symbol to `execFile` mock |

## Verification

- Zero `exec()` / `execSync()` / `promisify(exec)` calls remain in `src/`
- Build passes
- Lint: 0 errors (76 pre-existing warnings from #202)
- **All 2136 tests pass** (83 test files)

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` — 0 errors
- [x] `npm test` — 2136/2136 tests pass
- [x] Grep confirms zero `exec()` remaining in `src/`

Closes #433

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal optimization of Git command execution across CLI commands and workflow components for improved performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR successfully eliminates all command injection vulnerabilities in `src/` by replacing `exec()`/`execSync()`/`promisify(exec)` with their safer `execFile()` counterparts across 8 files. The migration is comprehensive and well-executed:

**Key improvements:**
- **Security**: Removes shell invocation entirely, preventing command injection through argument parameterization
- **Simplicity**: Eliminates manual quote escaping in `branchManager.ts:665` (commit messages no longer need `.replace(/"/g, '\\"')`)
- **Correctness**: Replaces shell fallback (`||`) in `patchManager.ts:320-324` with proper try/catch error handling
- **Cleanup**: Removes dead `normalizeExecResult` helper that was only needed for `exec()`
- **Testing**: Updates test mocks with proper `customPromisify` symbol support

**Impact:**
- 10 migrations in `branchManager.ts`
- 4 migrations in `patchManager.ts`
- 1 migration each in 5 CLI commands
- All git commands now use parameterized arrays (`['rev-parse', '--abbrev-ref', 'HEAD']`) instead of string interpolation
- All 2136 tests pass

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no identified risks
- The migration is thorough, systematic, and security-focused. All exec() calls have been properly replaced with execFile(), using argument arrays to eliminate shell invocation. The changes are straightforward substitutions that improve security without altering behavior. Tests have been updated to support the new implementation, and all 2136 tests pass.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/workflows/branchManager.ts | Migrated 10 execAsync → execFileAsync calls, removed manual quote escaping for commit messages, properly parameterized all git commands |
| src/workflows/patchManager.ts | Migrated 4 execAsync → execFileAsync calls, replaced shell fallback (||) with try/catch, removed dead normalizeExecResult helper |
| src/cli/commands/pr/create.ts | Changed dynamic exec import to execFile, properly parameterized git rev-parse command |
| tests/unit/patchManager.spec.ts | Added customPromisify symbol to execFile mock to support promisify(execFile) returning {stdout, stderr} |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App as Application Code
    participant Node as Node.js child_process
    participant Shell as Shell (bash/sh)
    participant Git as Git Command

    Note over App,Git: Before: exec() with shell invocation
    App->>Node: exec("git commit -m \"" + message + "\"")
    Node->>Shell: Invoke shell with interpolated string
    Shell->>Git: Parse and execute command
    Note over Shell,Git: ⚠️ Vulnerable to injection via message

    Note over App,Git: After: execFile() with parameterized args
    App->>Node: execFile('git', ['commit', '-m', message])
    Node->>Git: Execute directly with argv array
    Note over Node,Git: ✅ No shell, no injection possible
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->