### PR TITLE
chore: audit and update .gitignore for release completeness (CDMCH-115)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,3 @@
-.codemachine/logs
-.codemachine/memory
-.codemachine/prompts
-.codemachine/agents
-.codemachine/template.json
-
 # Dependencies
 node_modules/
 npm-debug.log*
@@ -56,18 +50,22 @@ oclif.manifest.json
 .codepipe/telemetry/
 ISSUE_RESOLUTION_PLAN.md
 
-# Claude Code / Claude Flow - config (committed)
-# .mcp.json, .npmrc, claude-flow.config.json — tracked
-# .claude/settings.json — tracked (hooks, statusline, permissions)
-.claude/*
-!.claude/settings.json
+# Development artifacts (AI tooling, IDE plugins)
+.codemachine/
+.serena/
+.claude/
+.mcp.json
+claude-flow.config.json
+.deps/
+CLAUDE.md
+tools/
 
-# Claude Flow - runtime state (ignored)
+# Claude Flow runtime state
 .claude-flow/
 .swarm/
 vectors.db
 tmp/
 my-ruvector/
 
-# Working notes (untracked)
+# Working notes
 thoughts/


### PR DESCRIPTION
Comprehensive .gitignore overhaul:
- Replace partial .codemachine/ patterns with blanket ignore
- Add .serena/, .claude/, .mcp.json, claude-flow.config.json, .deps/
- Add CLAUDE.md and tools/ ignore entries
- Remove !.claude/settings.json exception
- Organize with clear section comments
- Remove stale comments about tracked config files

Co-Authored-By: Claude <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/456" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ignore configuration to streamline development environment management and better handle build artifacts and tooling files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `.gitignore` to blanket-ignore several development tool directories, but introduces critical issues by ignoring files that are currently tracked in the repository.

**Key Issues:**
- Ignoring `.claude/` will untrack `.claude/settings.json` (committed in edf8abc), which contains critical hooks, permissions, and daemon configuration
- Ignoring `CLAUDE.md` will untrack this file (committed in e35f290), which contains essential Claude Flow V3 configuration and workflow documentation
- Ignoring `tools/` may untrack utility scripts if they're meant to be version controlled

**What Changed:**
- Replaced granular `.codemachine/` patterns with blanket ignore
- Added blanket ignores for `.serena/`, `.claude/`, `.mcp.json`, `claude-flow.config.json`, `.deps/`, `CLAUDE.md`, and `tools/`
- Removed the exception `!.claude/settings.json` that was previously keeping this file tracked
- Simplified section comments

<h3>Confidence Score: 0/5</h3>

- This PR is unsafe to merge - it will untrack critical configuration files
- Score reflects critical bugs that will cause tracked files (`.claude/settings.json` and `CLAUDE.md`) to become untracked, potentially losing important configuration and documentation. The blanket ignore patterns override existing exceptions without accounting for files already committed to the repository.
- `.gitignore` requires immediate attention to preserve tracked configuration files

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .gitignore | Ignores important tracked config files (`.claude/settings.json`, `CLAUDE.md`) that are currently committed to the repository |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->