### PR TITLE
refactor: declarative env checks and flatten PRCreate try-catch (CDMCH-148, CDMCH-149)

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -59,6 +59,7 @@ interface EnvCheckDescriptor {
   passMessage: string;
   failMessage: string;
   showValueInPass?: boolean;
+  /** Produce details for a passing check. Defaults to `{ length: value.length }` if omitted. */
   passDetails?: (value: string) => EnvCheckDetails;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Config type not fully specified for this usage
   resolveValue?: (c: any, varName: string) => string | undefined;
@@ -577,7 +578,7 @@ export default class Doctor extends Command {
     const envChecks: EnvCheckDescriptor[] = [
       {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- Config type not fully specified
-        enabled: (c) => !!(c.github?.enabled && c.github?.token_env_var),
+        enabled: (c) => Boolean(c.github?.enabled && c.github?.token_env_var),
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return -- Config type not fully specified
         envVar: (c) => c.github.token_env_var,
         label: 'GitHub',
@@ -590,7 +591,7 @@ export default class Doctor extends Command {
       },
       {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- Config type not fully specified
-        enabled: (c) => !!(c.linear?.enabled && c.linear?.api_key_env_var),
+        enabled: (c) => Boolean(c.linear?.enabled && c.linear?.api_key_env_var),
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return -- Config type not fully specified
         envVar: (c) => c.linear.api_key_env_var,
         label: 'Linear',
@@ -601,7 +602,7 @@ export default class Doctor extends Command {
       },
       {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- Config type not fully specified
-        enabled: (c) => !!c.runtime?.agent_endpoint_env_var,
+        enabled: (c) => Boolean(c.runtime?.agent_endpoint_env_var),
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return -- Config type not fully specified
         envVar: (c) => c.runtime.agent_endpoint_env_var,
         label: 'Agent',

--- a/src/cli/commands/pr/create.ts
+++ b/src/cli/commands/pr/create.ts
@@ -115,10 +115,11 @@ export default class PRCreate extends Command {
           error.code === CliErrorCode.RUN_DIR_NOT_FOUND
             ? PRExitCode.VALIDATION_ERROR
             : error.exitCode;
-        this.error(error.message, { exit: exitCode });
-      }
-
-      if (error instanceof Error) {
+        const message = error.remediation
+          ? `${error.message}\n\n${error.remediation}`
+          : error.message;
+        this.error(message, { exit: exitCode });
+      } else if (error instanceof Error) {
         this.error(`PR create failed: ${error.message}`, {
           exit: PRExitCode.ERROR,
         });
@@ -219,7 +220,11 @@ export default class PRCreate extends Command {
 
       const adapter = getPRAdapter(context);
 
-      const branchName = manifest.source || (await this.getCurrentBranch())!;
+      const currentBranch = manifest.source || (await this.getCurrentBranch());
+      if (!currentBranch) {
+        this.error('Unable to determine branch name', { exit: PRExitCode.VALIDATION_ERROR });
+      }
+      const branchName = currentBranch;
       const baseBranch = typedFlags.base || config.project.default_branch;
       const prTitle = typedFlags.title || manifest.title || `Feature: ${featureId}`;
       const prBody = typedFlags.body || this.generatePRBody(manifest);


### PR DESCRIPTION
Replace 3 repetitive imperative blocks in checkEnvironmentVariables with
a declarative array of check descriptors and a single loop. Extract
executePRCreation() from PRCreate.run() so inner try-catch handles
telemetry and outer try-catch handles CliError mapping.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/676" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors two areas of the CLI: (1) `checkEnvironmentVariables` in `doctor.ts` is converted from three repetitive imperative blocks into a declarative `EnvCheckDescriptor` array with a single processing loop, and (2) `PRCreate.run()` in `create.ts` extracts its core logic into a private `executePRCreation()` method to cleanly separate setup-phase errors from telemetry-guarded errors.

- The new `EnvCheckDescriptor` interface uses explicit, independent fields (`displayName`, `showValueInPass`, `passDetails`, `resolveValue`) rather than overloading a single field as an implicit discriminator — addressing concerns from previous review rounds.
- `EnvCheckDetails` is now typed as `Record<string, string | number>`, making it open for future descriptors without modifying the loop.
- The `passDetails` default behaviour (`{ length: value.length }`) is documented via JSDoc on the interface field.
- The outer catch in `run()` now correctly forwards `CliError.remediation` when present, addressing a previously flagged gap.
- A comment in `executePRCreation()` explicitly documents the intentional telemetry gap for pre-span setup failures.
- No functional regressions were identified; the refactoring is structurally sound.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; it is a well-scoped refactoring that addresses multiple concerns from prior review rounds with no new critical logic issues.
- Both files contain pure structural refactoring with identical runtime semantics to the original code. Previously flagged issues (CliError remediation forwarding, open EnvCheckDetails type, passDetails JSDoc, implicit resolveValue discriminator, pass/fail name asymmetry) have all been addressed. One minor observation remains: the Agent check's `displayName` ignores its `varName` parameter, so the failing diagnostic entry shows `'Agent Endpoint'` rather than the env var name — but the remediation text still surfaces the var name, so user impact is minimal.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/cli/commands/doctor.ts | Refactors `checkEnvironmentVariables` from three repetitive imperative blocks into a declarative `EnvCheckDescriptor` array and a single loop. The new `EnvCheckDetails` type is appropriately open (`Record<string, string | number>`). Previous review concerns (passDetails JSDoc, implicit resolveValue discriminator, closed union type) have been addressed. One minor concern: the `displayName` callback receives `varName` but the Agent descriptor ignores it, meaning the fail diagnostic name (`'Agent Endpoint'`) no longer surfaces the actual env var name — though remediation text still does. |
| src/cli/commands/pr/create.ts | Extracts `executePRCreation()` from `run()` to cleanly separate setup-phase errors from telemetry-guarded errors. The outer catch in `run()` now handles `CliError` remediation forwarding (previously flagged). An intentional comment documents the telemetry gap for pre-span setup failures. The split try-catch structure is correct: oclif errors from `this.error()` are properly re-thrown via `rethrowIfOclifError`, and `CliError`s are caught and surfaced with full message and remediation. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant run as PRCreate.run()
    participant exec as executePRCreation()
    participant setup as Setup (resolveRunDir / loadContext)
    participant telemetry as Telemetry (span / metrics)
    participant github as GitHub Adapter

    User->>run: codepipe pr create
    run->>exec: executePRCreation(flags, startTime)

    exec->>setup: resolveRunDirectorySettings()
    setup-->>exec: settings
    exec->>setup: selectFeatureId / requireFeatureId / requireConfig
    exec->>setup: loadPRContext()
    setup-->>exec: context (logger, manifest, runDir, config)

    exec->>telemetry: createRunMetricsCollector / createRunTraceManager / startSpan

    rect rgb(220, 240, 255)
        Note over exec,github: Inner try — telemetry-guarded
        exec->>exec: withSpan(preflight) — validate approvals, branch, validations
        exec->>github: adapter.createPullRequest(...)
        github-->>exec: PR result
        exec->>github: adapter.requestReviewers(...) [if --reviewers]
        exec->>exec: persistPRData / logDeploymentAction
        exec->>telemetry: flushTelemetrySuccess
    end

    alt Error in inner try
        exec->>telemetry: flushTelemetryError
        exec-->>run: re-throw error
        run->>run: rethrowIfOclifError (oclif errors exit here)
        run->>run: CliError → this.error(message + remediation, exitCode)
        run->>run: Error → this.error("PR create failed: ...", ERROR)
    end

    exec-->>run: void (success)
    run-->>User: PR URL + output
```

<sub>Last reviewed commit: 412c752</sub>

<!-- /greptile_comment -->