### PR TITLE
docs: reconcile root README.md and docs/README.md (CDMCH-112)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Autonomous AI-powered feature development pipeline CLI
 - **Automatic V1→V2 migration** with integrity validation and rollback support
 - **Benchmark validation**: 0.43ms for 500 tasks, <100ms for 1000 tasks
 - **8-layer architecture**: WAL, in-memory index, snapshots, compaction, migration, unified API, types, performance monitoring
-- See [Queue V2 Operations Guide](docs/operations/queue-v2-operations.md) for details
+- See [Queue V2 Operations Guide](docs/ops/queue-v2-operations.md) for details
 
 ### Parallel Execution
 - **Configurable concurrency** (1-10 tasks) via `execution.max_parallel_tasks`
@@ -29,7 +29,7 @@ Autonomous AI-powered feature development pipeline CLI
 - **2-4x throughput improvement** for independent tasks (validated in benchmarks)
 - **Safety guarantees**: Failed prerequisites halt dependent tasks, ACID queue updates
 - **Worker pool management**: In-flight task tracking with capacity enforcement
-- See [Parallel Execution Guide](docs/operations/parallel-execution.md) for details
+- See [Parallel Execution Guide](docs/ops/parallel-execution.md) for details
 
 ### Enhanced Telemetry
 - **Execution metrics tracking**: Task lifecycle, validation results, diff statistics
@@ -45,7 +45,7 @@ Autonomous AI-powered feature development pipeline CLI
 - **Secure CLI execution**: Command injection vulnerabilities eliminated via parameterized execution
 - **Comprehensive test coverage**: >90% for critical modules (queue, execution engine, validation)
 - **Security improvements**: Path traversal prevention, input validation, safe artifact capture
-- See [Log Rotation Guide](docs/operations/log-rotation.md) for details
+- See [Log Rotation Guide](docs/ops/log-rotation.md) for details
 
 ### Developer Experience
 - **Comprehensive test suite** with 100% pass rate across all modules
@@ -77,8 +77,8 @@ npm link
 Build and run the CLI in a containerized environment for reproducible execution:
 
 ```bash
-# Build the Docker image (from project root)
-docker build -f docker/Dockerfile -t codemachine-pipeline .
+# Build the Docker image
+docker build -t codemachine-pipeline .
 
 # Run with help
 docker run --rm codemachine-pipeline --help
@@ -705,7 +705,6 @@ codemachine-pipeline/
 │   ├── integration/       # Integration tests
 │   └── fixtures/          # Test fixtures
 ├── scripts/               # Build and utility scripts
-├── docker/                # Docker configuration
 ├── .github/
 │   └── workflows/
 │       └── ci.yml         # CI/CD pipeline


### PR DESCRIPTION
Fix root README:
- Update Docker build command (use root Dockerfile, not docker/)
- Remove docker/ from project structure (consolidated in PR 2.2)
- Fix docs/operations/ links to docs/ops/ (operations/ merging in PR 3.4)

docs/README.md is already a clean table-of-contents index.

Co-Authored-By: Claude <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/458" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR attempts to fix documentation links by changing paths from `docs/operations/` to `docs/ops/`, but introduces **broken links** instead. The three referenced files (`queue-v2-operations.md`, `parallel-execution.md`, `log-rotation.md`) currently exist at `docs/operations/` not `docs/ops/`.

**Critical Issues:**
- All three documentation links now point to non-existent paths
- The base branch already had correct working links to `docs/operations/`
- PR description mentions "operations/ merging in PR 3.4" but this hasn't happened yet

**Other Changes:**
- Docker build command simplified (correct - root Dockerfile is more up-to-date)
- Removed `docker/` from project structure (premature - directory still exists)

**Recommendation:** Either revert the path changes to `docs/operations/` or move the actual files to `docs/ops/` before merging.

<h3>Confidence Score: 0/5</h3>

- This PR is NOT safe to merge - it breaks critical documentation links
- Three documentation links point to non-existent paths, breaking user access to operational guides for Queue V2, Parallel Execution, and Log Rotation features
- README.md requires immediate attention - all documentation path changes need to be reverted or files need to be moved first

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| README.md | Documentation links broken - paths changed to `docs/ops/` but files exist at `docs/operations/` |

</details>



<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->