### PR TITLE
fix: cap retryAfterSeconds from external API at 300s (CDMCH-196)

### DIFF
--- a/src/adapters/agents/AgentAdapter.ts
+++ b/src/adapters/agents/AgentAdapter.ts
@@ -332,7 +332,10 @@ export class AgentAdapter {
     }
 
     if (agentError.retryAfterSeconds) {
-      const cappedSeconds = Math.min(agentError.retryAfterSeconds, MAX_RETRY_WAIT_SECONDS);
+      const cappedSeconds = Math.min(
+        Math.max(0, agentError.retryAfterSeconds),
+        MAX_RETRY_WAIT_SECONDS
+      );
       if (cappedSeconds < agentError.retryAfterSeconds) {
         this.logger.warn('Capping retry-after from external API', {
           sessionId,

--- a/tests/unit/agentAdapter.spec.ts
+++ b/tests/unit/agentAdapter.spec.ts
@@ -791,6 +791,41 @@ describe('AgentAdapter - Fallback Logic', () => {
     sleepSpy.mockRestore();
   });
 
+  it('should clamp negative retry-after values to 0 seconds', async () => {
+    const sleepSpy = vi.spyOn(
+      adapter as unknown as { sleep: (ms: number) => Promise<void> },
+      'sleep'
+    );
+    sleepSpy.mockResolvedValue();
+
+    let invokeCount = 0;
+    providerInvoker.mockImplementation(
+      (manifest, _request, sessionId, _startTime, fallbackAttempts) => {
+        invokeCount++;
+        if (invokeCount === 1) {
+          return Promise.reject(createRetryAfterError(-1));
+        }
+        return Promise.resolve(createProviderResponse(manifest, sessionId, fallbackAttempts));
+      }
+    );
+
+    const request: AgentSessionRequest = {
+      context: 'code_generation',
+      prompt: { instruction: 'Test' },
+      taskId: 'task-1',
+      featureId: 'FEAT-1',
+    };
+
+    await adapter.executeSession(request);
+
+    expect(sleepSpy).toHaveBeenCalledWith(0);
+    expect(logger.spies.warn).not.toHaveBeenCalledWith(
+      'Capping retry-after from external API',
+      expect.any(Object)
+    );
+    sleepSpy.mockRestore();
+  });
+
   it('should not use fallback on permanent error', async () => {
     providerInvoker.mockRejectedValue(new Error('Invalid API key'));
 


### PR DESCRIPTION
## **User description**
An adversarial or buggy agent provider could return an arbitrarily
large Retry-After value, causing the client to hang. Cap at 5 minutes
and log a warning when the cap is applied.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/739" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

___

## **CodeAnt-AI Description**
Cap external Retry-After values at 5 minutes and log when capped

### What Changed
- When an external provider returns a Retry-After, the client now limits the wait to 300 seconds before sleeping and retrying
- If the returned Retry-After exceeds 300 seconds a warning is logged that includes the original and capped values
- Exposes a MAX_RETRY_WAIT_SECONDS constant and adds tests verifying behavior for values above, at, and below the 300s threshold

### Impact
`✅ Prevents client hang from excessively large Retry-After`
`✅ Clearer logs when external providers return excessive retry delays`
`✅ Fewer unexpectedly long fallback wait periods`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR caps the `Retry-After` value returned by external agent providers at 300 seconds (`MAX_RETRY_WAIT_SECONDS`) and clamps negative values to 0 using `Math.min(Math.max(0, retryAfterSeconds), MAX_RETRY_WAIT_SECONDS)`. A warning is logged when the upper cap is applied, and four new unit tests cover values above, at, below, and below-zero the threshold.

**Key changes:**
- `src/adapters/agents/AgentAdapter.ts`: Adds `MAX_RETRY_WAIT_SECONDS = 300` constant (exported), applies `Math.min`/`Math.max` clamping to `retryAfterSeconds`, and emits a `warn` log when the upper bound is hit.
- `tests/unit/agentAdapter.spec.ts`: Imports `AgentAdapterError` and `MAX_RETRY_WAIT_SECONDS`, adds `createRetryAfterError` helper, and adds four new test cases.

**Issue found:**
- The warning condition (`cappedSeconds < agentError.retryAfterSeconds`) only fires when the upper cap is applied. For a negative `retryAfterSeconds` (e.g. `-1`), `cappedSeconds` is `0`, so `0 < -1` is `false` and no warning is emitted — even though the value was modified by the `Math.max` lower clamp. The condition should be `cappedSeconds !== agentError.retryAfterSeconds` to cover both bounds.

<h3>Confidence Score: 3/5</h3>

- Safe to merge with one minor logic fix — the functional protections (upper cap at 300s, lower clamp at 0) are correctly implemented and well-tested, but the warning condition should use `!==` instead of `<` to maintain consistency when both bounds are applied.
- The core protection against adversarial Retry-After values is sound and the new tests are comprehensive. However, the warning condition silently drops negative-value clamping without logging, inconsistent with the PR's stated goal of "log a warning when the cap is applied." Since both bounds are explicitly defended against in the code and tested, they should both emit warnings. The fix is simple and low-risk.
- src/adapters/agents/AgentAdapter.ts (warning condition at line 339) and tests/unit/agentAdapter.spec.ts (negative-value assertion at line 822)

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[agentError.retryAfterSeconds received] --> B{Is retryAfterSeconds truthy?}
    B -- No --> Z[Skip sleep, attempt fallback]
    B -- Yes --> C["cappedSeconds = Math.min(Math.max(0, retryAfterSeconds), 300)"]
    C --> D{"cappedSeconds < retryAfterSeconds?"}
    D -- Yes / upper cap hit --> E["logger.warn: Capping retry-after\n(original, capped logged)"]
    D -- No --> F["⚠️ Silent: negative values clamped to 0\nwithout warning (bug)"]
    E --> G["logger.info: Waiting before fallback retry"]
    F --> G
    G --> H["sleep(cappedSeconds * 1000 ms)"]
    H --> Z
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fadapters%2Fagents%2FAgentAdapter.ts%3A339-344%0A**Warning%20condition%20misses%20negative-value%20clamping**%0A%0AThe%20warn%20guard%20checks%20%60cappedSeconds%20%3C%20agentError.retryAfterSeconds%60%2C%20which%20only%20fires%20when%20the%20**upper**%20cap%20is%20applied.%20When%20%60retryAfterSeconds%60%20is%20negative%20%28e.g.%20%60-1%60%29%2C%20%60cappedSeconds%60%20is%20%600%60%2C%20so%20%600%20%3C%20-1%60%20evaluates%20to%20%60false%60%20%E2%80%94%20no%20warning%20is%20emitted%20even%20though%20the%20value%20was%20actually%20modified%20by%20%60Math.max%280%2C%20...%29%60.%0A%0AGiven%20the%20PR's%20stated%20goal%20of%20%22log%20a%20warning%20when%20the%20cap%20is%20applied%22%2C%20an%20adversarial%20provider%20returning%20%60-30%60%20would%20silently%20result%20in%20a%200%20ms%20sleep%20with%20no%20operator%20visibility.%20The%20condition%20should%20cover%20both%20bounds%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20if%20%28cappedSeconds%20!%3D%3D%20agentError.retryAfterSeconds%29%20%7B%0A%20%20%20%20%20%20%20%20this.logger.warn%28'Capping%20retry-after%20from%20external%20API'%2C%20%7B%0A%20%20%20%20%20%20%20%20%20%20sessionId%2C%0A%20%20%20%20%20%20%20%20%20%20original%3A%20agentError.retryAfterSeconds%2C%0A%20%20%20%20%20%20%20%20%20%20capped%3A%20cappedSeconds%2C%0A%20%20%20%20%20%20%20%20%7D%29%3B%0A%20%20%20%20%20%20%7D%0A%60%60%60%0A%0AThe%20corresponding%20test%20at%20line%20822%20in%20%60agentAdapter.spec.ts%60%20also%20needs%20updating%3A%20the%20%60not.toHaveBeenCalledWith%60%20assertion%20for%20%60retryAfterSeconds%20%3D%20-1%60%20should%20be%20flipped%20to%20a%20positive%20assertion%20that%20the%20warning%20**is**%20emitted.%0A%0A&repo=kinginyellows%2Fcodemachine-pipeline"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<sub>Last reviewed commit: 54ed770</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->