### PR TITLE
chore: update .npmignore for current project structure (CDMCH-110)

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,17 +1,38 @@
 # Source files (only dist/ should be published)
 src/
-test/
+tests/
 *.test.ts
+*.spec.ts
 
 # Configuration files
 tsconfig.json
-jest.config.js
-.eslintrc.json
+tsconfig.eslint.json
+eslint.config.cjs
+vitest.config.ts
 .prettierrc.json
+.npmrc
 
-# Development files
+# Development tooling
+.codemachine/
+.serena/
+.claude/
+.mcp.json
+claude-flow.config.json
+.deps/
+CLAUDE.md
+tools/
+scripts/
+
+# Documentation (keep README.md, LICENSE, CHANGELOG.md)
+docs/
+specification.md
+CONTRIBUTING.md
+
+# Testing
 .test-temp/
 coverage/
+
+# IDE
 .vscode/
 .idea/
 
@@ -21,10 +42,6 @@ coverage/
 # Docker
 Dockerfile
 .dockerignore
-
-# Documentation (keep README.md)
-specification.md
-codemachine-plan.md
 
 # Git
 .git/
@@ -41,6 +58,3 @@ logs/
 # OS
 .DS_Store
 Thumbs.db
-
-# CodeMachine
-.codemachine/


### PR DESCRIPTION
Remove stale entries (jest.config.js, .eslintrc.json, codemachine-plan.md).
Add missing entries for current tooling (.serena/, .claude/, .deps/,
CLAUDE.md, tools/, scripts/, vitest.config.ts, eslint.config.cjs,
tsconfig.eslint.json, .npmrc, .prettierrc.json, CONTRIBUTING.md, docs/).

npm pack now produces only: bin/, dist/, oclif.manifest.json,
package.json, README.md, LICENSE.

Co-Authored-By: Claude <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/457" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `.npmignore` to match the current project structure after migration from Jest to Vitest and ESLint flat config. The changes ensure only runtime-essential files (`bin/`, `dist/`, `oclif.manifest.json`, `package.json`, `README.md`, `LICENSE`) are published to npm.

**Key changes:**
- Removed stale entries: `jest.config.js`, `.eslintrc.json`, `codemachine-plan.md`, `test/` directory
- Added modern tooling: `vitest.config.ts`, `eslint.config.cjs`, `tsconfig.eslint.json`, `.npmrc`, `.prettierrc.json`
- Added development directories: `.serena/`, `.claude/`, `.deps/`, `tools/`, `scripts/`, `docs/`
- Added development files: `CLAUDE.md`, `CONTRIBUTING.md`, `specification.md`
- Better organization with clear section headers

The changes align with the `package.json` `files` field (lines 59-63) which explicitly lists only `/bin`, `/dist`, and `/oclif.manifest.json` for publication. All development tooling, docs, and configuration files are appropriately excluded.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no issues
- This is a straightforward housekeeping change that updates `.npmignore` to match the current project structure. All removed entries are obsolete (Jest/ESLint config from old tooling), and all added entries are appropriate development files that should not be published to npm. The changes align perfectly with the `package.json` `files` field.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .npmignore | Updated to reflect current tooling: removed stale entries (`jest.config.js`, `.eslintrc.json`, `codemachine-plan.md`), added new tooling directories (`.serena/`, `.claude/`, `.deps/`, `tools/`, `scripts/`) and config files (`vitest.config.ts`, `eslint.config.cjs`, `tsconfig.eslint.json`, `.npmrc`, `CLAUDE.md`, `CONTRIBUTING.md`, `docs/`). Ensures clean npm package with only runtime essentials. |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->