### PR TITLE
fix: add issueId validation to LinearAdapter public methods (CDMCH-161)

### DIFF
--- a/src/adapters/linear/LinearAdapter.ts
+++ b/src/adapters/linear/LinearAdapter.ts
@@ -153,8 +153,7 @@ const DEFAULT_CACHE_TTL = 3600; // 1 hour in seconds
 const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000; // 1 hour sliding window
 const SNAPSHOT_DIR = 'inputs';
 const LINEAR_ISSUE_IDENTIFIER_PATTERN = /^[A-Z][A-Z0-9]*-\d+$/;
-const STRUCTURED_OPAQUE_ISSUE_ID_PATTERN =
-  /^[a-f0-9]{8}(?:-[a-f0-9]{4}){3}-[a-f0-9]{12}$/;
+const STRUCTURED_OPAQUE_ISSUE_ID_PATTERN = /^[a-f0-9]{8}(?:-[a-f0-9]{4}){3}-[a-f0-9]{12}$/;
 
 /**
  * Linear adapter for issue operations via MCP

--- a/tests/integration/github_linear_regression.spec.ts
+++ b/tests/integration/github_linear_regression.spec.ts
@@ -463,14 +463,14 @@ describe('Linear Adapter Regression Tests', () => {
         mockClient as unknown as HttpClient
       );
 
-      await expect(adapterContract.fetchIssue('a1b2c3d4-e5f6-7890-abcd-1234567890ab')).resolves.toMatchObject(
-        {
-          identifier: 'ENG-123',
-          title: stringMatcher('regression tests'),
-          state: { name: 'In Progress' },
-          priority: 2,
-        }
-      );
+      await expect(
+        adapterContract.fetchIssue('a1b2c3d4-e5f6-7890-abcd-1234567890ab')
+      ).resolves.toMatchObject({
+        identifier: 'ENG-123',
+        title: stringMatcher('regression tests'),
+        state: { name: 'In Progress' },
+        priority: 2,
+      });
       expect(mockClient.post).toHaveBeenCalledWith(
         '/graphql',
         expect.objectContaining({
@@ -558,7 +558,9 @@ describe('Linear Adapter Regression Tests', () => {
         mockClient as unknown as HttpClient
       );
 
-      await expect(adapterContract.fetchIssue('33333333-3333-3333-3333-333333333333')).rejects.toThrow();
+      await expect(
+        adapterContract.fetchIssue('33333333-3333-3333-3333-333333333333')
+      ).rejects.toThrow();
 
       try {
         await adapterContract.fetchIssue('33333333-3333-3333-3333-333333333333');
@@ -586,7 +588,9 @@ describe('Linear Adapter Regression Tests', () => {
         mockClient as unknown as HttpClient
       );
 
-      await expect(adapterContract.fetchIssue('33333333-3333-3333-3333-333333333333')).rejects.toThrow();
+      await expect(
+        adapterContract.fetchIssue('33333333-3333-3333-3333-333333333333')
+      ).rejects.toThrow();
 
       try {
         await adapterContract.fetchIssue('33333333-3333-3333-3333-333333333333');
@@ -626,7 +630,10 @@ describe('Linear Adapter Regression Tests', () => {
       ).rejects.toThrow();
 
       try {
-        await previewAdapterContract.updateIssue({ issueId: '33333333-3333-3333-3333-333333333333', title: 'Test' });
+        await previewAdapterContract.updateIssue({
+          issueId: '33333333-3333-3333-3333-333333333333',
+          title: 'Test',
+        });
       } catch (error) {
         expect(error).toBeInstanceOf(LinearAdapterError);
         if (!(error instanceof LinearAdapterError)) {

--- a/tests/integration/linearAdapter.spec.ts
+++ b/tests/integration/linearAdapter.spec.ts
@@ -552,7 +552,9 @@ describe('LinearAdapter Integration Tests', () => {
 
       mockHttpClient.post.mockRejectedValue(networkError);
 
-      await expect(adapter.fetchIssueSnapshot('11111111-1111-1111-1111-111111111111')).rejects.toThrow(LinearAdapterError);
+      await expect(
+        adapter.fetchIssueSnapshot('11111111-1111-1111-1111-111111111111')
+      ).rejects.toThrow(LinearAdapterError);
 
       expect(mockLogger.error).toHaveBeenCalledWith(
         'Failed to fetch issue snapshot and no cache available',


### PR DESCRIPTION
## **User description**
Extract `validateIssueId()` from `getSnapshotPath()` and call it at
entry to `fetchIssue()`, `fetchComments()`, `updateIssue()`, and
`postComment()`. Prevents malformed issue IDs from reaching GraphQL.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->




___

## **CodeAnt-AI Description**
Validate Linear issue IDs early to reject malformed IDs before GraphQL

### What Changed
- Public adapter methods that accept an issue ID now validate the ID immediately and throw a permanent error for malformed or overly long IDs instead of sending them to the API.
- Snapshot path construction also validates IDs so cached snapshot lookups reject invalid IDs.
- Added tests ensuring malformed IDs are rejected before any HTTP call and that no "Failed ..." error logs are emitted for those cases.

### Impact
`✅ Clearer invalid-ID errors`
`✅ Fewer malformed GraphQL requests`
`✅ No network calls when issue IDs are invalid`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts issue ID validation into a new static `LinearAdapter.validateIssueId()` method and calls it at the entry point of all five public methods (`fetchIssueSnapshot`, `fetchIssue`, `fetchComments`, `updateIssue`, `postComment`).

**Key changes:**
- `validateIssueId` throws `LinearAdapterError(PERMANENT)` for empty, oversized, or pattern-mismatched IDs
- Two accepted formats: the human-readable identifier pattern (`TEAM-123`) and a UUID pattern for opaque IDs
- All test fixtures updated from previously-invalid ID strings to proper UUID-format values

**Issues found:**
- The `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` regex uses lowercase-only character class `[a-f0-9]` and will reject valid uppercase UUIDs. Adding the `i` flag would align with RFC 4122 case-insensitivity.
- In `updateIssue` and `postComment`, `validateIssueId` is called *after* the preview-features guard, so a caller passing a malformed ID with preview features disabled receives the feature-gate error rather than the more relevant validation error.

<h3>Confidence Score: 3/5</h3>

- Core validation logic is sound, but two correctness gaps prevent higher confidence: UUID regex rejects valid uppercase UUIDs per RFC 4122, and error message ordering obscures validation failures in gated methods.
- The core logic of extracting and calling `validateIssueId` before GraphQL requests is correct and well-tested. However, the UUID regex pattern accepts only lowercase hex digits, which means valid uppercase UUIDs — legal per RFC 4122 — are silently rejected as permanent errors. This is a correctness gap that a one-character fix (adding the `i` flag) resolves. Additionally, in `updateIssue` and `postComment`, validation is called after the preview-features guard, so callers with preview features disabled receive a less relevant error message. These two issues suggest the implementation needs adjustment before merging.
- src/adapters/linear/LinearAdapter.ts — Lines 156-157 (UUID pattern) and lines 353-364, 401-412 (validation order in gated methods)

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (18)</h3></summary>

1. `src/adapters/linear/LinearAdapter.ts`, line 209-217 ([link](https://github.com/kinginyellows/codemachine-pipeline/blob/ba30a0d24ddc378c52011c65a07173ff8d662f62/src/adapters/linear/LinearAdapter.ts#L209-L217)) 

   `fetchIssueSnapshot()` is a public entry point but lacks early `validateIssueId()` validation. The flow currently:

   1. Calls `loadCachedSnapshot(issueId)` (line 220), which calls `getSnapshotPath(issueId)` inside a try/catch. If validation fails here, the error is swallowed and null is returned.
   2. Falls through to call `fetchIssue(issueId)` (line 232) inside the outer try/catch. Validation fails here, throwing a plain `Error` **before** `fetchIssue()`'s own try/catch.
   3. The error propagates to `fetchIssueSnapshot()`'s catch block (line 253) where it is misclassified as `ErrorType.TRANSIENT` (line 267).

   This causes the misleading log at line 254: `"API fetch failed, attempting to use cached snapshot"` and wrong error semantics.

   Add early validation before the cache check to exit immediately with correct error semantics:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/adapters/linear/LinearAdapter.ts
   Line: 209-217

   Comment:
   `fetchIssueSnapshot()` is a public entry point but lacks early `validateIssueId()` validation. The flow currently:

   1. Calls `loadCachedSnapshot(issueId)` (line 220), which calls `getSnapshotPath(issueId)` inside a try/catch. If validation fails here, the error is swallowed and null is returned.
   2. Falls through to call `fetchIssue(issueId)` (line 232) inside the outer try/catch. Validation fails here, throwing a plain `Error` **before** `fetchIssue()`'s own try/catch.
   3. The error propagates to `fetchIssueSnapshot()`'s catch block (line 253) where it is misclassified as `ErrorType.TRANSIENT` (line 267).

   This causes the misleading log at line 254: `"API fetch failed, attempting to use cached snapshot"` and wrong error semantics.

   Add early validation before the cache check to exit immediately with correct error semantics:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `src/adapters/linear/LinearAdapter.ts`, line 209-219 ([link](https://github.com/kinginyellows/codemachine-pipeline/blob/c3f447a10c0d5f948b0dd83b07aebaaad8181488/src/adapters/linear/LinearAdapter.ts#L209-L219)) 

   **`fetchIssueSnapshot()` missing `validateIssueId()` guard**

   `fetchIssueSnapshot()` is a public method that accepts `issueId` but is the only public entry point that did **not** receive the new validation guard. When called with an invalid ID, instead of a clean early rejection, the following unexpected flow occurs:

   1. `loadCachedSnapshot(issueId)` is called (line 220), which internally calls `getSnapshotPath(issueId)` → `validateIssueId(issueId)` → throws a plain `Error`.
   2. That `Error` is **silently swallowed** inside `loadCachedSnapshot`'s `catch` block (line 464 — it's not an `isFileNotFound` error, so it logs a warning and returns `null`).
   3. Execution falls into the outer `try` (line 230), where `fetchIssue(issueId)` is called and `validateIssueId` fires again — this time the error is caught by `fetchIssueSnapshot`'s own `catch` (line 253).
   4. The catch block then attempts a second fallback `loadCachedSnapshot` call, which silently swallows the validation error *again*.
   5. Finally the error reaches `normalizeError` — but not before unnecessary I/O attempts and two swallowed validation errors.

   Adding the guard at the top of `fetchIssueSnapshot` prevents all of this:

   ```typescript
   async fetchIssueSnapshot(
     issueId: string,
     options?: {
       forceRefresh?: boolean;
       noCache?: boolean;
     }
   ): Promise<IssueSnapshot> {
     this.validateIssueId(issueId);
     // Check cache first unless noCache or forceRefresh
     if (this.runDir && !options?.noCache && !options?.forceRefresh) {
   ```

3. `src/adapters/linear/LinearAdapter.ts`, line 209-217 ([link](https://github.com/kinginyellows/codemachine-pipeline/blob/4619054162c6992dc0e83c4bc1ed0b3b16469ac0/src/adapters/linear/LinearAdapter.ts#L209-L217)) 

   `fetchIssueSnapshot()` is a public method but is not guarded by `validateIssueId()` at its entry, unlike the four other public methods updated in this PR.

   When `runDir` is set and caching is active (the default path), an invalid `issueId` reaches `loadCachedSnapshot()` → `getSnapshotPath()` → `validateIssueId()`, which throws a `LinearAdapterError`. That error is **silently swallowed** by `loadCachedSnapshot()`'s broad `catch` block (lines 458–469), which returns `null` on any non-file-not-found error. The method then falls through into the `try` block, calls `fetchIssue()` (which re-validates and throws correctly), but the outer catch at line 254 logs a misleading `"API fetch failed, attempting to use cached snapshot"` warning — when the real cause is an invalid issue ID, not an API failure.

   Adding `validateIssueId` at the top of `fetchIssueSnapshot()` short-circuits this path immediately and produces accurate logging:

4. `src/adapters/linear/LinearAdapter.ts`, line 519 ([link](https://github.com/kinginyellows/codemachine-pipeline/blob/489d759b44456dd5cf4b4bee8efb52937986f6f7/src/adapters/linear/LinearAdapter.ts#L519)) 

   **Regex is significantly weaker than the original**

   The regex `/^[a-zA-Z0-9._-]+$/` is much more permissive than the original `/^[A-Z][A-Z0-9]*-\d+$/` that was in the prior commit. Linear issue IDs follow a strict `TEAM-123` format (uppercase team key, hyphen, integer). The replacement regex now accepts:

   - Fully lowercase strings like `test` or `abc`
   - Dot-separated strings like `abc.def` or even just `..`
   - Arbitrary hyphen-separated tokens like `a-b-c-d` with no numeric suffix

   A value like `foo.bar` or `..` now passes validation even though it is not a valid Linear issue ID and will fail at the GraphQL layer. The stated goal of "preventing malformed issue IDs from reaching GraphQL" is undermined by loosening the regex.

   If broader ID formats (e.g., UUIDs) must be supported, that should be handled explicitly. Otherwise, restoring the stricter pattern preserves the original safety guarantee:

5. `src/adapters/linear/LinearAdapter.ts`, line 519 ([link](https://github.com/kinginyellows/codemachine-pipeline/blob/50fd8801815319493fe96933c1c76e81d299bced/src/adapters/linear/LinearAdapter.ts#L519)) 

   **Relaxed regex breaks Linear ID format enforcement**

   The new regex `^[a-zA-Z0-9._-]+Extract `validateIssueId()` from `getSnapshotPath()` and call it at
entry to `fetchIssue()`, `fetchComments()`, `updateIssue()`, and
`postComment()`. Prevents malformed issue IDs from reaching GraphQL.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts `validateIssueId()` from `getSnapshotPath()` into its own private method and calls it at the entry of each public method (`fetchIssueSnapshot`, `fetchIssue`, `fetchComments`, `updateIssue`, `postComment`) to catch malformed issue IDs before they reach GraphQL. The error type is upgraded to `LinearAdapterError` with `ErrorType.PERMANENT`, which resolves the previous thread's concern about bad IDs being classified as transient failures in `fetchIssueSnapshot`.

However, the PR introduces a significant regression by changing the validation regex from the strict `^[A-Z][A-Z0-9]*-\d+Extract `validateIssueId()` from `getSnapshotPath()` and call it at
entry to `fetchIssue()`, `fetchComments()`, `updateIssue()`, and
`postComment()`. Prevents malformed issue IDs from reaching GraphQL.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts a shared `validateIssueId()` helper from `getSnapshotPath()` and calls it at the entry of all five public methods (`fetchIssueSnapshot`, `fetchIssue`, `fetchComments`, `updateIssue`, `postComment`), fixing a previous concern about validation errors being thrown as plain `Error` instances (now correctly using `LinearAdapterError` with `ErrorType.PERMANENT`).

- The error-type fix is sound: `createErrorNormalizer` passes `LinearAdapterError` instances through unchanged, so callers of all five methods now receive the correct `PERMANENT` error classification on bad input.
- **Regression**: the validation regex was changed from `^[A-Z][A-Z0-9]*-\d+Extract `validateIssueId()` from `getSnapshotPath()` and call it at
entry to `fetchIssue()`, `fetchComments()`, `updateIssue()`, and
`postComment()`. Prevents malformed issue IDs from reaching GraphQL.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts issue-ID validation from `getSnapshotPath()` into a new static `validateIssueId()` method and calls it at the entry of all five public `LinearAdapter` methods (`fetchIssueSnapshot`, `fetchIssue`, `fetchComments`, `updateIssue`, `postComment`), ensuring malformed IDs throw a `LinearAdapterError` with `ErrorType.PERMANENT` before reaching any GraphQL call.

Key observations:
- **Regex evaluated before length guard** (`LinearAdapter.ts:521–533`): Both regex patterns are computed unconditionally before the `if` block whose `issueId.length > 100` clause was meant to short-circuit long inputs. The length guard cannot prevent the regexes from running on oversized strings because the `const` bindings that compute them come first.
- **Overly broad second pattern** (`LinearAdapter.ts:156–157`): The second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` (`[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+`) accepts any hyphen-separated alphanumeric string — `foo-bar`, `a-b`, etc. — which may undermine the stated goal of blocking malformed IDs.
- **Redundant validation calls**: `fetchIssueSnapshot` now calls `validateIssueId` directly and then again indirectly through `fetchIssue`, `fetchComments`, and `getSnapshotPath` — harmless but worth noting.
- **Missing test for `fetchIssueSnapshot`** (`linearAdapter.spec.ts`): Four new tests cover the other four public methods but the newly added guard in `fetchIssueSnapshot` has no corresponding test.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for correctness but the validation logic has implementation issues that weaken the intended guard.
- The PR's goal — prevent malformed IDs from reaching GraphQL — is sound, but the implementation has two meaningful deficiencies: the length guard is bypassed because regexes run before it, and the second pattern alternative is so permissive that many invalid IDs will still pass. Test coverage is also incomplete (missing `fetchIssueSnapshot` case). None of these issues cause production crashes today, but they leave the validation weaker than intended.
- Pay close attention to `src/adapters/linear/LinearAdapter.ts` — specifically the ordering of the length check versus regex evaluation in `validateIssueId`, and the breadth of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/adapters/linear/LinearAdapter.ts | Extracts `validateIssueId()` as a static method and calls it at the entry of all five public methods. Two issues: the regex patterns are evaluated before the `length > 100` guard (defeating the guard's purpose), and the second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` is so broad that nearly any hyphenated alphanumeric string passes validation. |
| tests/integration/linearAdapter.spec.ts | Adds four new tests covering malformed ID rejection for `fetchIssue`, `fetchComments`, `updateIssue`, and `postComment`. Missing a parallel test for `fetchIssueSnapshot`, leaving a coverage gap for the newly added validation guard in that method. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant fetchIssueSnapshot
    participant fetchIssue
    participant fetchComments
    participant updateIssue
    participant postComment
    participant validateIssueId
    participant GraphQL

    Caller->>fetchIssueSnapshot: issueId
    fetchIssueSnapshot->>validateIssueId: issueId (new)
    validateIssueId-->>fetchIssueSnapshot: ok / LinearAdapterError(PERMANENT)
    fetchIssueSnapshot->>fetchIssue: issueId
    fetchIssue->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchIssue: ok
    fetchIssue->>GraphQL: query
    fetchIssueSnapshot->>fetchComments: issueId
    fetchComments->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchComments: ok
    fetchComments->>GraphQL: query

    Caller->>updateIssue: params
    Note over updateIssue: preview-features guard first
    updateIssue->>validateIssueId: params.issueId (new)
    validateIssueId-->>updateIssue: ok / LinearAdapterError(PERMANENT)
    updateIssue->>GraphQL: mutation

    Caller->>postComment: params
    Note over postComment: preview-features guard first
    postComment->>validateIssueId: params.issueId (new)
    validateIssueId-->>postComment: ok / LinearAdapterError(PERMANENT)
    postComment->>GraphQL: mutation
```

 (which enforced the `TEAM-NUMBER` Linear format) to `^[a-zA-Z0-9._-]+Extract `validateIssueId()` from `getSnapshotPath()` and call it at
entry to `fetchIssue()`, `fetchComments()`, `updateIssue()`, and
`postComment()`. Prevents malformed issue IDs from reaching GraphQL.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts issue-ID validation from `getSnapshotPath()` into a new static `validateIssueId()` method and calls it at the entry of all five public `LinearAdapter` methods (`fetchIssueSnapshot`, `fetchIssue`, `fetchComments`, `updateIssue`, `postComment`), ensuring malformed IDs throw a `LinearAdapterError` with `ErrorType.PERMANENT` before reaching any GraphQL call.

Key observations:
- **Regex evaluated before length guard** (`LinearAdapter.ts:521–533`): Both regex patterns are computed unconditionally before the `if` block whose `issueId.length > 100` clause was meant to short-circuit long inputs. The length guard cannot prevent the regexes from running on oversized strings because the `const` bindings that compute them come first.
- **Overly broad second pattern** (`LinearAdapter.ts:156–157`): The second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` (`[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+`) accepts any hyphen-separated alphanumeric string — `foo-bar`, `a-b`, etc. — which may undermine the stated goal of blocking malformed IDs.
- **Redundant validation calls**: `fetchIssueSnapshot` now calls `validateIssueId` directly and then again indirectly through `fetchIssue`, `fetchComments`, and `getSnapshotPath` — harmless but worth noting.
- **Missing test for `fetchIssueSnapshot`** (`linearAdapter.spec.ts`): Four new tests cover the other four public methods but the newly added guard in `fetchIssueSnapshot` has no corresponding test.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for correctness but the validation logic has implementation issues that weaken the intended guard.
- The PR's goal — prevent malformed IDs from reaching GraphQL — is sound, but the implementation has two meaningful deficiencies: the length guard is bypassed because regexes run before it, and the second pattern alternative is so permissive that many invalid IDs will still pass. Test coverage is also incomplete (missing `fetchIssueSnapshot` case). None of these issues cause production crashes today, but they leave the validation weaker than intended.
- Pay close attention to `src/adapters/linear/LinearAdapter.ts` — specifically the ordering of the length check versus regex evaluation in `validateIssueId`, and the breadth of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/adapters/linear/LinearAdapter.ts | Extracts `validateIssueId()` as a static method and calls it at the entry of all five public methods. Two issues: the regex patterns are evaluated before the `length > 100` guard (defeating the guard's purpose), and the second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` is so broad that nearly any hyphenated alphanumeric string passes validation. |
| tests/integration/linearAdapter.spec.ts | Adds four new tests covering malformed ID rejection for `fetchIssue`, `fetchComments`, `updateIssue`, and `postComment`. Missing a parallel test for `fetchIssueSnapshot`, leaving a coverage gap for the newly added validation guard in that method. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant fetchIssueSnapshot
    participant fetchIssue
    participant fetchComments
    participant updateIssue
    participant postComment
    participant validateIssueId
    participant GraphQL

    Caller->>fetchIssueSnapshot: issueId
    fetchIssueSnapshot->>validateIssueId: issueId (new)
    validateIssueId-->>fetchIssueSnapshot: ok / LinearAdapterError(PERMANENT)
    fetchIssueSnapshot->>fetchIssue: issueId
    fetchIssue->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchIssue: ok
    fetchIssue->>GraphQL: query
    fetchIssueSnapshot->>fetchComments: issueId
    fetchComments->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchComments: ok
    fetchComments->>GraphQL: query

    Caller->>updateIssue: params
    Note over updateIssue: preview-features guard first
    updateIssue->>validateIssueId: params.issueId (new)
    validateIssueId-->>updateIssue: ok / LinearAdapterError(PERMANENT)
    updateIssue->>GraphQL: mutation

    Caller->>postComment: params
    Note over postComment: preview-features guard first
    postComment->>validateIssueId: params.issueId (new)
    validateIssueId-->>postComment: ok / LinearAdapterError(PERMANENT)
    postComment->>GraphQL: mutation
```

, which is far too permissive and accepts strings like `foo.bar`, `---`, and `123abc` — undermining the stated goal of preventing malformed IDs from reaching GraphQL.
- `validateIssueId` is placed inside the `try/catch` block in `fetchIssue`, `fetchComments`, `updateIssue`, and `postComment`, causing validation failures to be logged as API failures (`"Failed to fetch issue"` etc.), whereas `fetchIssueSnapshot` correctly places the call before its `try` block.
- The double-validation that now occurs when `fetchIssueSnapshot` calls `fetchIssue`/`fetchComments` (each of which re-validates an already-validated ID) is harmless but redundant.

<h3>Confidence Score: 3/5</h3>

- Not safe to merge as-is — the regex change weakens validation below the pre-PR baseline.
- The error-taxonomy fix (LinearAdapterError with PERMANENT type) is correct and well-implemented. However, the new regex accepts far too many non-Linear-format strings, which is a regression in the exact property this PR claims to improve. The misleading log messages are a minor but real operational concern. These two issues bring the confidence below the threshold for a clean merge.
- src/adapters/linear/LinearAdapter.ts — specifically line 519 (regex) and the validateIssueId placement in the four try/catch blocks.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/adapters/linear/LinearAdapter.ts | Extracts validateIssueId() into a shared private method and calls it at entry to all five public methods. The error type is now correctly LinearAdapterError(PERMANENT) instead of a plain Error, addressing the previous thread's concern. However, the validation regex was changed from the structurally-strict ^[A-Z][A-Z0-9]*-\d+$ to the permissive ^[a-zA-Z0-9._-]+$, which accepts many strings that are not valid Linear IDs and weakens the protection this PR was meant to add. Additionally, validateIssueId is placed inside the try/catch block in four methods, causing misleading "Failed to fetch/update/post" log entries for what are really input validation errors. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Caller] -->|issueId| B{validateIssueId}
    B -->|❌ invalid| C[throw LinearAdapterError\nErrorType.PERMANENT]
    B -->|✅ valid| D[proceed to try block]

    D --> E[fetchIssueSnapshot]
    D --> F[fetchIssue]
    D --> G[fetchComments]
    D --> H[updateIssue]
    D --> I[postComment]

    E -->|before try ✅| J[executeGraphQL / cache]
    F -->|inside try ⚠️| K[executeGraphQL]
    G -->|inside try ⚠️| L[executeGraphQL]
    H -->|inside try ⚠️| M[executeGraphQL]
    I -->|inside try ⚠️| N[executeGraphQL]

    K --> O{catch block}
    L --> O
    M --> O
    N --> O
    O -->|LinearAdapterError| P[normalizeError → pass-through]
    O -->|other error| Q[normalizeError → wrap as LinearAdapterError]
    P --> R[re-throw to caller]
    Q --> R
```

 (which enforced Linear's canonical `TEAM-123` format) to the very permissive `^[a-zA-Z0-9._-]+Extract `validateIssueId()` from `getSnapshotPath()` and call it at
entry to `fetchIssue()`, `fetchComments()`, `updateIssue()`, and
`postComment()`. Prevents malformed issue IDs from reaching GraphQL.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts a shared `validateIssueId()` helper from `getSnapshotPath()` and calls it at the entry of all five public methods (`fetchIssueSnapshot`, `fetchIssue`, `fetchComments`, `updateIssue`, `postComment`), fixing a previous concern about validation errors being thrown as plain `Error` instances (now correctly using `LinearAdapterError` with `ErrorType.PERMANENT`).

- The error-type fix is sound: `createErrorNormalizer` passes `LinearAdapterError` instances through unchanged, so callers of all five methods now receive the correct `PERMANENT` error classification on bad input.
- **Regression**: the validation regex was changed from `^[A-Z][A-Z0-9]*-\d+Extract `validateIssueId()` from `getSnapshotPath()` and call it at
entry to `fetchIssue()`, `fetchComments()`, `updateIssue()`, and
`postComment()`. Prevents malformed issue IDs from reaching GraphQL.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts issue-ID validation from `getSnapshotPath()` into a new static `validateIssueId()` method and calls it at the entry of all five public `LinearAdapter` methods (`fetchIssueSnapshot`, `fetchIssue`, `fetchComments`, `updateIssue`, `postComment`), ensuring malformed IDs throw a `LinearAdapterError` with `ErrorType.PERMANENT` before reaching any GraphQL call.

Key observations:
- **Regex evaluated before length guard** (`LinearAdapter.ts:521–533`): Both regex patterns are computed unconditionally before the `if` block whose `issueId.length > 100` clause was meant to short-circuit long inputs. The length guard cannot prevent the regexes from running on oversized strings because the `const` bindings that compute them come first.
- **Overly broad second pattern** (`LinearAdapter.ts:156–157`): The second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` (`[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+`) accepts any hyphen-separated alphanumeric string — `foo-bar`, `a-b`, etc. — which may undermine the stated goal of blocking malformed IDs.
- **Redundant validation calls**: `fetchIssueSnapshot` now calls `validateIssueId` directly and then again indirectly through `fetchIssue`, `fetchComments`, and `getSnapshotPath` — harmless but worth noting.
- **Missing test for `fetchIssueSnapshot`** (`linearAdapter.spec.ts`): Four new tests cover the other four public methods but the newly added guard in `fetchIssueSnapshot` has no corresponding test.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for correctness but the validation logic has implementation issues that weaken the intended guard.
- The PR's goal — prevent malformed IDs from reaching GraphQL — is sound, but the implementation has two meaningful deficiencies: the length guard is bypassed because regexes run before it, and the second pattern alternative is so permissive that many invalid IDs will still pass. Test coverage is also incomplete (missing `fetchIssueSnapshot` case). None of these issues cause production crashes today, but they leave the validation weaker than intended.
- Pay close attention to `src/adapters/linear/LinearAdapter.ts` — specifically the ordering of the length check versus regex evaluation in `validateIssueId`, and the breadth of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/adapters/linear/LinearAdapter.ts | Extracts `validateIssueId()` as a static method and calls it at the entry of all five public methods. Two issues: the regex patterns are evaluated before the `length > 100` guard (defeating the guard's purpose), and the second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` is so broad that nearly any hyphenated alphanumeric string passes validation. |
| tests/integration/linearAdapter.spec.ts | Adds four new tests covering malformed ID rejection for `fetchIssue`, `fetchComments`, `updateIssue`, and `postComment`. Missing a parallel test for `fetchIssueSnapshot`, leaving a coverage gap for the newly added validation guard in that method. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant fetchIssueSnapshot
    participant fetchIssue
    participant fetchComments
    participant updateIssue
    participant postComment
    participant validateIssueId
    participant GraphQL

    Caller->>fetchIssueSnapshot: issueId
    fetchIssueSnapshot->>validateIssueId: issueId (new)
    validateIssueId-->>fetchIssueSnapshot: ok / LinearAdapterError(PERMANENT)
    fetchIssueSnapshot->>fetchIssue: issueId
    fetchIssue->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchIssue: ok
    fetchIssue->>GraphQL: query
    fetchIssueSnapshot->>fetchComments: issueId
    fetchComments->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchComments: ok
    fetchComments->>GraphQL: query

    Caller->>updateIssue: params
    Note over updateIssue: preview-features guard first
    updateIssue->>validateIssueId: params.issueId (new)
    validateIssueId-->>updateIssue: ok / LinearAdapterError(PERMANENT)
    updateIssue->>GraphQL: mutation

    Caller->>postComment: params
    Note over postComment: preview-features guard first
    postComment->>validateIssueId: params.issueId (new)
    validateIssueId-->>postComment: ok / LinearAdapterError(PERMANENT)
    postComment->>GraphQL: mutation
```

 (which enforced the `TEAM-NUMBER` Linear format) to `^[a-zA-Z0-9._-]+Extract `validateIssueId()` from `getSnapshotPath()` and call it at
entry to `fetchIssue()`, `fetchComments()`, `updateIssue()`, and
`postComment()`. Prevents malformed issue IDs from reaching GraphQL.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts issue-ID validation from `getSnapshotPath()` into a new static `validateIssueId()` method and calls it at the entry of all five public `LinearAdapter` methods (`fetchIssueSnapshot`, `fetchIssue`, `fetchComments`, `updateIssue`, `postComment`), ensuring malformed IDs throw a `LinearAdapterError` with `ErrorType.PERMANENT` before reaching any GraphQL call.

Key observations:
- **Regex evaluated before length guard** (`LinearAdapter.ts:521–533`): Both regex patterns are computed unconditionally before the `if` block whose `issueId.length > 100` clause was meant to short-circuit long inputs. The length guard cannot prevent the regexes from running on oversized strings because the `const` bindings that compute them come first.
- **Overly broad second pattern** (`LinearAdapter.ts:156–157`): The second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` (`[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+`) accepts any hyphen-separated alphanumeric string — `foo-bar`, `a-b`, etc. — which may undermine the stated goal of blocking malformed IDs.
- **Redundant validation calls**: `fetchIssueSnapshot` now calls `validateIssueId` directly and then again indirectly through `fetchIssue`, `fetchComments`, and `getSnapshotPath` — harmless but worth noting.
- **Missing test for `fetchIssueSnapshot`** (`linearAdapter.spec.ts`): Four new tests cover the other four public methods but the newly added guard in `fetchIssueSnapshot` has no corresponding test.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for correctness but the validation logic has implementation issues that weaken the intended guard.
- The PR's goal — prevent malformed IDs from reaching GraphQL — is sound, but the implementation has two meaningful deficiencies: the length guard is bypassed because regexes run before it, and the second pattern alternative is so permissive that many invalid IDs will still pass. Test coverage is also incomplete (missing `fetchIssueSnapshot` case). None of these issues cause production crashes today, but they leave the validation weaker than intended.
- Pay close attention to `src/adapters/linear/LinearAdapter.ts` — specifically the ordering of the length check versus regex evaluation in `validateIssueId`, and the breadth of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/adapters/linear/LinearAdapter.ts | Extracts `validateIssueId()` as a static method and calls it at the entry of all five public methods. Two issues: the regex patterns are evaluated before the `length > 100` guard (defeating the guard's purpose), and the second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` is so broad that nearly any hyphenated alphanumeric string passes validation. |
| tests/integration/linearAdapter.spec.ts | Adds four new tests covering malformed ID rejection for `fetchIssue`, `fetchComments`, `updateIssue`, and `postComment`. Missing a parallel test for `fetchIssueSnapshot`, leaving a coverage gap for the newly added validation guard in that method. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant fetchIssueSnapshot
    participant fetchIssue
    participant fetchComments
    participant updateIssue
    participant postComment
    participant validateIssueId
    participant GraphQL

    Caller->>fetchIssueSnapshot: issueId
    fetchIssueSnapshot->>validateIssueId: issueId (new)
    validateIssueId-->>fetchIssueSnapshot: ok / LinearAdapterError(PERMANENT)
    fetchIssueSnapshot->>fetchIssue: issueId
    fetchIssue->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchIssue: ok
    fetchIssue->>GraphQL: query
    fetchIssueSnapshot->>fetchComments: issueId
    fetchComments->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchComments: ok
    fetchComments->>GraphQL: query

    Caller->>updateIssue: params
    Note over updateIssue: preview-features guard first
    updateIssue->>validateIssueId: params.issueId (new)
    validateIssueId-->>updateIssue: ok / LinearAdapterError(PERMANENT)
    updateIssue->>GraphQL: mutation

    Caller->>postComment: params
    Note over postComment: preview-features guard first
    postComment->>validateIssueId: params.issueId (new)
    validateIssueId-->>postComment: ok / LinearAdapterError(PERMANENT)
    postComment->>GraphQL: mutation
```

, which is far too permissive and accepts strings like `foo.bar`, `---`, and `123abc` — undermining the stated goal of preventing malformed IDs from reaching GraphQL.
- `validateIssueId` is placed inside the `try/catch` block in `fetchIssue`, `fetchComments`, `updateIssue`, and `postComment`, causing validation failures to be logged as API failures (`"Failed to fetch issue"` etc.), whereas `fetchIssueSnapshot` correctly places the call before its `try` block.
- The double-validation that now occurs when `fetchIssueSnapshot` calls `fetchIssue`/`fetchComments` (each of which re-validates an already-validated ID) is harmless but redundant.

<h3>Confidence Score: 3/5</h3>

- Not safe to merge as-is — the regex change weakens validation below the pre-PR baseline.
- The error-taxonomy fix (LinearAdapterError with PERMANENT type) is correct and well-implemented. However, the new regex accepts far too many non-Linear-format strings, which is a regression in the exact property this PR claims to improve. The misleading log messages are a minor but real operational concern. These two issues bring the confidence below the threshold for a clean merge.
- src/adapters/linear/LinearAdapter.ts — specifically line 519 (regex) and the validateIssueId placement in the four try/catch blocks.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/adapters/linear/LinearAdapter.ts | Extracts validateIssueId() into a shared private method and calls it at entry to all five public methods. The error type is now correctly LinearAdapterError(PERMANENT) instead of a plain Error, addressing the previous thread's concern. However, the validation regex was changed from the structurally-strict ^[A-Z][A-Z0-9]*-\d+$ to the permissive ^[a-zA-Z0-9._-]+$, which accepts many strings that are not valid Linear IDs and weakens the protection this PR was meant to add. Additionally, validateIssueId is placed inside the try/catch block in four methods, causing misleading "Failed to fetch/update/post" log entries for what are really input validation errors. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Caller] -->|issueId| B{validateIssueId}
    B -->|❌ invalid| C[throw LinearAdapterError\nErrorType.PERMANENT]
    B -->|✅ valid| D[proceed to try block]

    D --> E[fetchIssueSnapshot]
    D --> F[fetchIssue]
    D --> G[fetchComments]
    D --> H[updateIssue]
    D --> I[postComment]

    E -->|before try ✅| J[executeGraphQL / cache]
    F -->|inside try ⚠️| K[executeGraphQL]
    G -->|inside try ⚠️| L[executeGraphQL]
    H -->|inside try ⚠️| M[executeGraphQL]
    I -->|inside try ⚠️| N[executeGraphQL]

    K --> O{catch block}
    L --> O
    M --> O
    N --> O
    O -->|LinearAdapterError| P[normalizeError → pass-through]
    O -->|other error| Q[normalizeError → wrap as LinearAdapterError]
    P --> R[re-throw to caller]
    Q --> R
```

, which accepts arbitrary strings that are not valid Linear issue IDs. This undermines the stated goal of the PR.

- **Regex loosened significantly** (`^[A-Z][A-Z0-9]*-\d+Extract `validateIssueId()` from `getSnapshotPath()` and call it at
entry to `fetchIssue()`, `fetchComments()`, `updateIssue()`, and
`postComment()`. Prevents malformed issue IDs from reaching GraphQL.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts a shared `validateIssueId()` helper from `getSnapshotPath()` and calls it at the entry of all five public methods (`fetchIssueSnapshot`, `fetchIssue`, `fetchComments`, `updateIssue`, `postComment`), fixing a previous concern about validation errors being thrown as plain `Error` instances (now correctly using `LinearAdapterError` with `ErrorType.PERMANENT`).

- The error-type fix is sound: `createErrorNormalizer` passes `LinearAdapterError` instances through unchanged, so callers of all five methods now receive the correct `PERMANENT` error classification on bad input.
- **Regression**: the validation regex was changed from `^[A-Z][A-Z0-9]*-\d+Extract `validateIssueId()` from `getSnapshotPath()` and call it at
entry to `fetchIssue()`, `fetchComments()`, `updateIssue()`, and
`postComment()`. Prevents malformed issue IDs from reaching GraphQL.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts issue-ID validation from `getSnapshotPath()` into a new static `validateIssueId()` method and calls it at the entry of all five public `LinearAdapter` methods (`fetchIssueSnapshot`, `fetchIssue`, `fetchComments`, `updateIssue`, `postComment`), ensuring malformed IDs throw a `LinearAdapterError` with `ErrorType.PERMANENT` before reaching any GraphQL call.

Key observations:
- **Regex evaluated before length guard** (`LinearAdapter.ts:521–533`): Both regex patterns are computed unconditionally before the `if` block whose `issueId.length > 100` clause was meant to short-circuit long inputs. The length guard cannot prevent the regexes from running on oversized strings because the `const` bindings that compute them come first.
- **Overly broad second pattern** (`LinearAdapter.ts:156–157`): The second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` (`[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+`) accepts any hyphen-separated alphanumeric string — `foo-bar`, `a-b`, etc. — which may undermine the stated goal of blocking malformed IDs.
- **Redundant validation calls**: `fetchIssueSnapshot` now calls `validateIssueId` directly and then again indirectly through `fetchIssue`, `fetchComments`, and `getSnapshotPath` — harmless but worth noting.
- **Missing test for `fetchIssueSnapshot`** (`linearAdapter.spec.ts`): Four new tests cover the other four public methods but the newly added guard in `fetchIssueSnapshot` has no corresponding test.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for correctness but the validation logic has implementation issues that weaken the intended guard.
- The PR's goal — prevent malformed IDs from reaching GraphQL — is sound, but the implementation has two meaningful deficiencies: the length guard is bypassed because regexes run before it, and the second pattern alternative is so permissive that many invalid IDs will still pass. Test coverage is also incomplete (missing `fetchIssueSnapshot` case). None of these issues cause production crashes today, but they leave the validation weaker than intended.
- Pay close attention to `src/adapters/linear/LinearAdapter.ts` — specifically the ordering of the length check versus regex evaluation in `validateIssueId`, and the breadth of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/adapters/linear/LinearAdapter.ts | Extracts `validateIssueId()` as a static method and calls it at the entry of all five public methods. Two issues: the regex patterns are evaluated before the `length > 100` guard (defeating the guard's purpose), and the second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` is so broad that nearly any hyphenated alphanumeric string passes validation. |
| tests/integration/linearAdapter.spec.ts | Adds four new tests covering malformed ID rejection for `fetchIssue`, `fetchComments`, `updateIssue`, and `postComment`. Missing a parallel test for `fetchIssueSnapshot`, leaving a coverage gap for the newly added validation guard in that method. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant fetchIssueSnapshot
    participant fetchIssue
    participant fetchComments
    participant updateIssue
    participant postComment
    participant validateIssueId
    participant GraphQL

    Caller->>fetchIssueSnapshot: issueId
    fetchIssueSnapshot->>validateIssueId: issueId (new)
    validateIssueId-->>fetchIssueSnapshot: ok / LinearAdapterError(PERMANENT)
    fetchIssueSnapshot->>fetchIssue: issueId
    fetchIssue->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchIssue: ok
    fetchIssue->>GraphQL: query
    fetchIssueSnapshot->>fetchComments: issueId
    fetchComments->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchComments: ok
    fetchComments->>GraphQL: query

    Caller->>updateIssue: params
    Note over updateIssue: preview-features guard first
    updateIssue->>validateIssueId: params.issueId (new)
    validateIssueId-->>updateIssue: ok / LinearAdapterError(PERMANENT)
    updateIssue->>GraphQL: mutation

    Caller->>postComment: params
    Note over postComment: preview-features guard first
    postComment->>validateIssueId: params.issueId (new)
    validateIssueId-->>postComment: ok / LinearAdapterError(PERMANENT)
    postComment->>GraphQL: mutation
```

 (which enforced the `TEAM-NUMBER` Linear format) to `^[a-zA-Z0-9._-]+Extract `validateIssueId()` from `getSnapshotPath()` and call it at
entry to `fetchIssue()`, `fetchComments()`, `updateIssue()`, and
`postComment()`. Prevents malformed issue IDs from reaching GraphQL.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts issue-ID validation from `getSnapshotPath()` into a new static `validateIssueId()` method and calls it at the entry of all five public `LinearAdapter` methods (`fetchIssueSnapshot`, `fetchIssue`, `fetchComments`, `updateIssue`, `postComment`), ensuring malformed IDs throw a `LinearAdapterError` with `ErrorType.PERMANENT` before reaching any GraphQL call.

Key observations:
- **Regex evaluated before length guard** (`LinearAdapter.ts:521–533`): Both regex patterns are computed unconditionally before the `if` block whose `issueId.length > 100` clause was meant to short-circuit long inputs. The length guard cannot prevent the regexes from running on oversized strings because the `const` bindings that compute them come first.
- **Overly broad second pattern** (`LinearAdapter.ts:156–157`): The second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` (`[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+`) accepts any hyphen-separated alphanumeric string — `foo-bar`, `a-b`, etc. — which may undermine the stated goal of blocking malformed IDs.
- **Redundant validation calls**: `fetchIssueSnapshot` now calls `validateIssueId` directly and then again indirectly through `fetchIssue`, `fetchComments`, and `getSnapshotPath` — harmless but worth noting.
- **Missing test for `fetchIssueSnapshot`** (`linearAdapter.spec.ts`): Four new tests cover the other four public methods but the newly added guard in `fetchIssueSnapshot` has no corresponding test.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for correctness but the validation logic has implementation issues that weaken the intended guard.
- The PR's goal — prevent malformed IDs from reaching GraphQL — is sound, but the implementation has two meaningful deficiencies: the length guard is bypassed because regexes run before it, and the second pattern alternative is so permissive that many invalid IDs will still pass. Test coverage is also incomplete (missing `fetchIssueSnapshot` case). None of these issues cause production crashes today, but they leave the validation weaker than intended.
- Pay close attention to `src/adapters/linear/LinearAdapter.ts` — specifically the ordering of the length check versus regex evaluation in `validateIssueId`, and the breadth of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/adapters/linear/LinearAdapter.ts | Extracts `validateIssueId()` as a static method and calls it at the entry of all five public methods. Two issues: the regex patterns are evaluated before the `length > 100` guard (defeating the guard's purpose), and the second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` is so broad that nearly any hyphenated alphanumeric string passes validation. |
| tests/integration/linearAdapter.spec.ts | Adds four new tests covering malformed ID rejection for `fetchIssue`, `fetchComments`, `updateIssue`, and `postComment`. Missing a parallel test for `fetchIssueSnapshot`, leaving a coverage gap for the newly added validation guard in that method. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant fetchIssueSnapshot
    participant fetchIssue
    participant fetchComments
    participant updateIssue
    participant postComment
    participant validateIssueId
    participant GraphQL

    Caller->>fetchIssueSnapshot: issueId
    fetchIssueSnapshot->>validateIssueId: issueId (new)
    validateIssueId-->>fetchIssueSnapshot: ok / LinearAdapterError(PERMANENT)
    fetchIssueSnapshot->>fetchIssue: issueId
    fetchIssue->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchIssue: ok
    fetchIssue->>GraphQL: query
    fetchIssueSnapshot->>fetchComments: issueId
    fetchComments->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchComments: ok
    fetchComments->>GraphQL: query

    Caller->>updateIssue: params
    Note over updateIssue: preview-features guard first
    updateIssue->>validateIssueId: params.issueId (new)
    validateIssueId-->>updateIssue: ok / LinearAdapterError(PERMANENT)
    updateIssue->>GraphQL: mutation

    Caller->>postComment: params
    Note over postComment: preview-features guard first
    postComment->>validateIssueId: params.issueId (new)
    validateIssueId-->>postComment: ok / LinearAdapterError(PERMANENT)
    postComment->>GraphQL: mutation
```

, which is far too permissive and accepts strings like `foo.bar`, `---`, and `123abc` — undermining the stated goal of preventing malformed IDs from reaching GraphQL.
- `validateIssueId` is placed inside the `try/catch` block in `fetchIssue`, `fetchComments`, `updateIssue`, and `postComment`, causing validation failures to be logged as API failures (`"Failed to fetch issue"` etc.), whereas `fetchIssueSnapshot` correctly places the call before its `try` block.
- The double-validation that now occurs when `fetchIssueSnapshot` calls `fetchIssue`/`fetchComments` (each of which re-validates an already-validated ID) is harmless but redundant.

<h3>Confidence Score: 3/5</h3>

- Not safe to merge as-is — the regex change weakens validation below the pre-PR baseline.
- The error-taxonomy fix (LinearAdapterError with PERMANENT type) is correct and well-implemented. However, the new regex accepts far too many non-Linear-format strings, which is a regression in the exact property this PR claims to improve. The misleading log messages are a minor but real operational concern. These two issues bring the confidence below the threshold for a clean merge.
- src/adapters/linear/LinearAdapter.ts — specifically line 519 (regex) and the validateIssueId placement in the four try/catch blocks.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/adapters/linear/LinearAdapter.ts | Extracts validateIssueId() into a shared private method and calls it at entry to all five public methods. The error type is now correctly LinearAdapterError(PERMANENT) instead of a plain Error, addressing the previous thread's concern. However, the validation regex was changed from the structurally-strict ^[A-Z][A-Z0-9]*-\d+$ to the permissive ^[a-zA-Z0-9._-]+$, which accepts many strings that are not valid Linear IDs and weakens the protection this PR was meant to add. Additionally, validateIssueId is placed inside the try/catch block in four methods, causing misleading "Failed to fetch/update/post" log entries for what are really input validation errors. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Caller] -->|issueId| B{validateIssueId}
    B -->|❌ invalid| C[throw LinearAdapterError\nErrorType.PERMANENT]
    B -->|✅ valid| D[proceed to try block]

    D --> E[fetchIssueSnapshot]
    D --> F[fetchIssue]
    D --> G[fetchComments]
    D --> H[updateIssue]
    D --> I[postComment]

    E -->|before try ✅| J[executeGraphQL / cache]
    F -->|inside try ⚠️| K[executeGraphQL]
    G -->|inside try ⚠️| L[executeGraphQL]
    H -->|inside try ⚠️| M[executeGraphQL]
    I -->|inside try ⚠️| N[executeGraphQL]

    K --> O{catch block}
    L --> O
    M --> O
    N --> O
    O -->|LinearAdapterError| P[normalizeError → pass-through]
    O -->|other error| Q[normalizeError → wrap as LinearAdapterError]
    P --> R[re-throw to caller]
    Q --> R
```

 → `^[a-zA-Z0-9._-]+Extract `validateIssueId()` from `getSnapshotPath()` and call it at
entry to `fetchIssue()`, `fetchComments()`, `updateIssue()`, and
`postComment()`. Prevents malformed issue IDs from reaching GraphQL.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts a shared `validateIssueId()` helper from `getSnapshotPath()` and calls it at the entry of all five public methods (`fetchIssueSnapshot`, `fetchIssue`, `fetchComments`, `updateIssue`, `postComment`), fixing a previous concern about validation errors being thrown as plain `Error` instances (now correctly using `LinearAdapterError` with `ErrorType.PERMANENT`).

- The error-type fix is sound: `createErrorNormalizer` passes `LinearAdapterError` instances through unchanged, so callers of all five methods now receive the correct `PERMANENT` error classification on bad input.
- **Regression**: the validation regex was changed from `^[A-Z][A-Z0-9]*-\d+Extract `validateIssueId()` from `getSnapshotPath()` and call it at
entry to `fetchIssue()`, `fetchComments()`, `updateIssue()`, and
`postComment()`. Prevents malformed issue IDs from reaching GraphQL.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts issue-ID validation from `getSnapshotPath()` into a new static `validateIssueId()` method and calls it at the entry of all five public `LinearAdapter` methods (`fetchIssueSnapshot`, `fetchIssue`, `fetchComments`, `updateIssue`, `postComment`), ensuring malformed IDs throw a `LinearAdapterError` with `ErrorType.PERMANENT` before reaching any GraphQL call.

Key observations:
- **Regex evaluated before length guard** (`LinearAdapter.ts:521–533`): Both regex patterns are computed unconditionally before the `if` block whose `issueId.length > 100` clause was meant to short-circuit long inputs. The length guard cannot prevent the regexes from running on oversized strings because the `const` bindings that compute them come first.
- **Overly broad second pattern** (`LinearAdapter.ts:156–157`): The second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` (`[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+`) accepts any hyphen-separated alphanumeric string — `foo-bar`, `a-b`, etc. — which may undermine the stated goal of blocking malformed IDs.
- **Redundant validation calls**: `fetchIssueSnapshot` now calls `validateIssueId` directly and then again indirectly through `fetchIssue`, `fetchComments`, and `getSnapshotPath` — harmless but worth noting.
- **Missing test for `fetchIssueSnapshot`** (`linearAdapter.spec.ts`): Four new tests cover the other four public methods but the newly added guard in `fetchIssueSnapshot` has no corresponding test.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for correctness but the validation logic has implementation issues that weaken the intended guard.
- The PR's goal — prevent malformed IDs from reaching GraphQL — is sound, but the implementation has two meaningful deficiencies: the length guard is bypassed because regexes run before it, and the second pattern alternative is so permissive that many invalid IDs will still pass. Test coverage is also incomplete (missing `fetchIssueSnapshot` case). None of these issues cause production crashes today, but they leave the validation weaker than intended.
- Pay close attention to `src/adapters/linear/LinearAdapter.ts` — specifically the ordering of the length check versus regex evaluation in `validateIssueId`, and the breadth of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/adapters/linear/LinearAdapter.ts | Extracts `validateIssueId()` as a static method and calls it at the entry of all five public methods. Two issues: the regex patterns are evaluated before the `length > 100` guard (defeating the guard's purpose), and the second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` is so broad that nearly any hyphenated alphanumeric string passes validation. |
| tests/integration/linearAdapter.spec.ts | Adds four new tests covering malformed ID rejection for `fetchIssue`, `fetchComments`, `updateIssue`, and `postComment`. Missing a parallel test for `fetchIssueSnapshot`, leaving a coverage gap for the newly added validation guard in that method. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant fetchIssueSnapshot
    participant fetchIssue
    participant fetchComments
    participant updateIssue
    participant postComment
    participant validateIssueId
    participant GraphQL

    Caller->>fetchIssueSnapshot: issueId
    fetchIssueSnapshot->>validateIssueId: issueId (new)
    validateIssueId-->>fetchIssueSnapshot: ok / LinearAdapterError(PERMANENT)
    fetchIssueSnapshot->>fetchIssue: issueId
    fetchIssue->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchIssue: ok
    fetchIssue->>GraphQL: query
    fetchIssueSnapshot->>fetchComments: issueId
    fetchComments->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchComments: ok
    fetchComments->>GraphQL: query

    Caller->>updateIssue: params
    Note over updateIssue: preview-features guard first
    updateIssue->>validateIssueId: params.issueId (new)
    validateIssueId-->>updateIssue: ok / LinearAdapterError(PERMANENT)
    updateIssue->>GraphQL: mutation

    Caller->>postComment: params
    Note over postComment: preview-features guard first
    postComment->>validateIssueId: params.issueId (new)
    validateIssueId-->>postComment: ok / LinearAdapterError(PERMANENT)
    postComment->>GraphQL: mutation
```

 (which enforced the `TEAM-NUMBER` Linear format) to `^[a-zA-Z0-9._-]+Extract `validateIssueId()` from `getSnapshotPath()` and call it at
entry to `fetchIssue()`, `fetchComments()`, `updateIssue()`, and
`postComment()`. Prevents malformed issue IDs from reaching GraphQL.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts issue-ID validation from `getSnapshotPath()` into a new static `validateIssueId()` method and calls it at the entry of all five public `LinearAdapter` methods (`fetchIssueSnapshot`, `fetchIssue`, `fetchComments`, `updateIssue`, `postComment`), ensuring malformed IDs throw a `LinearAdapterError` with `ErrorType.PERMANENT` before reaching any GraphQL call.

Key observations:
- **Regex evaluated before length guard** (`LinearAdapter.ts:521–533`): Both regex patterns are computed unconditionally before the `if` block whose `issueId.length > 100` clause was meant to short-circuit long inputs. The length guard cannot prevent the regexes from running on oversized strings because the `const` bindings that compute them come first.
- **Overly broad second pattern** (`LinearAdapter.ts:156–157`): The second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` (`[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+`) accepts any hyphen-separated alphanumeric string — `foo-bar`, `a-b`, etc. — which may undermine the stated goal of blocking malformed IDs.
- **Redundant validation calls**: `fetchIssueSnapshot` now calls `validateIssueId` directly and then again indirectly through `fetchIssue`, `fetchComments`, and `getSnapshotPath` — harmless but worth noting.
- **Missing test for `fetchIssueSnapshot`** (`linearAdapter.spec.ts`): Four new tests cover the other four public methods but the newly added guard in `fetchIssueSnapshot` has no corresponding test.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for correctness but the validation logic has implementation issues that weaken the intended guard.
- The PR's goal — prevent malformed IDs from reaching GraphQL — is sound, but the implementation has two meaningful deficiencies: the length guard is bypassed because regexes run before it, and the second pattern alternative is so permissive that many invalid IDs will still pass. Test coverage is also incomplete (missing `fetchIssueSnapshot` case). None of these issues cause production crashes today, but they leave the validation weaker than intended.
- Pay close attention to `src/adapters/linear/LinearAdapter.ts` — specifically the ordering of the length check versus regex evaluation in `validateIssueId`, and the breadth of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/adapters/linear/LinearAdapter.ts | Extracts `validateIssueId()` as a static method and calls it at the entry of all five public methods. Two issues: the regex patterns are evaluated before the `length > 100` guard (defeating the guard's purpose), and the second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` is so broad that nearly any hyphenated alphanumeric string passes validation. |
| tests/integration/linearAdapter.spec.ts | Adds four new tests covering malformed ID rejection for `fetchIssue`, `fetchComments`, `updateIssue`, and `postComment`. Missing a parallel test for `fetchIssueSnapshot`, leaving a coverage gap for the newly added validation guard in that method. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant fetchIssueSnapshot
    participant fetchIssue
    participant fetchComments
    participant updateIssue
    participant postComment
    participant validateIssueId
    participant GraphQL

    Caller->>fetchIssueSnapshot: issueId
    fetchIssueSnapshot->>validateIssueId: issueId (new)
    validateIssueId-->>fetchIssueSnapshot: ok / LinearAdapterError(PERMANENT)
    fetchIssueSnapshot->>fetchIssue: issueId
    fetchIssue->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchIssue: ok
    fetchIssue->>GraphQL: query
    fetchIssueSnapshot->>fetchComments: issueId
    fetchComments->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchComments: ok
    fetchComments->>GraphQL: query

    Caller->>updateIssue: params
    Note over updateIssue: preview-features guard first
    updateIssue->>validateIssueId: params.issueId (new)
    validateIssueId-->>updateIssue: ok / LinearAdapterError(PERMANENT)
    updateIssue->>GraphQL: mutation

    Caller->>postComment: params
    Note over postComment: preview-features guard first
    postComment->>validateIssueId: params.issueId (new)
    validateIssueId-->>postComment: ok / LinearAdapterError(PERMANENT)
    postComment->>GraphQL: mutation
```

, which is far too permissive and accepts strings like `foo.bar`, `---`, and `123abc` — undermining the stated goal of preventing malformed IDs from reaching GraphQL.
- `validateIssueId` is placed inside the `try/catch` block in `fetchIssue`, `fetchComments`, `updateIssue`, and `postComment`, causing validation failures to be logged as API failures (`"Failed to fetch issue"` etc.), whereas `fetchIssueSnapshot` correctly places the call before its `try` block.
- The double-validation that now occurs when `fetchIssueSnapshot` calls `fetchIssue`/`fetchComments` (each of which re-validates an already-validated ID) is harmless but redundant.

<h3>Confidence Score: 3/5</h3>

- Not safe to merge as-is — the regex change weakens validation below the pre-PR baseline.
- The error-taxonomy fix (LinearAdapterError with PERMANENT type) is correct and well-implemented. However, the new regex accepts far too many non-Linear-format strings, which is a regression in the exact property this PR claims to improve. The misleading log messages are a minor but real operational concern. These two issues bring the confidence below the threshold for a clean merge.
- src/adapters/linear/LinearAdapter.ts — specifically line 519 (regex) and the validateIssueId placement in the four try/catch blocks.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/adapters/linear/LinearAdapter.ts | Extracts validateIssueId() into a shared private method and calls it at entry to all five public methods. The error type is now correctly LinearAdapterError(PERMANENT) instead of a plain Error, addressing the previous thread's concern. However, the validation regex was changed from the structurally-strict ^[A-Z][A-Z0-9]*-\d+$ to the permissive ^[a-zA-Z0-9._-]+$, which accepts many strings that are not valid Linear IDs and weakens the protection this PR was meant to add. Additionally, validateIssueId is placed inside the try/catch block in four methods, causing misleading "Failed to fetch/update/post" log entries for what are really input validation errors. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Caller] -->|issueId| B{validateIssueId}
    B -->|❌ invalid| C[throw LinearAdapterError\nErrorType.PERMANENT]
    B -->|✅ valid| D[proceed to try block]

    D --> E[fetchIssueSnapshot]
    D --> F[fetchIssue]
    D --> G[fetchComments]
    D --> H[updateIssue]
    D --> I[postComment]

    E -->|before try ✅| J[executeGraphQL / cache]
    F -->|inside try ⚠️| K[executeGraphQL]
    G -->|inside try ⚠️| L[executeGraphQL]
    H -->|inside try ⚠️| M[executeGraphQL]
    I -->|inside try ⚠️| N[executeGraphQL]

    K --> O{catch block}
    L --> O
    M --> O
    N --> O
    O -->|LinearAdapterError| P[normalizeError → pass-through]
    O -->|other error| Q[normalizeError → wrap as LinearAdapterError]
    P --> R[re-throw to caller]
    Q --> R
```

): accepts strings like `abc`, `foo-bar`, `1.2.3` that are not valid Linear identifiers and will still produce confusing GraphQL errors rather than early rejection.
- **Validation inside `try` blocks** (`fetchIssue`, `fetchComments`, `updateIssue`, `postComment`): when validation fails, the catch block emits misleading log messages (e.g., `"Failed to fetch issue"`) that imply an API failure rather than bad input. The pattern used in `fetchIssueSnapshot` — calling `validateIssueId` *before* the `try` block — should be applied consistently.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is — the regex change silently accepts invalid Linear issue IDs, undermining the core goal of the PR.
- The structural refactoring (extracting `validateIssueId`, throwing `LinearAdapterError` with `PERMANENT` type) is an improvement, but the loosened regex is a correctness regression that defeats the stated purpose of early input validation. Strings that are clearly not Linear IDs (`abc`, `1.2`, `foo-bar`) now bypass the guard and will reach GraphQL, producing confusing downstream errors instead of clear early rejections.
- src/adapters/linear/LinearAdapter.ts — specifically the `validateIssueId` regex on line 519 and placement of validation calls relative to `try/catch` blocks.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/adapters/linear/LinearAdapter.ts | Extracts `validateIssueId()` from `getSnapshotPath()` and calls it in all public methods; however, the regex was significantly loosened (from enforcing `TEAM-123` format to allowing any alphanumeric/dot/dash string), which undermines the validation. Validation calls inside `try` blocks also generate misleading error logs. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant fetchIssueSnapshot
    participant validateIssueId
    participant fetchIssue
    participant fetchComments
    participant GraphQL

    Caller->>fetchIssueSnapshot: issueId
    fetchIssueSnapshot->>validateIssueId: issueId (outside try/catch ✅)
    alt invalid ID
        validateIssueId-->>Caller: LinearAdapterError(PERMANENT)
    else valid ID
        fetchIssueSnapshot->>fetchIssue: issueId
        fetchIssue->>validateIssueId: issueId (inside try/catch ⚠️)
        fetchIssue->>GraphQL: query
        GraphQL-->>fetchIssue: result
        fetchIssueSnapshot->>fetchComments: issueId
        fetchComments->>validateIssueId: issueId (inside try/catch ⚠️)
        fetchComments->>GraphQL: query
        GraphQL-->>fetchComments: result
        fetchIssueSnapshot-->>Caller: IssueSnapshot
    end
```

 is far too permissive and silently accepts strings that are not valid Linear issue IDs. The original regex `^[A-Z][A-Z0-9]*-\d+Extract `validateIssueId()` from `getSnapshotPath()` and call it at
entry to `fetchIssue()`, `fetchComments()`, `updateIssue()`, and
`postComment()`. Prevents malformed issue IDs from reaching GraphQL.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts `validateIssueId()` from `getSnapshotPath()` into its own private method and calls it at the entry of each public method (`fetchIssueSnapshot`, `fetchIssue`, `fetchComments`, `updateIssue`, `postComment`) to catch malformed issue IDs before they reach GraphQL. The error type is upgraded to `LinearAdapterError` with `ErrorType.PERMANENT`, which resolves the previous thread's concern about bad IDs being classified as transient failures in `fetchIssueSnapshot`.

However, the PR introduces a significant regression by changing the validation regex from the strict `^[A-Z][A-Z0-9]*-\d+Extract `validateIssueId()` from `getSnapshotPath()` and call it at
entry to `fetchIssue()`, `fetchComments()`, `updateIssue()`, and
`postComment()`. Prevents malformed issue IDs from reaching GraphQL.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts a shared `validateIssueId()` helper from `getSnapshotPath()` and calls it at the entry of all five public methods (`fetchIssueSnapshot`, `fetchIssue`, `fetchComments`, `updateIssue`, `postComment`), fixing a previous concern about validation errors being thrown as plain `Error` instances (now correctly using `LinearAdapterError` with `ErrorType.PERMANENT`).

- The error-type fix is sound: `createErrorNormalizer` passes `LinearAdapterError` instances through unchanged, so callers of all five methods now receive the correct `PERMANENT` error classification on bad input.
- **Regression**: the validation regex was changed from `^[A-Z][A-Z0-9]*-\d+Extract `validateIssueId()` from `getSnapshotPath()` and call it at
entry to `fetchIssue()`, `fetchComments()`, `updateIssue()`, and
`postComment()`. Prevents malformed issue IDs from reaching GraphQL.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts issue-ID validation from `getSnapshotPath()` into a new static `validateIssueId()` method and calls it at the entry of all five public `LinearAdapter` methods (`fetchIssueSnapshot`, `fetchIssue`, `fetchComments`, `updateIssue`, `postComment`), ensuring malformed IDs throw a `LinearAdapterError` with `ErrorType.PERMANENT` before reaching any GraphQL call.

Key observations:
- **Regex evaluated before length guard** (`LinearAdapter.ts:521–533`): Both regex patterns are computed unconditionally before the `if` block whose `issueId.length > 100` clause was meant to short-circuit long inputs. The length guard cannot prevent the regexes from running on oversized strings because the `const` bindings that compute them come first.
- **Overly broad second pattern** (`LinearAdapter.ts:156–157`): The second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` (`[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+`) accepts any hyphen-separated alphanumeric string — `foo-bar`, `a-b`, etc. — which may undermine the stated goal of blocking malformed IDs.
- **Redundant validation calls**: `fetchIssueSnapshot` now calls `validateIssueId` directly and then again indirectly through `fetchIssue`, `fetchComments`, and `getSnapshotPath` — harmless but worth noting.
- **Missing test for `fetchIssueSnapshot`** (`linearAdapter.spec.ts`): Four new tests cover the other four public methods but the newly added guard in `fetchIssueSnapshot` has no corresponding test.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for correctness but the validation logic has implementation issues that weaken the intended guard.
- The PR's goal — prevent malformed IDs from reaching GraphQL — is sound, but the implementation has two meaningful deficiencies: the length guard is bypassed because regexes run before it, and the second pattern alternative is so permissive that many invalid IDs will still pass. Test coverage is also incomplete (missing `fetchIssueSnapshot` case). None of these issues cause production crashes today, but they leave the validation weaker than intended.
- Pay close attention to `src/adapters/linear/LinearAdapter.ts` — specifically the ordering of the length check versus regex evaluation in `validateIssueId`, and the breadth of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/adapters/linear/LinearAdapter.ts | Extracts `validateIssueId()` as a static method and calls it at the entry of all five public methods. Two issues: the regex patterns are evaluated before the `length > 100` guard (defeating the guard's purpose), and the second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` is so broad that nearly any hyphenated alphanumeric string passes validation. |
| tests/integration/linearAdapter.spec.ts | Adds four new tests covering malformed ID rejection for `fetchIssue`, `fetchComments`, `updateIssue`, and `postComment`. Missing a parallel test for `fetchIssueSnapshot`, leaving a coverage gap for the newly added validation guard in that method. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant fetchIssueSnapshot
    participant fetchIssue
    participant fetchComments
    participant updateIssue
    participant postComment
    participant validateIssueId
    participant GraphQL

    Caller->>fetchIssueSnapshot: issueId
    fetchIssueSnapshot->>validateIssueId: issueId (new)
    validateIssueId-->>fetchIssueSnapshot: ok / LinearAdapterError(PERMANENT)
    fetchIssueSnapshot->>fetchIssue: issueId
    fetchIssue->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchIssue: ok
    fetchIssue->>GraphQL: query
    fetchIssueSnapshot->>fetchComments: issueId
    fetchComments->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchComments: ok
    fetchComments->>GraphQL: query

    Caller->>updateIssue: params
    Note over updateIssue: preview-features guard first
    updateIssue->>validateIssueId: params.issueId (new)
    validateIssueId-->>updateIssue: ok / LinearAdapterError(PERMANENT)
    updateIssue->>GraphQL: mutation

    Caller->>postComment: params
    Note over postComment: preview-features guard first
    postComment->>validateIssueId: params.issueId (new)
    validateIssueId-->>postComment: ok / LinearAdapterError(PERMANENT)
    postComment->>GraphQL: mutation
```

 (which enforced the `TEAM-NUMBER` Linear format) to `^[a-zA-Z0-9._-]+Extract `validateIssueId()` from `getSnapshotPath()` and call it at
entry to `fetchIssue()`, `fetchComments()`, `updateIssue()`, and
`postComment()`. Prevents malformed issue IDs from reaching GraphQL.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts issue-ID validation from `getSnapshotPath()` into a new static `validateIssueId()` method and calls it at the entry of all five public `LinearAdapter` methods (`fetchIssueSnapshot`, `fetchIssue`, `fetchComments`, `updateIssue`, `postComment`), ensuring malformed IDs throw a `LinearAdapterError` with `ErrorType.PERMANENT` before reaching any GraphQL call.

Key observations:
- **Regex evaluated before length guard** (`LinearAdapter.ts:521–533`): Both regex patterns are computed unconditionally before the `if` block whose `issueId.length > 100` clause was meant to short-circuit long inputs. The length guard cannot prevent the regexes from running on oversized strings because the `const` bindings that compute them come first.
- **Overly broad second pattern** (`LinearAdapter.ts:156–157`): The second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` (`[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+`) accepts any hyphen-separated alphanumeric string — `foo-bar`, `a-b`, etc. — which may undermine the stated goal of blocking malformed IDs.
- **Redundant validation calls**: `fetchIssueSnapshot` now calls `validateIssueId` directly and then again indirectly through `fetchIssue`, `fetchComments`, and `getSnapshotPath` — harmless but worth noting.
- **Missing test for `fetchIssueSnapshot`** (`linearAdapter.spec.ts`): Four new tests cover the other four public methods but the newly added guard in `fetchIssueSnapshot` has no corresponding test.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for correctness but the validation logic has implementation issues that weaken the intended guard.
- The PR's goal — prevent malformed IDs from reaching GraphQL — is sound, but the implementation has two meaningful deficiencies: the length guard is bypassed because regexes run before it, and the second pattern alternative is so permissive that many invalid IDs will still pass. Test coverage is also incomplete (missing `fetchIssueSnapshot` case). None of these issues cause production crashes today, but they leave the validation weaker than intended.
- Pay close attention to `src/adapters/linear/LinearAdapter.ts` — specifically the ordering of the length check versus regex evaluation in `validateIssueId`, and the breadth of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/adapters/linear/LinearAdapter.ts | Extracts `validateIssueId()` as a static method and calls it at the entry of all five public methods. Two issues: the regex patterns are evaluated before the `length > 100` guard (defeating the guard's purpose), and the second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` is so broad that nearly any hyphenated alphanumeric string passes validation. |
| tests/integration/linearAdapter.spec.ts | Adds four new tests covering malformed ID rejection for `fetchIssue`, `fetchComments`, `updateIssue`, and `postComment`. Missing a parallel test for `fetchIssueSnapshot`, leaving a coverage gap for the newly added validation guard in that method. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant fetchIssueSnapshot
    participant fetchIssue
    participant fetchComments
    participant updateIssue
    participant postComment
    participant validateIssueId
    participant GraphQL

    Caller->>fetchIssueSnapshot: issueId
    fetchIssueSnapshot->>validateIssueId: issueId (new)
    validateIssueId-->>fetchIssueSnapshot: ok / LinearAdapterError(PERMANENT)
    fetchIssueSnapshot->>fetchIssue: issueId
    fetchIssue->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchIssue: ok
    fetchIssue->>GraphQL: query
    fetchIssueSnapshot->>fetchComments: issueId
    fetchComments->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchComments: ok
    fetchComments->>GraphQL: query

    Caller->>updateIssue: params
    Note over updateIssue: preview-features guard first
    updateIssue->>validateIssueId: params.issueId (new)
    validateIssueId-->>updateIssue: ok / LinearAdapterError(PERMANENT)
    updateIssue->>GraphQL: mutation

    Caller->>postComment: params
    Note over postComment: preview-features guard first
    postComment->>validateIssueId: params.issueId (new)
    validateIssueId-->>postComment: ok / LinearAdapterError(PERMANENT)
    postComment->>GraphQL: mutation
```

, which is far too permissive and accepts strings like `foo.bar`, `---`, and `123abc` — undermining the stated goal of preventing malformed IDs from reaching GraphQL.
- `validateIssueId` is placed inside the `try/catch` block in `fetchIssue`, `fetchComments`, `updateIssue`, and `postComment`, causing validation failures to be logged as API failures (`"Failed to fetch issue"` etc.), whereas `fetchIssueSnapshot` correctly places the call before its `try` block.
- The double-validation that now occurs when `fetchIssueSnapshot` calls `fetchIssue`/`fetchComments` (each of which re-validates an already-validated ID) is harmless but redundant.

<h3>Confidence Score: 3/5</h3>

- Not safe to merge as-is — the regex change weakens validation below the pre-PR baseline.
- The error-taxonomy fix (LinearAdapterError with PERMANENT type) is correct and well-implemented. However, the new regex accepts far too many non-Linear-format strings, which is a regression in the exact property this PR claims to improve. The misleading log messages are a minor but real operational concern. These two issues bring the confidence below the threshold for a clean merge.
- src/adapters/linear/LinearAdapter.ts — specifically line 519 (regex) and the validateIssueId placement in the four try/catch blocks.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/adapters/linear/LinearAdapter.ts | Extracts validateIssueId() into a shared private method and calls it at entry to all five public methods. The error type is now correctly LinearAdapterError(PERMANENT) instead of a plain Error, addressing the previous thread's concern. However, the validation regex was changed from the structurally-strict ^[A-Z][A-Z0-9]*-\d+$ to the permissive ^[a-zA-Z0-9._-]+$, which accepts many strings that are not valid Linear IDs and weakens the protection this PR was meant to add. Additionally, validateIssueId is placed inside the try/catch block in four methods, causing misleading "Failed to fetch/update/post" log entries for what are really input validation errors. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Caller] -->|issueId| B{validateIssueId}
    B -->|❌ invalid| C[throw LinearAdapterError\nErrorType.PERMANENT]
    B -->|✅ valid| D[proceed to try block]

    D --> E[fetchIssueSnapshot]
    D --> F[fetchIssue]
    D --> G[fetchComments]
    D --> H[updateIssue]
    D --> I[postComment]

    E -->|before try ✅| J[executeGraphQL / cache]
    F -->|inside try ⚠️| K[executeGraphQL]
    G -->|inside try ⚠️| L[executeGraphQL]
    H -->|inside try ⚠️| M[executeGraphQL]
    I -->|inside try ⚠️| N[executeGraphQL]

    K --> O{catch block}
    L --> O
    M --> O
    N --> O
    O -->|LinearAdapterError| P[normalizeError → pass-through]
    O -->|other error| Q[normalizeError → wrap as LinearAdapterError]
    P --> R[re-throw to caller]
    Q --> R
```

 (which enforced Linear's canonical `TEAM-123` format) to the very permissive `^[a-zA-Z0-9._-]+Extract `validateIssueId()` from `getSnapshotPath()` and call it at
entry to `fetchIssue()`, `fetchComments()`, `updateIssue()`, and
`postComment()`. Prevents malformed issue IDs from reaching GraphQL.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts a shared `validateIssueId()` helper from `getSnapshotPath()` and calls it at the entry of all five public methods (`fetchIssueSnapshot`, `fetchIssue`, `fetchComments`, `updateIssue`, `postComment`), fixing a previous concern about validation errors being thrown as plain `Error` instances (now correctly using `LinearAdapterError` with `ErrorType.PERMANENT`).

- The error-type fix is sound: `createErrorNormalizer` passes `LinearAdapterError` instances through unchanged, so callers of all five methods now receive the correct `PERMANENT` error classification on bad input.
- **Regression**: the validation regex was changed from `^[A-Z][A-Z0-9]*-\d+Extract `validateIssueId()` from `getSnapshotPath()` and call it at
entry to `fetchIssue()`, `fetchComments()`, `updateIssue()`, and
`postComment()`. Prevents malformed issue IDs from reaching GraphQL.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts issue-ID validation from `getSnapshotPath()` into a new static `validateIssueId()` method and calls it at the entry of all five public `LinearAdapter` methods (`fetchIssueSnapshot`, `fetchIssue`, `fetchComments`, `updateIssue`, `postComment`), ensuring malformed IDs throw a `LinearAdapterError` with `ErrorType.PERMANENT` before reaching any GraphQL call.

Key observations:
- **Regex evaluated before length guard** (`LinearAdapter.ts:521–533`): Both regex patterns are computed unconditionally before the `if` block whose `issueId.length > 100` clause was meant to short-circuit long inputs. The length guard cannot prevent the regexes from running on oversized strings because the `const` bindings that compute them come first.
- **Overly broad second pattern** (`LinearAdapter.ts:156–157`): The second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` (`[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+`) accepts any hyphen-separated alphanumeric string — `foo-bar`, `a-b`, etc. — which may undermine the stated goal of blocking malformed IDs.
- **Redundant validation calls**: `fetchIssueSnapshot` now calls `validateIssueId` directly and then again indirectly through `fetchIssue`, `fetchComments`, and `getSnapshotPath` — harmless but worth noting.
- **Missing test for `fetchIssueSnapshot`** (`linearAdapter.spec.ts`): Four new tests cover the other four public methods but the newly added guard in `fetchIssueSnapshot` has no corresponding test.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for correctness but the validation logic has implementation issues that weaken the intended guard.
- The PR's goal — prevent malformed IDs from reaching GraphQL — is sound, but the implementation has two meaningful deficiencies: the length guard is bypassed because regexes run before it, and the second pattern alternative is so permissive that many invalid IDs will still pass. Test coverage is also incomplete (missing `fetchIssueSnapshot` case). None of these issues cause production crashes today, but they leave the validation weaker than intended.
- Pay close attention to `src/adapters/linear/LinearAdapter.ts` — specifically the ordering of the length check versus regex evaluation in `validateIssueId`, and the breadth of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/adapters/linear/LinearAdapter.ts | Extracts `validateIssueId()` as a static method and calls it at the entry of all five public methods. Two issues: the regex patterns are evaluated before the `length > 100` guard (defeating the guard's purpose), and the second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` is so broad that nearly any hyphenated alphanumeric string passes validation. |
| tests/integration/linearAdapter.spec.ts | Adds four new tests covering malformed ID rejection for `fetchIssue`, `fetchComments`, `updateIssue`, and `postComment`. Missing a parallel test for `fetchIssueSnapshot`, leaving a coverage gap for the newly added validation guard in that method. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant fetchIssueSnapshot
    participant fetchIssue
    participant fetchComments
    participant updateIssue
    participant postComment
    participant validateIssueId
    participant GraphQL

    Caller->>fetchIssueSnapshot: issueId
    fetchIssueSnapshot->>validateIssueId: issueId (new)
    validateIssueId-->>fetchIssueSnapshot: ok / LinearAdapterError(PERMANENT)
    fetchIssueSnapshot->>fetchIssue: issueId
    fetchIssue->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchIssue: ok
    fetchIssue->>GraphQL: query
    fetchIssueSnapshot->>fetchComments: issueId
    fetchComments->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchComments: ok
    fetchComments->>GraphQL: query

    Caller->>updateIssue: params
    Note over updateIssue: preview-features guard first
    updateIssue->>validateIssueId: params.issueId (new)
    validateIssueId-->>updateIssue: ok / LinearAdapterError(PERMANENT)
    updateIssue->>GraphQL: mutation

    Caller->>postComment: params
    Note over postComment: preview-features guard first
    postComment->>validateIssueId: params.issueId (new)
    validateIssueId-->>postComment: ok / LinearAdapterError(PERMANENT)
    postComment->>GraphQL: mutation
```

 (which enforced the `TEAM-NUMBER` Linear format) to `^[a-zA-Z0-9._-]+Extract `validateIssueId()` from `getSnapshotPath()` and call it at
entry to `fetchIssue()`, `fetchComments()`, `updateIssue()`, and
`postComment()`. Prevents malformed issue IDs from reaching GraphQL.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts issue-ID validation from `getSnapshotPath()` into a new static `validateIssueId()` method and calls it at the entry of all five public `LinearAdapter` methods (`fetchIssueSnapshot`, `fetchIssue`, `fetchComments`, `updateIssue`, `postComment`), ensuring malformed IDs throw a `LinearAdapterError` with `ErrorType.PERMANENT` before reaching any GraphQL call.

Key observations:
- **Regex evaluated before length guard** (`LinearAdapter.ts:521–533`): Both regex patterns are computed unconditionally before the `if` block whose `issueId.length > 100` clause was meant to short-circuit long inputs. The length guard cannot prevent the regexes from running on oversized strings because the `const` bindings that compute them come first.
- **Overly broad second pattern** (`LinearAdapter.ts:156–157`): The second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` (`[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+`) accepts any hyphen-separated alphanumeric string — `foo-bar`, `a-b`, etc. — which may undermine the stated goal of blocking malformed IDs.
- **Redundant validation calls**: `fetchIssueSnapshot` now calls `validateIssueId` directly and then again indirectly through `fetchIssue`, `fetchComments`, and `getSnapshotPath` — harmless but worth noting.
- **Missing test for `fetchIssueSnapshot`** (`linearAdapter.spec.ts`): Four new tests cover the other four public methods but the newly added guard in `fetchIssueSnapshot` has no corresponding test.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for correctness but the validation logic has implementation issues that weaken the intended guard.
- The PR's goal — prevent malformed IDs from reaching GraphQL — is sound, but the implementation has two meaningful deficiencies: the length guard is bypassed because regexes run before it, and the second pattern alternative is so permissive that many invalid IDs will still pass. Test coverage is also incomplete (missing `fetchIssueSnapshot` case). None of these issues cause production crashes today, but they leave the validation weaker than intended.
- Pay close attention to `src/adapters/linear/LinearAdapter.ts` — specifically the ordering of the length check versus regex evaluation in `validateIssueId`, and the breadth of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/adapters/linear/LinearAdapter.ts | Extracts `validateIssueId()` as a static method and calls it at the entry of all five public methods. Two issues: the regex patterns are evaluated before the `length > 100` guard (defeating the guard's purpose), and the second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` is so broad that nearly any hyphenated alphanumeric string passes validation. |
| tests/integration/linearAdapter.spec.ts | Adds four new tests covering malformed ID rejection for `fetchIssue`, `fetchComments`, `updateIssue`, and `postComment`. Missing a parallel test for `fetchIssueSnapshot`, leaving a coverage gap for the newly added validation guard in that method. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant fetchIssueSnapshot
    participant fetchIssue
    participant fetchComments
    participant updateIssue
    participant postComment
    participant validateIssueId
    participant GraphQL

    Caller->>fetchIssueSnapshot: issueId
    fetchIssueSnapshot->>validateIssueId: issueId (new)
    validateIssueId-->>fetchIssueSnapshot: ok / LinearAdapterError(PERMANENT)
    fetchIssueSnapshot->>fetchIssue: issueId
    fetchIssue->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchIssue: ok
    fetchIssue->>GraphQL: query
    fetchIssueSnapshot->>fetchComments: issueId
    fetchComments->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchComments: ok
    fetchComments->>GraphQL: query

    Caller->>updateIssue: params
    Note over updateIssue: preview-features guard first
    updateIssue->>validateIssueId: params.issueId (new)
    validateIssueId-->>updateIssue: ok / LinearAdapterError(PERMANENT)
    updateIssue->>GraphQL: mutation

    Caller->>postComment: params
    Note over postComment: preview-features guard first
    postComment->>validateIssueId: params.issueId (new)
    validateIssueId-->>postComment: ok / LinearAdapterError(PERMANENT)
    postComment->>GraphQL: mutation
```

, which is far too permissive and accepts strings like `foo.bar`, `---`, and `123abc` — undermining the stated goal of preventing malformed IDs from reaching GraphQL.
- `validateIssueId` is placed inside the `try/catch` block in `fetchIssue`, `fetchComments`, `updateIssue`, and `postComment`, causing validation failures to be logged as API failures (`"Failed to fetch issue"` etc.), whereas `fetchIssueSnapshot` correctly places the call before its `try` block.
- The double-validation that now occurs when `fetchIssueSnapshot` calls `fetchIssue`/`fetchComments` (each of which re-validates an already-validated ID) is harmless but redundant.

<h3>Confidence Score: 3/5</h3>

- Not safe to merge as-is — the regex change weakens validation below the pre-PR baseline.
- The error-taxonomy fix (LinearAdapterError with PERMANENT type) is correct and well-implemented. However, the new regex accepts far too many non-Linear-format strings, which is a regression in the exact property this PR claims to improve. The misleading log messages are a minor but real operational concern. These two issues bring the confidence below the threshold for a clean merge.
- src/adapters/linear/LinearAdapter.ts — specifically line 519 (regex) and the validateIssueId placement in the four try/catch blocks.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/adapters/linear/LinearAdapter.ts | Extracts validateIssueId() into a shared private method and calls it at entry to all five public methods. The error type is now correctly LinearAdapterError(PERMANENT) instead of a plain Error, addressing the previous thread's concern. However, the validation regex was changed from the structurally-strict ^[A-Z][A-Z0-9]*-\d+$ to the permissive ^[a-zA-Z0-9._-]+$, which accepts many strings that are not valid Linear IDs and weakens the protection this PR was meant to add. Additionally, validateIssueId is placed inside the try/catch block in four methods, causing misleading "Failed to fetch/update/post" log entries for what are really input validation errors. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Caller] -->|issueId| B{validateIssueId}
    B -->|❌ invalid| C[throw LinearAdapterError\nErrorType.PERMANENT]
    B -->|✅ valid| D[proceed to try block]

    D --> E[fetchIssueSnapshot]
    D --> F[fetchIssue]
    D --> G[fetchComments]
    D --> H[updateIssue]
    D --> I[postComment]

    E -->|before try ✅| J[executeGraphQL / cache]
    F -->|inside try ⚠️| K[executeGraphQL]
    G -->|inside try ⚠️| L[executeGraphQL]
    H -->|inside try ⚠️| M[executeGraphQL]
    I -->|inside try ⚠️| N[executeGraphQL]

    K --> O{catch block}
    L --> O
    M --> O
    N --> O
    O -->|LinearAdapterError| P[normalizeError → pass-through]
    O -->|other error| Q[normalizeError → wrap as LinearAdapterError]
    P --> R[re-throw to caller]
    Q --> R
```

, which accepts arbitrary strings that are not valid Linear issue IDs. This undermines the stated goal of the PR.

- **Regex loosened significantly** (`^[A-Z][A-Z0-9]*-\d+Extract `validateIssueId()` from `getSnapshotPath()` and call it at
entry to `fetchIssue()`, `fetchComments()`, `updateIssue()`, and
`postComment()`. Prevents malformed issue IDs from reaching GraphQL.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts a shared `validateIssueId()` helper from `getSnapshotPath()` and calls it at the entry of all five public methods (`fetchIssueSnapshot`, `fetchIssue`, `fetchComments`, `updateIssue`, `postComment`), fixing a previous concern about validation errors being thrown as plain `Error` instances (now correctly using `LinearAdapterError` with `ErrorType.PERMANENT`).

- The error-type fix is sound: `createErrorNormalizer` passes `LinearAdapterError` instances through unchanged, so callers of all five methods now receive the correct `PERMANENT` error classification on bad input.
- **Regression**: the validation regex was changed from `^[A-Z][A-Z0-9]*-\d+Extract `validateIssueId()` from `getSnapshotPath()` and call it at
entry to `fetchIssue()`, `fetchComments()`, `updateIssue()`, and
`postComment()`. Prevents malformed issue IDs from reaching GraphQL.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts issue-ID validation from `getSnapshotPath()` into a new static `validateIssueId()` method and calls it at the entry of all five public `LinearAdapter` methods (`fetchIssueSnapshot`, `fetchIssue`, `fetchComments`, `updateIssue`, `postComment`), ensuring malformed IDs throw a `LinearAdapterError` with `ErrorType.PERMANENT` before reaching any GraphQL call.

Key observations:
- **Regex evaluated before length guard** (`LinearAdapter.ts:521–533`): Both regex patterns are computed unconditionally before the `if` block whose `issueId.length > 100` clause was meant to short-circuit long inputs. The length guard cannot prevent the regexes from running on oversized strings because the `const` bindings that compute them come first.
- **Overly broad second pattern** (`LinearAdapter.ts:156–157`): The second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` (`[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+`) accepts any hyphen-separated alphanumeric string — `foo-bar`, `a-b`, etc. — which may undermine the stated goal of blocking malformed IDs.
- **Redundant validation calls**: `fetchIssueSnapshot` now calls `validateIssueId` directly and then again indirectly through `fetchIssue`, `fetchComments`, and `getSnapshotPath` — harmless but worth noting.
- **Missing test for `fetchIssueSnapshot`** (`linearAdapter.spec.ts`): Four new tests cover the other four public methods but the newly added guard in `fetchIssueSnapshot` has no corresponding test.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for correctness but the validation logic has implementation issues that weaken the intended guard.
- The PR's goal — prevent malformed IDs from reaching GraphQL — is sound, but the implementation has two meaningful deficiencies: the length guard is bypassed because regexes run before it, and the second pattern alternative is so permissive that many invalid IDs will still pass. Test coverage is also incomplete (missing `fetchIssueSnapshot` case). None of these issues cause production crashes today, but they leave the validation weaker than intended.
- Pay close attention to `src/adapters/linear/LinearAdapter.ts` — specifically the ordering of the length check versus regex evaluation in `validateIssueId`, and the breadth of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/adapters/linear/LinearAdapter.ts | Extracts `validateIssueId()` as a static method and calls it at the entry of all five public methods. Two issues: the regex patterns are evaluated before the `length > 100` guard (defeating the guard's purpose), and the second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` is so broad that nearly any hyphenated alphanumeric string passes validation. |
| tests/integration/linearAdapter.spec.ts | Adds four new tests covering malformed ID rejection for `fetchIssue`, `fetchComments`, `updateIssue`, and `postComment`. Missing a parallel test for `fetchIssueSnapshot`, leaving a coverage gap for the newly added validation guard in that method. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant fetchIssueSnapshot
    participant fetchIssue
    participant fetchComments
    participant updateIssue
    participant postComment
    participant validateIssueId
    participant GraphQL

    Caller->>fetchIssueSnapshot: issueId
    fetchIssueSnapshot->>validateIssueId: issueId (new)
    validateIssueId-->>fetchIssueSnapshot: ok / LinearAdapterError(PERMANENT)
    fetchIssueSnapshot->>fetchIssue: issueId
    fetchIssue->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchIssue: ok
    fetchIssue->>GraphQL: query
    fetchIssueSnapshot->>fetchComments: issueId
    fetchComments->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchComments: ok
    fetchComments->>GraphQL: query

    Caller->>updateIssue: params
    Note over updateIssue: preview-features guard first
    updateIssue->>validateIssueId: params.issueId (new)
    validateIssueId-->>updateIssue: ok / LinearAdapterError(PERMANENT)
    updateIssue->>GraphQL: mutation

    Caller->>postComment: params
    Note over postComment: preview-features guard first
    postComment->>validateIssueId: params.issueId (new)
    validateIssueId-->>postComment: ok / LinearAdapterError(PERMANENT)
    postComment->>GraphQL: mutation
```

 (which enforced the `TEAM-NUMBER` Linear format) to `^[a-zA-Z0-9._-]+Extract `validateIssueId()` from `getSnapshotPath()` and call it at
entry to `fetchIssue()`, `fetchComments()`, `updateIssue()`, and
`postComment()`. Prevents malformed issue IDs from reaching GraphQL.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts issue-ID validation from `getSnapshotPath()` into a new static `validateIssueId()` method and calls it at the entry of all five public `LinearAdapter` methods (`fetchIssueSnapshot`, `fetchIssue`, `fetchComments`, `updateIssue`, `postComment`), ensuring malformed IDs throw a `LinearAdapterError` with `ErrorType.PERMANENT` before reaching any GraphQL call.

Key observations:
- **Regex evaluated before length guard** (`LinearAdapter.ts:521–533`): Both regex patterns are computed unconditionally before the `if` block whose `issueId.length > 100` clause was meant to short-circuit long inputs. The length guard cannot prevent the regexes from running on oversized strings because the `const` bindings that compute them come first.
- **Overly broad second pattern** (`LinearAdapter.ts:156–157`): The second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` (`[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+`) accepts any hyphen-separated alphanumeric string — `foo-bar`, `a-b`, etc. — which may undermine the stated goal of blocking malformed IDs.
- **Redundant validation calls**: `fetchIssueSnapshot` now calls `validateIssueId` directly and then again indirectly through `fetchIssue`, `fetchComments`, and `getSnapshotPath` — harmless but worth noting.
- **Missing test for `fetchIssueSnapshot`** (`linearAdapter.spec.ts`): Four new tests cover the other four public methods but the newly added guard in `fetchIssueSnapshot` has no corresponding test.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for correctness but the validation logic has implementation issues that weaken the intended guard.
- The PR's goal — prevent malformed IDs from reaching GraphQL — is sound, but the implementation has two meaningful deficiencies: the length guard is bypassed because regexes run before it, and the second pattern alternative is so permissive that many invalid IDs will still pass. Test coverage is also incomplete (missing `fetchIssueSnapshot` case). None of these issues cause production crashes today, but they leave the validation weaker than intended.
- Pay close attention to `src/adapters/linear/LinearAdapter.ts` — specifically the ordering of the length check versus regex evaluation in `validateIssueId`, and the breadth of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/adapters/linear/LinearAdapter.ts | Extracts `validateIssueId()` as a static method and calls it at the entry of all five public methods. Two issues: the regex patterns are evaluated before the `length > 100` guard (defeating the guard's purpose), and the second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` is so broad that nearly any hyphenated alphanumeric string passes validation. |
| tests/integration/linearAdapter.spec.ts | Adds four new tests covering malformed ID rejection for `fetchIssue`, `fetchComments`, `updateIssue`, and `postComment`. Missing a parallel test for `fetchIssueSnapshot`, leaving a coverage gap for the newly added validation guard in that method. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant fetchIssueSnapshot
    participant fetchIssue
    participant fetchComments
    participant updateIssue
    participant postComment
    participant validateIssueId
    participant GraphQL

    Caller->>fetchIssueSnapshot: issueId
    fetchIssueSnapshot->>validateIssueId: issueId (new)
    validateIssueId-->>fetchIssueSnapshot: ok / LinearAdapterError(PERMANENT)
    fetchIssueSnapshot->>fetchIssue: issueId
    fetchIssue->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchIssue: ok
    fetchIssue->>GraphQL: query
    fetchIssueSnapshot->>fetchComments: issueId
    fetchComments->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchComments: ok
    fetchComments->>GraphQL: query

    Caller->>updateIssue: params
    Note over updateIssue: preview-features guard first
    updateIssue->>validateIssueId: params.issueId (new)
    validateIssueId-->>updateIssue: ok / LinearAdapterError(PERMANENT)
    updateIssue->>GraphQL: mutation

    Caller->>postComment: params
    Note over postComment: preview-features guard first
    postComment->>validateIssueId: params.issueId (new)
    validateIssueId-->>postComment: ok / LinearAdapterError(PERMANENT)
    postComment->>GraphQL: mutation
```

, which is far too permissive and accepts strings like `foo.bar`, `---`, and `123abc` — undermining the stated goal of preventing malformed IDs from reaching GraphQL.
- `validateIssueId` is placed inside the `try/catch` block in `fetchIssue`, `fetchComments`, `updateIssue`, and `postComment`, causing validation failures to be logged as API failures (`"Failed to fetch issue"` etc.), whereas `fetchIssueSnapshot` correctly places the call before its `try` block.
- The double-validation that now occurs when `fetchIssueSnapshot` calls `fetchIssue`/`fetchComments` (each of which re-validates an already-validated ID) is harmless but redundant.

<h3>Confidence Score: 3/5</h3>

- Not safe to merge as-is — the regex change weakens validation below the pre-PR baseline.
- The error-taxonomy fix (LinearAdapterError with PERMANENT type) is correct and well-implemented. However, the new regex accepts far too many non-Linear-format strings, which is a regression in the exact property this PR claims to improve. The misleading log messages are a minor but real operational concern. These two issues bring the confidence below the threshold for a clean merge.
- src/adapters/linear/LinearAdapter.ts — specifically line 519 (regex) and the validateIssueId placement in the four try/catch blocks.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/adapters/linear/LinearAdapter.ts | Extracts validateIssueId() into a shared private method and calls it at entry to all five public methods. The error type is now correctly LinearAdapterError(PERMANENT) instead of a plain Error, addressing the previous thread's concern. However, the validation regex was changed from the structurally-strict ^[A-Z][A-Z0-9]*-\d+$ to the permissive ^[a-zA-Z0-9._-]+$, which accepts many strings that are not valid Linear IDs and weakens the protection this PR was meant to add. Additionally, validateIssueId is placed inside the try/catch block in four methods, causing misleading "Failed to fetch/update/post" log entries for what are really input validation errors. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Caller] -->|issueId| B{validateIssueId}
    B -->|❌ invalid| C[throw LinearAdapterError\nErrorType.PERMANENT]
    B -->|✅ valid| D[proceed to try block]

    D --> E[fetchIssueSnapshot]
    D --> F[fetchIssue]
    D --> G[fetchComments]
    D --> H[updateIssue]
    D --> I[postComment]

    E -->|before try ✅| J[executeGraphQL / cache]
    F -->|inside try ⚠️| K[executeGraphQL]
    G -->|inside try ⚠️| L[executeGraphQL]
    H -->|inside try ⚠️| M[executeGraphQL]
    I -->|inside try ⚠️| N[executeGraphQL]

    K --> O{catch block}
    L --> O
    M --> O
    N --> O
    O -->|LinearAdapterError| P[normalizeError → pass-through]
    O -->|other error| Q[normalizeError → wrap as LinearAdapterError]
    P --> R[re-throw to caller]
    Q --> R
```

 → `^[a-zA-Z0-9._-]+Extract `validateIssueId()` from `getSnapshotPath()` and call it at
entry to `fetchIssue()`, `fetchComments()`, `updateIssue()`, and
`postComment()`. Prevents malformed issue IDs from reaching GraphQL.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts a shared `validateIssueId()` helper from `getSnapshotPath()` and calls it at the entry of all five public methods (`fetchIssueSnapshot`, `fetchIssue`, `fetchComments`, `updateIssue`, `postComment`), fixing a previous concern about validation errors being thrown as plain `Error` instances (now correctly using `LinearAdapterError` with `ErrorType.PERMANENT`).

- The error-type fix is sound: `createErrorNormalizer` passes `LinearAdapterError` instances through unchanged, so callers of all five methods now receive the correct `PERMANENT` error classification on bad input.
- **Regression**: the validation regex was changed from `^[A-Z][A-Z0-9]*-\d+Extract `validateIssueId()` from `getSnapshotPath()` and call it at
entry to `fetchIssue()`, `fetchComments()`, `updateIssue()`, and
`postComment()`. Prevents malformed issue IDs from reaching GraphQL.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts issue-ID validation from `getSnapshotPath()` into a new static `validateIssueId()` method and calls it at the entry of all five public `LinearAdapter` methods (`fetchIssueSnapshot`, `fetchIssue`, `fetchComments`, `updateIssue`, `postComment`), ensuring malformed IDs throw a `LinearAdapterError` with `ErrorType.PERMANENT` before reaching any GraphQL call.

Key observations:
- **Regex evaluated before length guard** (`LinearAdapter.ts:521–533`): Both regex patterns are computed unconditionally before the `if` block whose `issueId.length > 100` clause was meant to short-circuit long inputs. The length guard cannot prevent the regexes from running on oversized strings because the `const` bindings that compute them come first.
- **Overly broad second pattern** (`LinearAdapter.ts:156–157`): The second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` (`[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+`) accepts any hyphen-separated alphanumeric string — `foo-bar`, `a-b`, etc. — which may undermine the stated goal of blocking malformed IDs.
- **Redundant validation calls**: `fetchIssueSnapshot` now calls `validateIssueId` directly and then again indirectly through `fetchIssue`, `fetchComments`, and `getSnapshotPath` — harmless but worth noting.
- **Missing test for `fetchIssueSnapshot`** (`linearAdapter.spec.ts`): Four new tests cover the other four public methods but the newly added guard in `fetchIssueSnapshot` has no corresponding test.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for correctness but the validation logic has implementation issues that weaken the intended guard.
- The PR's goal — prevent malformed IDs from reaching GraphQL — is sound, but the implementation has two meaningful deficiencies: the length guard is bypassed because regexes run before it, and the second pattern alternative is so permissive that many invalid IDs will still pass. Test coverage is also incomplete (missing `fetchIssueSnapshot` case). None of these issues cause production crashes today, but they leave the validation weaker than intended.
- Pay close attention to `src/adapters/linear/LinearAdapter.ts` — specifically the ordering of the length check versus regex evaluation in `validateIssueId`, and the breadth of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/adapters/linear/LinearAdapter.ts | Extracts `validateIssueId()` as a static method and calls it at the entry of all five public methods. Two issues: the regex patterns are evaluated before the `length > 100` guard (defeating the guard's purpose), and the second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` is so broad that nearly any hyphenated alphanumeric string passes validation. |
| tests/integration/linearAdapter.spec.ts | Adds four new tests covering malformed ID rejection for `fetchIssue`, `fetchComments`, `updateIssue`, and `postComment`. Missing a parallel test for `fetchIssueSnapshot`, leaving a coverage gap for the newly added validation guard in that method. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant fetchIssueSnapshot
    participant fetchIssue
    participant fetchComments
    participant updateIssue
    participant postComment
    participant validateIssueId
    participant GraphQL

    Caller->>fetchIssueSnapshot: issueId
    fetchIssueSnapshot->>validateIssueId: issueId (new)
    validateIssueId-->>fetchIssueSnapshot: ok / LinearAdapterError(PERMANENT)
    fetchIssueSnapshot->>fetchIssue: issueId
    fetchIssue->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchIssue: ok
    fetchIssue->>GraphQL: query
    fetchIssueSnapshot->>fetchComments: issueId
    fetchComments->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchComments: ok
    fetchComments->>GraphQL: query

    Caller->>updateIssue: params
    Note over updateIssue: preview-features guard first
    updateIssue->>validateIssueId: params.issueId (new)
    validateIssueId-->>updateIssue: ok / LinearAdapterError(PERMANENT)
    updateIssue->>GraphQL: mutation

    Caller->>postComment: params
    Note over postComment: preview-features guard first
    postComment->>validateIssueId: params.issueId (new)
    validateIssueId-->>postComment: ok / LinearAdapterError(PERMANENT)
    postComment->>GraphQL: mutation
```

 (which enforced the `TEAM-NUMBER` Linear format) to `^[a-zA-Z0-9._-]+Extract `validateIssueId()` from `getSnapshotPath()` and call it at
entry to `fetchIssue()`, `fetchComments()`, `updateIssue()`, and
`postComment()`. Prevents malformed issue IDs from reaching GraphQL.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts issue-ID validation from `getSnapshotPath()` into a new static `validateIssueId()` method and calls it at the entry of all five public `LinearAdapter` methods (`fetchIssueSnapshot`, `fetchIssue`, `fetchComments`, `updateIssue`, `postComment`), ensuring malformed IDs throw a `LinearAdapterError` with `ErrorType.PERMANENT` before reaching any GraphQL call.

Key observations:
- **Regex evaluated before length guard** (`LinearAdapter.ts:521–533`): Both regex patterns are computed unconditionally before the `if` block whose `issueId.length > 100` clause was meant to short-circuit long inputs. The length guard cannot prevent the regexes from running on oversized strings because the `const` bindings that compute them come first.
- **Overly broad second pattern** (`LinearAdapter.ts:156–157`): The second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` (`[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+`) accepts any hyphen-separated alphanumeric string — `foo-bar`, `a-b`, etc. — which may undermine the stated goal of blocking malformed IDs.
- **Redundant validation calls**: `fetchIssueSnapshot` now calls `validateIssueId` directly and then again indirectly through `fetchIssue`, `fetchComments`, and `getSnapshotPath` — harmless but worth noting.
- **Missing test for `fetchIssueSnapshot`** (`linearAdapter.spec.ts`): Four new tests cover the other four public methods but the newly added guard in `fetchIssueSnapshot` has no corresponding test.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for correctness but the validation logic has implementation issues that weaken the intended guard.
- The PR's goal — prevent malformed IDs from reaching GraphQL — is sound, but the implementation has two meaningful deficiencies: the length guard is bypassed because regexes run before it, and the second pattern alternative is so permissive that many invalid IDs will still pass. Test coverage is also incomplete (missing `fetchIssueSnapshot` case). None of these issues cause production crashes today, but they leave the validation weaker than intended.
- Pay close attention to `src/adapters/linear/LinearAdapter.ts` — specifically the ordering of the length check versus regex evaluation in `validateIssueId`, and the breadth of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/adapters/linear/LinearAdapter.ts | Extracts `validateIssueId()` as a static method and calls it at the entry of all five public methods. Two issues: the regex patterns are evaluated before the `length > 100` guard (defeating the guard's purpose), and the second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` is so broad that nearly any hyphenated alphanumeric string passes validation. |
| tests/integration/linearAdapter.spec.ts | Adds four new tests covering malformed ID rejection for `fetchIssue`, `fetchComments`, `updateIssue`, and `postComment`. Missing a parallel test for `fetchIssueSnapshot`, leaving a coverage gap for the newly added validation guard in that method. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant fetchIssueSnapshot
    participant fetchIssue
    participant fetchComments
    participant updateIssue
    participant postComment
    participant validateIssueId
    participant GraphQL

    Caller->>fetchIssueSnapshot: issueId
    fetchIssueSnapshot->>validateIssueId: issueId (new)
    validateIssueId-->>fetchIssueSnapshot: ok / LinearAdapterError(PERMANENT)
    fetchIssueSnapshot->>fetchIssue: issueId
    fetchIssue->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchIssue: ok
    fetchIssue->>GraphQL: query
    fetchIssueSnapshot->>fetchComments: issueId
    fetchComments->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchComments: ok
    fetchComments->>GraphQL: query

    Caller->>updateIssue: params
    Note over updateIssue: preview-features guard first
    updateIssue->>validateIssueId: params.issueId (new)
    validateIssueId-->>updateIssue: ok / LinearAdapterError(PERMANENT)
    updateIssue->>GraphQL: mutation

    Caller->>postComment: params
    Note over postComment: preview-features guard first
    postComment->>validateIssueId: params.issueId (new)
    validateIssueId-->>postComment: ok / LinearAdapterError(PERMANENT)
    postComment->>GraphQL: mutation
```

, which is far too permissive and accepts strings like `foo.bar`, `---`, and `123abc` — undermining the stated goal of preventing malformed IDs from reaching GraphQL.
- `validateIssueId` is placed inside the `try/catch` block in `fetchIssue`, `fetchComments`, `updateIssue`, and `postComment`, causing validation failures to be logged as API failures (`"Failed to fetch issue"` etc.), whereas `fetchIssueSnapshot` correctly places the call before its `try` block.
- The double-validation that now occurs when `fetchIssueSnapshot` calls `fetchIssue`/`fetchComments` (each of which re-validates an already-validated ID) is harmless but redundant.

<h3>Confidence Score: 3/5</h3>

- Not safe to merge as-is — the regex change weakens validation below the pre-PR baseline.
- The error-taxonomy fix (LinearAdapterError with PERMANENT type) is correct and well-implemented. However, the new regex accepts far too many non-Linear-format strings, which is a regression in the exact property this PR claims to improve. The misleading log messages are a minor but real operational concern. These two issues bring the confidence below the threshold for a clean merge.
- src/adapters/linear/LinearAdapter.ts — specifically line 519 (regex) and the validateIssueId placement in the four try/catch blocks.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/adapters/linear/LinearAdapter.ts | Extracts validateIssueId() into a shared private method and calls it at entry to all five public methods. The error type is now correctly LinearAdapterError(PERMANENT) instead of a plain Error, addressing the previous thread's concern. However, the validation regex was changed from the structurally-strict ^[A-Z][A-Z0-9]*-\d+$ to the permissive ^[a-zA-Z0-9._-]+$, which accepts many strings that are not valid Linear IDs and weakens the protection this PR was meant to add. Additionally, validateIssueId is placed inside the try/catch block in four methods, causing misleading "Failed to fetch/update/post" log entries for what are really input validation errors. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Caller] -->|issueId| B{validateIssueId}
    B -->|❌ invalid| C[throw LinearAdapterError\nErrorType.PERMANENT]
    B -->|✅ valid| D[proceed to try block]

    D --> E[fetchIssueSnapshot]
    D --> F[fetchIssue]
    D --> G[fetchComments]
    D --> H[updateIssue]
    D --> I[postComment]

    E -->|before try ✅| J[executeGraphQL / cache]
    F -->|inside try ⚠️| K[executeGraphQL]
    G -->|inside try ⚠️| L[executeGraphQL]
    H -->|inside try ⚠️| M[executeGraphQL]
    I -->|inside try ⚠️| N[executeGraphQL]

    K --> O{catch block}
    L --> O
    M --> O
    N --> O
    O -->|LinearAdapterError| P[normalizeError → pass-through]
    O -->|other error| Q[normalizeError → wrap as LinearAdapterError]
    P --> R[re-throw to caller]
    Q --> R
```

): accepts strings like `abc`, `foo-bar`, `1.2.3` that are not valid Linear identifiers and will still produce confusing GraphQL errors rather than early rejection.
- **Validation inside `try` blocks** (`fetchIssue`, `fetchComments`, `updateIssue`, `postComment`): when validation fails, the catch block emits misleading log messages (e.g., `"Failed to fetch issue"`) that imply an API failure rather than bad input. The pattern used in `fetchIssueSnapshot` — calling `validateIssueId` *before* the `try` block — should be applied consistently.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is — the regex change silently accepts invalid Linear issue IDs, undermining the core goal of the PR.
- The structural refactoring (extracting `validateIssueId`, throwing `LinearAdapterError` with `PERMANENT` type) is an improvement, but the loosened regex is a correctness regression that defeats the stated purpose of early input validation. Strings that are clearly not Linear IDs (`abc`, `1.2`, `foo-bar`) now bypass the guard and will reach GraphQL, producing confusing downstream errors instead of clear early rejections.
- src/adapters/linear/LinearAdapter.ts — specifically the `validateIssueId` regex on line 519 and placement of validation calls relative to `try/catch` blocks.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/adapters/linear/LinearAdapter.ts | Extracts `validateIssueId()` from `getSnapshotPath()` and calls it in all public methods; however, the regex was significantly loosened (from enforcing `TEAM-123` format to allowing any alphanumeric/dot/dash string), which undermines the validation. Validation calls inside `try` blocks also generate misleading error logs. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant fetchIssueSnapshot
    participant validateIssueId
    participant fetchIssue
    participant fetchComments
    participant GraphQL

    Caller->>fetchIssueSnapshot: issueId
    fetchIssueSnapshot->>validateIssueId: issueId (outside try/catch ✅)
    alt invalid ID
        validateIssueId-->>Caller: LinearAdapterError(PERMANENT)
    else valid ID
        fetchIssueSnapshot->>fetchIssue: issueId
        fetchIssue->>validateIssueId: issueId (inside try/catch ⚠️)
        fetchIssue->>GraphQL: query
        GraphQL-->>fetchIssue: result
        fetchIssueSnapshot->>fetchComments: issueId
        fetchComments->>validateIssueId: issueId (inside try/catch ⚠️)
        fetchComments->>GraphQL: query
        GraphQL-->>fetchComments: result
        fetchIssueSnapshot-->>Caller: IssueSnapshot
    end
```

 correctly enforced Linear's canonical `TEAM-123` format. The replacement accepts strings like `abc`, `foo-bar`, `1.2.3`, or even `...` — none of which are valid Linear issue identifiers. This defeats the stated goal of "prevents malformed issue IDs from reaching GraphQL," since a wide range of non-conforming strings will now pass validation and still produce confusing GraphQL errors.

6. `src/adapters/linear/LinearAdapter.ts`, line 293-294 ([link](https://github.com/kinginyellows/codemachine-pipeline/blob/50fd8801815319493fe96933c1c76e81d299bced/src/adapters/linear/LinearAdapter.ts#L293-L294)) 

   **Misleading error log when validation fails inside try/catch**

   `validateIssueId` is placed inside the `try` block, so when it throws a `LinearAdapterError` the catch block logs `"Failed to fetch issue"` (or the analogous message in `fetchComments`, `updateIssue`, `postComment`) — making a bad-input error look like an API failure in telemetry. Because `fetchIssueSnapshot` already guards with `this.validateIssueId(issueId)` before calling these methods, moving validation before each method's `try` block (matching the pattern in `fetchIssueSnapshot`) would produce accurate log attribution and keep the `PERMANENT` error type propagating cleanly without passing through `normalizeError`.

   This pattern applies to all four methods: `fetchIssue` (line 293), `fetchComments` (line 327), `updateIssue` (line 357), and `postComment` (line 405).

7. `src/adapters/linear/LinearAdapter.ts`, line 519 ([link](https://github.com/kinginyellows/codemachine-pipeline/blob/4d16c161473885edafa6ec7b833deac3c940533a/src/adapters/linear/LinearAdapter.ts#L519)) 

   **Validation regex significantly weakened — no longer enforces Linear ID format**

   The original regex `^[A-Z][A-Z0-9]*-\d+Extract `validateIssueId()` from `getSnapshotPath()` and call it at
entry to `fetchIssue()`, `fetchComments()`, `updateIssue()`, and
`postComment()`. Prevents malformed issue IDs from reaching GraphQL.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts a shared `validateIssueId()` helper from `getSnapshotPath()` and calls it at the entry of all five public methods (`fetchIssueSnapshot`, `fetchIssue`, `fetchComments`, `updateIssue`, `postComment`), fixing a previous concern about validation errors being thrown as plain `Error` instances (now correctly using `LinearAdapterError` with `ErrorType.PERMANENT`).

- The error-type fix is sound: `createErrorNormalizer` passes `LinearAdapterError` instances through unchanged, so callers of all five methods now receive the correct `PERMANENT` error classification on bad input.
- **Regression**: the validation regex was changed from `^[A-Z][A-Z0-9]*-\d+Extract `validateIssueId()` from `getSnapshotPath()` and call it at
entry to `fetchIssue()`, `fetchComments()`, `updateIssue()`, and
`postComment()`. Prevents malformed issue IDs from reaching GraphQL.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts issue-ID validation from `getSnapshotPath()` into a new static `validateIssueId()` method and calls it at the entry of all five public `LinearAdapter` methods (`fetchIssueSnapshot`, `fetchIssue`, `fetchComments`, `updateIssue`, `postComment`), ensuring malformed IDs throw a `LinearAdapterError` with `ErrorType.PERMANENT` before reaching any GraphQL call.

Key observations:
- **Regex evaluated before length guard** (`LinearAdapter.ts:521–533`): Both regex patterns are computed unconditionally before the `if` block whose `issueId.length > 100` clause was meant to short-circuit long inputs. The length guard cannot prevent the regexes from running on oversized strings because the `const` bindings that compute them come first.
- **Overly broad second pattern** (`LinearAdapter.ts:156–157`): The second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` (`[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+`) accepts any hyphen-separated alphanumeric string — `foo-bar`, `a-b`, etc. — which may undermine the stated goal of blocking malformed IDs.
- **Redundant validation calls**: `fetchIssueSnapshot` now calls `validateIssueId` directly and then again indirectly through `fetchIssue`, `fetchComments`, and `getSnapshotPath` — harmless but worth noting.
- **Missing test for `fetchIssueSnapshot`** (`linearAdapter.spec.ts`): Four new tests cover the other four public methods but the newly added guard in `fetchIssueSnapshot` has no corresponding test.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for correctness but the validation logic has implementation issues that weaken the intended guard.
- The PR's goal — prevent malformed IDs from reaching GraphQL — is sound, but the implementation has two meaningful deficiencies: the length guard is bypassed because regexes run before it, and the second pattern alternative is so permissive that many invalid IDs will still pass. Test coverage is also incomplete (missing `fetchIssueSnapshot` case). None of these issues cause production crashes today, but they leave the validation weaker than intended.
- Pay close attention to `src/adapters/linear/LinearAdapter.ts` — specifically the ordering of the length check versus regex evaluation in `validateIssueId`, and the breadth of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/adapters/linear/LinearAdapter.ts | Extracts `validateIssueId()` as a static method and calls it at the entry of all five public methods. Two issues: the regex patterns are evaluated before the `length > 100` guard (defeating the guard's purpose), and the second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` is so broad that nearly any hyphenated alphanumeric string passes validation. |
| tests/integration/linearAdapter.spec.ts | Adds four new tests covering malformed ID rejection for `fetchIssue`, `fetchComments`, `updateIssue`, and `postComment`. Missing a parallel test for `fetchIssueSnapshot`, leaving a coverage gap for the newly added validation guard in that method. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant fetchIssueSnapshot
    participant fetchIssue
    participant fetchComments
    participant updateIssue
    participant postComment
    participant validateIssueId
    participant GraphQL

    Caller->>fetchIssueSnapshot: issueId
    fetchIssueSnapshot->>validateIssueId: issueId (new)
    validateIssueId-->>fetchIssueSnapshot: ok / LinearAdapterError(PERMANENT)
    fetchIssueSnapshot->>fetchIssue: issueId
    fetchIssue->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchIssue: ok
    fetchIssue->>GraphQL: query
    fetchIssueSnapshot->>fetchComments: issueId
    fetchComments->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchComments: ok
    fetchComments->>GraphQL: query

    Caller->>updateIssue: params
    Note over updateIssue: preview-features guard first
    updateIssue->>validateIssueId: params.issueId (new)
    validateIssueId-->>updateIssue: ok / LinearAdapterError(PERMANENT)
    updateIssue->>GraphQL: mutation

    Caller->>postComment: params
    Note over postComment: preview-features guard first
    postComment->>validateIssueId: params.issueId (new)
    validateIssueId-->>postComment: ok / LinearAdapterError(PERMANENT)
    postComment->>GraphQL: mutation
```

 (which enforced the `TEAM-NUMBER` Linear format) to `^[a-zA-Z0-9._-]+Extract `validateIssueId()` from `getSnapshotPath()` and call it at
entry to `fetchIssue()`, `fetchComments()`, `updateIssue()`, and
`postComment()`. Prevents malformed issue IDs from reaching GraphQL.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts issue-ID validation from `getSnapshotPath()` into a new static `validateIssueId()` method and calls it at the entry of all five public `LinearAdapter` methods (`fetchIssueSnapshot`, `fetchIssue`, `fetchComments`, `updateIssue`, `postComment`), ensuring malformed IDs throw a `LinearAdapterError` with `ErrorType.PERMANENT` before reaching any GraphQL call.

Key observations:
- **Regex evaluated before length guard** (`LinearAdapter.ts:521–533`): Both regex patterns are computed unconditionally before the `if` block whose `issueId.length > 100` clause was meant to short-circuit long inputs. The length guard cannot prevent the regexes from running on oversized strings because the `const` bindings that compute them come first.
- **Overly broad second pattern** (`LinearAdapter.ts:156–157`): The second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` (`[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+`) accepts any hyphen-separated alphanumeric string — `foo-bar`, `a-b`, etc. — which may undermine the stated goal of blocking malformed IDs.
- **Redundant validation calls**: `fetchIssueSnapshot` now calls `validateIssueId` directly and then again indirectly through `fetchIssue`, `fetchComments`, and `getSnapshotPath` — harmless but worth noting.
- **Missing test for `fetchIssueSnapshot`** (`linearAdapter.spec.ts`): Four new tests cover the other four public methods but the newly added guard in `fetchIssueSnapshot` has no corresponding test.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for correctness but the validation logic has implementation issues that weaken the intended guard.
- The PR's goal — prevent malformed IDs from reaching GraphQL — is sound, but the implementation has two meaningful deficiencies: the length guard is bypassed because regexes run before it, and the second pattern alternative is so permissive that many invalid IDs will still pass. Test coverage is also incomplete (missing `fetchIssueSnapshot` case). None of these issues cause production crashes today, but they leave the validation weaker than intended.
- Pay close attention to `src/adapters/linear/LinearAdapter.ts` — specifically the ordering of the length check versus regex evaluation in `validateIssueId`, and the breadth of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/adapters/linear/LinearAdapter.ts | Extracts `validateIssueId()` as a static method and calls it at the entry of all five public methods. Two issues: the regex patterns are evaluated before the `length > 100` guard (defeating the guard's purpose), and the second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` is so broad that nearly any hyphenated alphanumeric string passes validation. |
| tests/integration/linearAdapter.spec.ts | Adds four new tests covering malformed ID rejection for `fetchIssue`, `fetchComments`, `updateIssue`, and `postComment`. Missing a parallel test for `fetchIssueSnapshot`, leaving a coverage gap for the newly added validation guard in that method. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant fetchIssueSnapshot
    participant fetchIssue
    participant fetchComments
    participant updateIssue
    participant postComment
    participant validateIssueId
    participant GraphQL

    Caller->>fetchIssueSnapshot: issueId
    fetchIssueSnapshot->>validateIssueId: issueId (new)
    validateIssueId-->>fetchIssueSnapshot: ok / LinearAdapterError(PERMANENT)
    fetchIssueSnapshot->>fetchIssue: issueId
    fetchIssue->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchIssue: ok
    fetchIssue->>GraphQL: query
    fetchIssueSnapshot->>fetchComments: issueId
    fetchComments->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchComments: ok
    fetchComments->>GraphQL: query

    Caller->>updateIssue: params
    Note over updateIssue: preview-features guard first
    updateIssue->>validateIssueId: params.issueId (new)
    validateIssueId-->>updateIssue: ok / LinearAdapterError(PERMANENT)
    updateIssue->>GraphQL: mutation

    Caller->>postComment: params
    Note over postComment: preview-features guard first
    postComment->>validateIssueId: params.issueId (new)
    validateIssueId-->>postComment: ok / LinearAdapterError(PERMANENT)
    postComment->>GraphQL: mutation
```

, which is far too permissive and accepts strings like `foo.bar`, `---`, and `123abc` — undermining the stated goal of preventing malformed IDs from reaching GraphQL.
- `validateIssueId` is placed inside the `try/catch` block in `fetchIssue`, `fetchComments`, `updateIssue`, and `postComment`, causing validation failures to be logged as API failures (`"Failed to fetch issue"` etc.), whereas `fetchIssueSnapshot` correctly places the call before its `try` block.
- The double-validation that now occurs when `fetchIssueSnapshot` calls `fetchIssue`/`fetchComments` (each of which re-validates an already-validated ID) is harmless but redundant.

<h3>Confidence Score: 3/5</h3>

- Not safe to merge as-is — the regex change weakens validation below the pre-PR baseline.
- The error-taxonomy fix (LinearAdapterError with PERMANENT type) is correct and well-implemented. However, the new regex accepts far too many non-Linear-format strings, which is a regression in the exact property this PR claims to improve. The misleading log messages are a minor but real operational concern. These two issues bring the confidence below the threshold for a clean merge.
- src/adapters/linear/LinearAdapter.ts — specifically line 519 (regex) and the validateIssueId placement in the four try/catch blocks.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/adapters/linear/LinearAdapter.ts | Extracts validateIssueId() into a shared private method and calls it at entry to all five public methods. The error type is now correctly LinearAdapterError(PERMANENT) instead of a plain Error, addressing the previous thread's concern. However, the validation regex was changed from the structurally-strict ^[A-Z][A-Z0-9]*-\d+$ to the permissive ^[a-zA-Z0-9._-]+$, which accepts many strings that are not valid Linear IDs and weakens the protection this PR was meant to add. Additionally, validateIssueId is placed inside the try/catch block in four methods, causing misleading "Failed to fetch/update/post" log entries for what are really input validation errors. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Caller] -->|issueId| B{validateIssueId}
    B -->|❌ invalid| C[throw LinearAdapterError\nErrorType.PERMANENT]
    B -->|✅ valid| D[proceed to try block]

    D --> E[fetchIssueSnapshot]
    D --> F[fetchIssue]
    D --> G[fetchComments]
    D --> H[updateIssue]
    D --> I[postComment]

    E -->|before try ✅| J[executeGraphQL / cache]
    F -->|inside try ⚠️| K[executeGraphQL]
    G -->|inside try ⚠️| L[executeGraphQL]
    H -->|inside try ⚠️| M[executeGraphQL]
    I -->|inside try ⚠️| N[executeGraphQL]

    K --> O{catch block}
    L --> O
    M --> O
    N --> O
    O -->|LinearAdapterError| P[normalizeError → pass-through]
    O -->|other error| Q[normalizeError → wrap as LinearAdapterError]
    P --> R[re-throw to caller]
    Q --> R
```

 enforced the canonical Linear issue-ID structure (`TEAM-NUMBER`, e.g. `CDMCH-161`). The replacement `^[a-zA-Z0-9._-]+Extract `validateIssueId()` from `getSnapshotPath()` and call it at
entry to `fetchIssue()`, `fetchComments()`, `updateIssue()`, and
`postComment()`. Prevents malformed issue IDs from reaching GraphQL.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts a shared `validateIssueId()` helper from `getSnapshotPath()` and calls it at the entry of all five public methods (`fetchIssueSnapshot`, `fetchIssue`, `fetchComments`, `updateIssue`, `postComment`), fixing a previous concern about validation errors being thrown as plain `Error` instances (now correctly using `LinearAdapterError` with `ErrorType.PERMANENT`).

- The error-type fix is sound: `createErrorNormalizer` passes `LinearAdapterError` instances through unchanged, so callers of all five methods now receive the correct `PERMANENT` error classification on bad input.
- **Regression**: the validation regex was changed from `^[A-Z][A-Z0-9]*-\d+Extract `validateIssueId()` from `getSnapshotPath()` and call it at
entry to `fetchIssue()`, `fetchComments()`, `updateIssue()`, and
`postComment()`. Prevents malformed issue IDs from reaching GraphQL.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts issue-ID validation from `getSnapshotPath()` into a new static `validateIssueId()` method and calls it at the entry of all five public `LinearAdapter` methods (`fetchIssueSnapshot`, `fetchIssue`, `fetchComments`, `updateIssue`, `postComment`), ensuring malformed IDs throw a `LinearAdapterError` with `ErrorType.PERMANENT` before reaching any GraphQL call.

Key observations:
- **Regex evaluated before length guard** (`LinearAdapter.ts:521–533`): Both regex patterns are computed unconditionally before the `if` block whose `issueId.length > 100` clause was meant to short-circuit long inputs. The length guard cannot prevent the regexes from running on oversized strings because the `const` bindings that compute them come first.
- **Overly broad second pattern** (`LinearAdapter.ts:156–157`): The second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` (`[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+`) accepts any hyphen-separated alphanumeric string — `foo-bar`, `a-b`, etc. — which may undermine the stated goal of blocking malformed IDs.
- **Redundant validation calls**: `fetchIssueSnapshot` now calls `validateIssueId` directly and then again indirectly through `fetchIssue`, `fetchComments`, and `getSnapshotPath` — harmless but worth noting.
- **Missing test for `fetchIssueSnapshot`** (`linearAdapter.spec.ts`): Four new tests cover the other four public methods but the newly added guard in `fetchIssueSnapshot` has no corresponding test.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for correctness but the validation logic has implementation issues that weaken the intended guard.
- The PR's goal — prevent malformed IDs from reaching GraphQL — is sound, but the implementation has two meaningful deficiencies: the length guard is bypassed because regexes run before it, and the second pattern alternative is so permissive that many invalid IDs will still pass. Test coverage is also incomplete (missing `fetchIssueSnapshot` case). None of these issues cause production crashes today, but they leave the validation weaker than intended.
- Pay close attention to `src/adapters/linear/LinearAdapter.ts` — specifically the ordering of the length check versus regex evaluation in `validateIssueId`, and the breadth of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/adapters/linear/LinearAdapter.ts | Extracts `validateIssueId()` as a static method and calls it at the entry of all five public methods. Two issues: the regex patterns are evaluated before the `length > 100` guard (defeating the guard's purpose), and the second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` is so broad that nearly any hyphenated alphanumeric string passes validation. |
| tests/integration/linearAdapter.spec.ts | Adds four new tests covering malformed ID rejection for `fetchIssue`, `fetchComments`, `updateIssue`, and `postComment`. Missing a parallel test for `fetchIssueSnapshot`, leaving a coverage gap for the newly added validation guard in that method. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant fetchIssueSnapshot
    participant fetchIssue
    participant fetchComments
    participant updateIssue
    participant postComment
    participant validateIssueId
    participant GraphQL

    Caller->>fetchIssueSnapshot: issueId
    fetchIssueSnapshot->>validateIssueId: issueId (new)
    validateIssueId-->>fetchIssueSnapshot: ok / LinearAdapterError(PERMANENT)
    fetchIssueSnapshot->>fetchIssue: issueId
    fetchIssue->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchIssue: ok
    fetchIssue->>GraphQL: query
    fetchIssueSnapshot->>fetchComments: issueId
    fetchComments->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchComments: ok
    fetchComments->>GraphQL: query

    Caller->>updateIssue: params
    Note over updateIssue: preview-features guard first
    updateIssue->>validateIssueId: params.issueId (new)
    validateIssueId-->>updateIssue: ok / LinearAdapterError(PERMANENT)
    updateIssue->>GraphQL: mutation

    Caller->>postComment: params
    Note over postComment: preview-features guard first
    postComment->>validateIssueId: params.issueId (new)
    validateIssueId-->>postComment: ok / LinearAdapterError(PERMANENT)
    postComment->>GraphQL: mutation
```

 (which enforced the `TEAM-NUMBER` Linear format) to `^[a-zA-Z0-9._-]+Extract `validateIssueId()` from `getSnapshotPath()` and call it at
entry to `fetchIssue()`, `fetchComments()`, `updateIssue()`, and
`postComment()`. Prevents malformed issue IDs from reaching GraphQL.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts issue-ID validation from `getSnapshotPath()` into a new static `validateIssueId()` method and calls it at the entry of all five public `LinearAdapter` methods (`fetchIssueSnapshot`, `fetchIssue`, `fetchComments`, `updateIssue`, `postComment`), ensuring malformed IDs throw a `LinearAdapterError` with `ErrorType.PERMANENT` before reaching any GraphQL call.

Key observations:
- **Regex evaluated before length guard** (`LinearAdapter.ts:521–533`): Both regex patterns are computed unconditionally before the `if` block whose `issueId.length > 100` clause was meant to short-circuit long inputs. The length guard cannot prevent the regexes from running on oversized strings because the `const` bindings that compute them come first.
- **Overly broad second pattern** (`LinearAdapter.ts:156–157`): The second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` (`[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+`) accepts any hyphen-separated alphanumeric string — `foo-bar`, `a-b`, etc. — which may undermine the stated goal of blocking malformed IDs.
- **Redundant validation calls**: `fetchIssueSnapshot` now calls `validateIssueId` directly and then again indirectly through `fetchIssue`, `fetchComments`, and `getSnapshotPath` — harmless but worth noting.
- **Missing test for `fetchIssueSnapshot`** (`linearAdapter.spec.ts`): Four new tests cover the other four public methods but the newly added guard in `fetchIssueSnapshot` has no corresponding test.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for correctness but the validation logic has implementation issues that weaken the intended guard.
- The PR's goal — prevent malformed IDs from reaching GraphQL — is sound, but the implementation has two meaningful deficiencies: the length guard is bypassed because regexes run before it, and the second pattern alternative is so permissive that many invalid IDs will still pass. Test coverage is also incomplete (missing `fetchIssueSnapshot` case). None of these issues cause production crashes today, but they leave the validation weaker than intended.
- Pay close attention to `src/adapters/linear/LinearAdapter.ts` — specifically the ordering of the length check versus regex evaluation in `validateIssueId`, and the breadth of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/adapters/linear/LinearAdapter.ts | Extracts `validateIssueId()` as a static method and calls it at the entry of all five public methods. Two issues: the regex patterns are evaluated before the `length > 100` guard (defeating the guard's purpose), and the second alternative of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` is so broad that nearly any hyphenated alphanumeric string passes validation. |
| tests/integration/linearAdapter.spec.ts | Adds four new tests covering malformed ID rejection for `fetchIssue`, `fetchComments`, `updateIssue`, and `postComment`. Missing a parallel test for `fetchIssueSnapshot`, leaving a coverage gap for the newly added validation guard in that method. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant fetchIssueSnapshot
    participant fetchIssue
    participant fetchComments
    participant updateIssue
    participant postComment
    participant validateIssueId
    participant GraphQL

    Caller->>fetchIssueSnapshot: issueId
    fetchIssueSnapshot->>validateIssueId: issueId (new)
    validateIssueId-->>fetchIssueSnapshot: ok / LinearAdapterError(PERMANENT)
    fetchIssueSnapshot->>fetchIssue: issueId
    fetchIssue->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchIssue: ok
    fetchIssue->>GraphQL: query
    fetchIssueSnapshot->>fetchComments: issueId
    fetchComments->>validateIssueId: issueId (new, redundant)
    validateIssueId-->>fetchComments: ok
    fetchComments->>GraphQL: query

    Caller->>updateIssue: params
    Note over updateIssue: preview-features guard first
    updateIssue->>validateIssueId: params.issueId (new)
    validateIssueId-->>updateIssue: ok / LinearAdapterError(PERMANENT)
    updateIssue->>GraphQL: mutation

    Caller->>postComment: params
    Note over postComment: preview-features guard first
    postComment->>validateIssueId: params.issueId (new)
    validateIssueId-->>postComment: ok / LinearAdapterError(PERMANENT)
    postComment->>GraphQL: mutation
```

, which is far too permissive and accepts strings like `foo.bar`, `---`, and `123abc` — undermining the stated goal of preventing malformed IDs from reaching GraphQL.
- `validateIssueId` is placed inside the `try/catch` block in `fetchIssue`, `fetchComments`, `updateIssue`, and `postComment`, causing validation failures to be logged as API failures (`"Failed to fetch issue"` etc.), whereas `fetchIssueSnapshot` correctly places the call before its `try` block.
- The double-validation that now occurs when `fetchIssueSnapshot` calls `fetchIssue`/`fetchComments` (each of which re-validates an already-validated ID) is harmless but redundant.

<h3>Confidence Score: 3/5</h3>

- Not safe to merge as-is — the regex change weakens validation below the pre-PR baseline.
- The error-taxonomy fix (LinearAdapterError with PERMANENT type) is correct and well-implemented. However, the new regex accepts far too many non-Linear-format strings, which is a regression in the exact property this PR claims to improve. The misleading log messages are a minor but real operational concern. These two issues bring the confidence below the threshold for a clean merge.
- src/adapters/linear/LinearAdapter.ts — specifically line 519 (regex) and the validateIssueId placement in the four try/catch blocks.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/adapters/linear/LinearAdapter.ts | Extracts validateIssueId() into a shared private method and calls it at entry to all five public methods. The error type is now correctly LinearAdapterError(PERMANENT) instead of a plain Error, addressing the previous thread's concern. However, the validation regex was changed from the structurally-strict ^[A-Z][A-Z0-9]*-\d+$ to the permissive ^[a-zA-Z0-9._-]+$, which accepts many strings that are not valid Linear IDs and weakens the protection this PR was meant to add. Additionally, validateIssueId is placed inside the try/catch block in four methods, causing misleading "Failed to fetch/update/post" log entries for what are really input validation errors. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Caller] -->|issueId| B{validateIssueId}
    B -->|❌ invalid| C[throw LinearAdapterError\nErrorType.PERMANENT]
    B -->|✅ valid| D[proceed to try block]

    D --> E[fetchIssueSnapshot]
    D --> F[fetchIssue]
    D --> G[fetchComments]
    D --> H[updateIssue]
    D --> I[postComment]

    E -->|before try ✅| J[executeGraphQL / cache]
    F -->|inside try ⚠️| K[executeGraphQL]
    G -->|inside try ⚠️| L[executeGraphQL]
    H -->|inside try ⚠️| M[executeGraphQL]
    I -->|inside try ⚠️| N[executeGraphQL]

    K --> O{catch block}
    L --> O
    M --> O
    N --> O
    O -->|LinearAdapterError| P[normalizeError → pass-through]
    O -->|other error| Q[normalizeError → wrap as LinearAdapterError]
    P --> R[re-throw to caller]
    Q --> R
```

 accepts many strings that are clearly not valid Linear IDs and will still reach GraphQL:

   - `foo.bar.baz` — dots, no dash-number suffix
   - `123-abc` — starts with a digit, non-numeric suffix
   - `a-b-c` — multiple dashes, no numeric component
   - `---` — only dashes
   - `abc` — no separator at all

   This is a regression in the one property the PR set out to improve. If the intent was to also accept lowercase team keys, the minimal fix is to relax only the case constraint while keeping the structural pattern:

8. `src/adapters/linear/LinearAdapter.ts`, line 293-294 ([link](https://github.com/kinginyellows/codemachine-pipeline/blob/4d16c161473885edafa6ec7b833deac3c940533a/src/adapters/linear/LinearAdapter.ts#L293-L294)) 

   **Validation failure logged as API fetch failure**

   `validateIssueId` is placed inside the `try` block, so when it throws a `LinearAdapterError`, the `catch` at line 313 runs first and logs `"Failed to fetch issue"` before `normalizeError` (which passes `LinearAdapterError` through unchanged) re-throws the error. The log entry is misleading — the issue is a bad input, not a network/API failure.

   The same pattern appears in:
   - `fetchComments` — `src/adapters/linear/LinearAdapter.ts:327`
   - `updateIssue` — `src/adapters/linear/LinearAdapter.ts:357`
   - `postComment` — `src/adapters/linear/LinearAdapter.ts:405`

   Moving the call before the `try` block (as done in `fetchIssueSnapshot` at line 218) would make the log message accurate and avoids any future ambiguity if the logger output is used for alerting:

   ```typescript
   // fetchIssue example
   async fetchIssue(issueId: string): Promise<LinearIssue> {
     this.validateIssueId(issueId);   // ← before try
     try {
       const data = await this.executeGraphQL<...>(...);
       ...
     } catch (error) {
       this.logger.error('Failed to fetch issue', { issueId, error: serializeError(error) });
       throw this.normalizeError(error, 'fetchIssue');
     }
   }
   ```

9. `src/adapters/linear/LinearAdapter.ts`, line 521-533 ([link](https://github.com/kinginyellows/codemachine-pipeline/blob/da661204e5c9f3dacf1c7aa0ddff15f67973f02b/src/adapters/linear/LinearAdapter.ts#L521-L533)) 

   **Regex patterns run before the length guard**

   Both regex patterns are evaluated unconditionally before the `if` block that contains the `issueId.length > 100` short-circuit. This means a 1 000-character (or longer) string is matched against both patterns even though the length check would have rejected it immediately. The length guard's purpose is to bound the work done on oversized inputs — computing the regexes first defeats that.

   Restructure to check `!issueId` and `length > 100` in a fast-path guard before running the patterns:

10. `src/adapters/linear/LinearAdapter.ts`, line 156-157 ([link](https://github.com/kinginyellows/codemachine-pipeline/blob/da661204e5c9f3dacf1c7aa0ddff15f67973f02b/src/adapters/linear/LinearAdapter.ts#L156-L157)) 

    **Second alternative in `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` is overly broad**

    The second alternative `[A-Za-z0-9]+(?:-[A-Za-z0-9]+)+` matches any hyphen-separated alphanumeric string — `foo-bar`, `a-b`, `test-abc`, etc. This is likely much broader than intended for "structured opaque" IDs and could render the validation largely ineffective for its stated purpose of preventing malformed issue IDs from reaching GraphQL.

    If the intent is purely to allow UUIDs and Linear-style identifiers, consider removing the overly permissive second alternative and anchoring on those two formats only. If there is a known third format (e.g. a specific slug convention), a more restrictive pattern with documented examples would make the intent clearer and the guard stronger.

11. `tests/integration/linearAdapter.spec.ts`, line 266-286 ([link](https://github.com/kinginyellows/codemachine-pipeline/blob/da661204e5c9f3dacf1c7aa0ddff15f67973f02b/tests/integration/linearAdapter.spec.ts#L266-L286)) 

    **Missing test for `fetchIssueSnapshot` validation**

    Tests were added for `fetchIssue`, `fetchComments`, `updateIssue`, and `postComment`, but there is no corresponding test for `fetchIssueSnapshot` with a malformed issue ID, even though `validateIssueId` was added there at line 221. Without a test, a future refactor could silently remove that guard without breaking the test suite.

    Consider adding a test similar to the ones below — this mirrors the pattern used for the other four public methods:

    ```typescript
    it('should reject malformed issue IDs before fetching snapshot', async () => {
      await expect(adapter.fetchIssueSnapshot('---')).rejects.toMatchObject({
        errorType: ErrorType.PERMANENT,
      });
      expect(mockHttpClient.post).not.toHaveBeenCalled();
    });
    ```

12. `src/adapters/linear/LinearAdapter.ts`, line 353-364 ([link](https://github.com/kinginyellows/codemachine-pipeline/blob/d699c076c90b203143dac23f4bf322096ee34f55/src/adapters/linear/LinearAdapter.ts#L353-L364)) 

    **Validation order inconsistency with preview-feature guard**

    `validateIssueId` is placed _after_ the `enablePreviewFeatures` guard in both `updateIssue` (line 364) and `postComment` (line 412). This means that when preview features are disabled, a caller passing an invalid issue ID receives the "preview features required" error rather than the "invalid issue ID" error — ID validation is silently skipped for non-preview adapters.

    While neither path lets a malformed ID reach GraphQL, the stated goal of the PR is to validate IDs "at entry" to each method. Moving `validateIssueId` before the preview-feature guard would make validation unconditional and produce consistent error messages regardless of the feature flag:

    ```typescript
    async updateIssue(params: UpdateIssueParams): Promise<void> {
      LinearAdapter.validateIssueId(params.issueId); // validate first
      if (!this.enablePreviewFeatures) {
        throw new LinearAdapterError(
          'Issue updates require preview features to be enabled',
          ...
        );
      }
      // ...
    }
    ```

    The same applies to `postComment`.

13. `src/adapters/linear/LinearAdapter.ts`, line 155-157 ([link](https://github.com/kinginyellows/codemachine-pipeline/blob/d699c076c90b203143dac23f4bf322096ee34f55/src/adapters/linear/LinearAdapter.ts#L155-L157)) 

    **`STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` second branch is very broad**

    The second alternative `[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*` has no minimum-length requirement and accepts virtually any alphanumeric string — including single characters like `a`, `1`, or `Z`. This is a significant expansion from the original pattern which only accepted `[A-Z][A-Z0-9]*-\d+`.

    Practical consequences:
    - Strings like `a` or `ENG-abc` (which looks like a malformed Linear identifier with a non-numeric suffix) pass validation and reach the GraphQL API, generating an API error rather than a local validation error.
    - A caller who mistypes `ENG-123` as `ENG-abc` will get a confusing downstream GraphQL error instead of an "invalid ID" error.

    If the intent is purely to support UUID-format opaque IDs (plus the standard `TEAM-NNN` identifiers), the second alternative could be narrowed. If broader opaque IDs are genuinely needed, consider at least enforcing a minimum length (e.g., `[A-Za-z0-9]{2,}(?:-[A-Za-z0-9]+)*`) and documenting the rationale in a comment above the constant.

14. `src/adapters/linear/LinearAdapter.ts`, line 221 ([link](https://github.com/kinginyellows/codemachine-pipeline/blob/d699c076c90b203143dac23f4bf322096ee34f55/src/adapters/linear/LinearAdapter.ts#L221)) 

    **Redundant validation across the `fetchIssueSnapshot` call chain**

    `validateIssueId` is called here at the top of `fetchIssueSnapshot`, which is good. However, the same `issueId` is then validated again in every downstream call within this method:

    - `fetchIssue` (line 301) — calls `validateIssueId`
    - `fetchComments` (line 334) — calls `validateIssueId`
    - `getSnapshotPath` (line 541, via `loadCachedSnapshot`/`saveSnapshot`) — calls `validateIssueId`

    For a single `fetchIssueSnapshot` call with a valid ID, `validateIssueId` runs 4+ times. While this is not harmful (the checks are cheap), consider whether `getSnapshotPath` and the public methods need to re-validate when they are always invoked after an entry-point that already guarantees validity. A lightweight approach would be to keep validation only at the public entry points and remove the internal re-validation from `getSnapshotPath`.

    <sub>Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!</sub>

15. `src/adapters/linear/LinearAdapter.ts`, line 156-157 ([link](https://github.com/kinginyellows/codemachine-pipeline/blob/b464c5da8838632bd2df795584f51ab3181b25ad/src/adapters/linear/LinearAdapter.ts#L156-L157)) 

    **`STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` second branch is overly permissive**

    The fallback branch `[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*` in `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` matches virtually any alphanumeric string — including single characters like `a`, short words like `hello`, or arbitrary hyphen-delimited tokens like `test-value`. The old validation only accepted `^[A-Z][A-Z0-9]*-\d+## **User description**
Extract `validateIssueId()` from `getSnapshotPath()` and call it at
entry to `fetchIssue()`, `fetchComments()`, `updateIssue()`, and
`postComment()`. Prevents malformed issue IDs from reaching GraphQL.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/740" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->




___

## **CodeAnt-AI Description**
Validate Linear issue IDs early to reject malformed IDs before GraphQL

### What Changed
- Public adapter methods that accept an issue ID now validate the ID immediately and throw a permanent error for malformed or overly long IDs instead of sending them to the API.
- Snapshot path construction also validates IDs so cached snapshot lookups reject invalid IDs.
- Added tests ensuring malformed IDs are rejected before any HTTP call and that no "Failed ..." error logs are emitted for those cases.

### Impact
`✅ Clearer invalid-ID errors`
`✅ Fewer malformed GraphQL requests`
`✅ No network calls when issue IDs are invalid`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces early `issueId` validation across all public `LinearAdapter` methods by extracting the check into a static `validateIssueId()` method that throws a typed `LinearAdapterError(PERMANENT)` — fixing both the missing validation coverage and the previously incorrect `TRANSIENT` classification for a bad-ID error in the stale-cache path.

**Key changes:**
- `validateIssueId()` is now a `static` method called at the entry of `fetchIssue`, `fetchComments`, `updateIssue`, `postComment`, and `fetchIssueSnapshot` — malformed IDs are rejected before any network I/O.
- The stale-cache error type classification in `fetchIssueSnapshot` now correctly preserves `LinearAdapterError.errorType` (e.g. `PERMANENT`) instead of defaulting every non-`HttpError` to `TRANSIENT`.
- Two new constants define the allowed ID formats: `LINEAR_ISSUE_IDENTIFIER_PATTERN` (strict `TEAM-123` format) and `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` (UUID + generic alphanumeric fallback).
- **Concern:** The fallback branch `[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*` inside `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` is extremely broad — it admits single-character IDs (`a`), arbitrary words (`hello`), and any hyphen-delimited token (`bad-id`). Strings that were previously rejected by the strict pattern will now silently pass validation and reach the GraphQL API.
- **Minor concern:** The `issueId.length > 100` guard is evaluated *after* both regex tests, meaning a long string (up to the caller-controlled input length) unnecessarily runs through both regex engines before being rejected. The second regex branch is also susceptible to O(n²) backtracking on trailing-dash inputs.

<h3>Confidence Score: 3/5</h3>

- Mostly safe, but the overly broad opaque-ID pattern undermines the validation goal and should be addressed before merge.
- The core fix (typed PERMANENT errors, correct stale-cache error classification) is correct and well-tested. However, `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN`'s second branch is so broad that it passes IDs that the old code would have rejected, which partially defeats the purpose of the PR. This logic issue and the minor ReDoS risk lower the score from 5 to 3.
- Pay close attention to `src/adapters/linear/LinearAdapter.ts`, specifically the `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` constant and the ordering of checks inside `validateIssueId()`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/adapters/linear/LinearAdapter.ts | Extracts `validateIssueId()` as a static method throwing `LinearAdapterError(PERMANENT)` and calls it at the entry point of all five public methods. Also improves stale-cache error classification to preserve `LinearAdapterError.errorType`. Two issues found: the `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` fallback branch is overly broad, and the length guard runs after both regex evaluations, creating a minor ReDoS risk. |
| tests/integration/linearAdapter.spec.ts | Adds well-structured tests verifying malformed IDs are rejected before HTTP calls across all four public methods, a test for opaque single-segment IDs, and a test that stale-cache snapshots preserve `ErrorType.PERMANENT`. Test coverage is thorough and assertions correctly check both the error shape and the absence of logger/HTTP side-effects. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Caller passes issueId] --> B{validateIssueId}
    B -->|empty / length > 100 / no pattern match| C[throw LinearAdapterError\nErrorType.PERMANENT]
    B -->|passes LINEAR_ISSUE_IDENTIFIER_PATTERN\neg. ENG-123| D[proceed to API call]
    B -->|passes STRUCTURED_OPAQUE_ISSUE_ID_PATTERN\neg. UUID or any alphanum+dash| D

    D --> E{Which method?}
    E --> F[fetchIssue]
    E --> G[fetchComments]
    E --> H[updateIssue]
    E --> I[postComment]
    E --> J[fetchIssueSnapshot]

    J --> K{API call succeeds?}
    K -->|yes| L[return fresh snapshot]
    K -->|no| M{stale cache available?}
    M -->|yes| N[mark last_error.type\nLinearAdapterError → PERMANENT\nHttpError → error.type\nother → TRANSIENT]
    M -->|no| O[throw normalizeError]
```

, so this represents a very large expansion of what is considered valid.

    IDs like `nonexistent-id`, `bad-id`, or `a` will all pass validation and reach the GraphQL API, which undermines the stated goal of "preventing malformed issue IDs from reaching GraphQL." If the intent is to additionally accept Linear's UUID-format node IDs, the first branch of the pattern (UUID regex) is sufficient for that purpose. The second, generic branch should be narrowed or removed unless there's a specific, documented format it's intended to match.

16. `src/adapters/linear/LinearAdapter.ts`, line 526-538 ([link](https://github.com/kinginyellows/codemachine-pipeline/blob/b464c5da8838632bd2df795584f51ab3181b25ad/src/adapters/linear/LinearAdapter.ts#L526-L538)) 

    **Length check should precede regex evaluation**

    Both regex tests are run before the `issueId.length > 100` guard is evaluated. For a pathologically long string (e.g. 1,000+ characters), both regexes execute unnecessarily against a string that will be rejected by the length guard anyway.

    More importantly, the second branch of `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` — `[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*` — can exhibit O(n²) backtracking on inputs that contain a trailing `-` (the engine speculatively tries all split points for `[A-Za-z0-9]+` before concluding there is no match). Since the length check comes after the regex, a carefully crafted ~100-character string ending in `-` would trigger this. Moving the length guard first eliminates the risk:

17. `src/adapters/linear/LinearAdapter.ts`, line 353-364 ([link](https://github.com/kinginyellows/codemachine-pipeline/blob/278a5ab9ac03b89b32c879eca7cb9063a2809d8a/src/adapters/linear/LinearAdapter.ts#L353-L364)) 

    `validateIssueId` is called *after* the preview-feature guard in both `updateIssue` and `postComment`. When preview features are disabled **and** the issue ID is malformed, the caller receives "Issue updates require preview features to be enabled" instead of "Invalid Linear issue ID". This makes debugging harder — a caller who passes a bad ID in a non-preview environment will never see the validation error.

    Consider calling `validateIssueId` first so callers always get the most relevant error:

    

    The same applies to `postComment` (line 412).


18. `src/adapters/linear/LinearAdapter.ts`, line 156-157 ([link](https://github.com/kinginyellows/codemachine-pipeline/blob/278a5ab9ac03b89b32c879eca7cb9063a2809d8a/src/adapters/linear/LinearAdapter.ts#L156-L157)) 

    `STRUCTURED_OPAQUE_ISSUE_ID_PATTERN` uses `[a-f0-9]`, which rejects any UUID containing uppercase hex digits. RFC 4122 treats UUIDs as case-insensitive, and callers who copy IDs from tools or APIs that canonicalize to uppercase would have valid issue IDs silently rejected with a `PERMANENT` error.

    All existing tests use lowercase UUIDs, so this gap is not caught by the current test suite. Adding the `i` flag makes the pattern case-insensitive:

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fadapters%2Flinear%2FLinearAdapter.ts%3A353-364%0A%60validateIssueId%60%20is%20called%20*after*%20the%20preview-feature%20guard%20in%20both%20%60updateIssue%60%20and%20%60postComment%60.%20When%20preview%20features%20are%20disabled%20**and**%20the%20issue%20ID%20is%20malformed%2C%20the%20caller%20receives%20%22Issue%20updates%20require%20preview%20features%20to%20be%20enabled%22%20instead%20of%20%22Invalid%20Linear%20issue%20ID%22.%20This%20makes%20debugging%20harder%20%E2%80%94%20a%20caller%20who%20passes%20a%20bad%20ID%20in%20a%20non-preview%20environment%20will%20never%20see%20the%20validation%20error.%0A%0AConsider%20calling%20%60validateIssueId%60%20first%20so%20callers%20always%20get%20the%20most%20relevant%20error%3A%0A%0A%60%60%60suggestion%0Aasync%20updateIssue%28params%3A%20UpdateIssueParams%29%3A%20Promise%3Cvoid%3E%20%7B%0A%20%20LinearAdapter.validateIssueId%28params.issueId%29%3B%0A%20%20if%20%28!this.enablePreviewFeatures%29%20%7B%0A%20%20%20%20throw%20new%20LinearAdapterError%28%0A%20%20%20%20%20%20'Issue%20updates%20require%20preview%20features%20to%20be%20enabled'%2C%0A%20%20%20%20%20%20ErrorType.PERMANENT%2C%0A%20%20%20%20%20%20undefined%2C%0A%20%20%20%20%20%20undefined%2C%0A%20%20%20%20%20%20'updateIssue'%0A%20%20%20%20%29%3B%0A%20%20%7D%0A%20%20...%0A%7D%0A%60%60%60%0A%0AThe%20same%20applies%20to%20%60postComment%60%20%28line%20412%29.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fadapters%2Flinear%2FLinearAdapter.ts%3A156-157%0A%60STRUCTURED_OPAQUE_ISSUE_ID_PATTERN%60%20uses%20%60%5Ba-f0-9%5D%60%2C%20which%20rejects%20any%20UUID%20containing%20uppercase%20hex%20digits.%20RFC%204122%20treats%20UUIDs%20as%20case-insensitive%2C%20and%20callers%20who%20copy%20IDs%20from%20tools%20or%20APIs%20that%20canonicalize%20to%20uppercase%20would%20have%20valid%20issue%20IDs%20silently%20rejected%20with%20a%20%60PERMANENT%60%20error.%0A%0AAll%20existing%20tests%20use%20lowercase%20UUIDs%2C%20so%20this%20gap%20is%20not%20caught%20by%20the%20current%20test%20suite.%20Adding%20the%20%60i%60%20flag%20makes%20the%20pattern%20case-insensitive%3A%0A%0A%60%60%60suggestion%0Aconst%20STRUCTURED_OPAQUE_ISSUE_ID_PATTERN%20%3D%0A%20%20%2F%5E%5Ba-f0-9%5D%7B8%7D%28%3F%3A-%5Ba-f0-9%5D%7B4%7D%29%7B3%7D-%5Ba-f0-9%5D%7B12%7D%24%2Fi%3B%0A%60%60%60%0A%0A&repo=kinginyellows%2Fcodemachine-pipeline"><picture><source media="(prefers-color-scheme: dark)" srcset="https://img.shields.io/badge/Fix_All_in_Codex-black?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=white"><img alt="Fix All in Codex" src="https://img.shields.io/badge/Fix_All_in_Codex-white?logo=data%3Aimage%2Fpng%3Bbase64%2CiVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAERlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAMKADAAQAAAABAAAAMAAAAADbN2wMAAAGD0lEQVRoBe1ZC4hUVRg%2B%2Fx1H81GrjDNrarUmVpCVIokEFUrlo6SoRqFQBHfHfVFEglD0EqFQ1Mp9yO74AFuipQcZuRaEFhERtqgkheHW5hLN7I7rWu1jdub%2BfWfqjHfu3Lneuzuzu4F3Wc75n%2Bf%2F7vnPuf85I8TVZ3TfAOVj%2BE0bovO8Xs8qFmIJCQ7Ap45%2BRAg6q3PyWH048DV4YOX%2FGRaAitLORR7SdgsS99qFxsw%2FMtPLdWHf%2B3Z6Q5ENFQBVhbq2CaYtRMLjdGBMwdEBPbEhHC7G7OTncQ0gGGz2BKYuO0BE64YSArNoh91RQXwLsbiOieKC%2BXckWCuTfqSuMXDSjV%2FXAKrLOncJ0p5zM4gbXRbcKnSxtTY8%2FWMndq4AVIY6lxJrXyBtXNk5CcSsg3XTNEjxUEPDzF6zzEhrRuJKfU3QzpEIXsaBFH16PE84Ggyen2gXl2MAVaWxB%2BF2oZ2zvMuwuxVPm3TAzq8jAOUbuxYjabbbOSqgbG11KBbM5d82lytCnQ9rTK9gOu%2FO5WAk%2BNh%2Bfz1z9vS848eXJszjWQIIhU54vTxnD%2FJ9k9lg1GjWH61p9B82j5%2BVQjL48VxyZEwFj6iZtNXm4CU9zsz0ijk1yPcHzPxRp5nvsoohYwaqyqJrkFMhK8VR55GYaRVDGoAsEQR5XrdSMvNQDsi%2FC2Z%2BYWm6xsp%2FGkCgaNkjePs3WykZedgRBnVOLKhp9PmYk2uNskL2iTlrB5LjpQEg7x9zGMBP9eHi01K3tjHQjNlodmg3XLV2KwdpANh1llgpZPFYzK8siy5QfE70b0Y%2B2dYrSnc4LarW6ys3RGeYfaQBQHCTWWhFy1oIR4A3lKzuwKzzWA%2BO1o6yGUqL9L6BvNrhYPDMeKO9AQDZFk1GIyBYXl0WWa54bR3dO7A22hRdqFZWBIGiwLNG%2F5cBMLs6JbEYtzO1c8FbS8u8ARxKNhsdF6yvaS9WBqNTlP%2FLAAS1KqaTFrNwu3%2FqsnSpUds4%2FSOA%2BM6J7XB0kEpFWpEnXdwZAHCLW8ca0RajDdLoEyNdqD6TeFL5TgOIU%2FxdLMa4EjhpdSHCRj28nREpQXB1k66O0wBwdOtCQG8bA7Lts%2FilN35ph9JJLWqi%2BxVd0JbIv3LlzxPkGGkAkuhP6ltR952T%2FSs9OhbtwYNz%2BqWerGBRhrx5JZt8yvv6OpLSXwaA%2Ffv9fyZ1luWB5Wc7HQDzl3Xh6R8qepy46RkcN29TdKFbrLWYOtxkAJAD14f932M3idkGkby8ZcqvI%2BHUlkufda4WCX1WXFyc2tM3OCXS3TtJ%2FsfFwGRJS36in2cL1itSRWIuRxl8TpUykpV1Hkh96YiKM%2FQzCD5Xs99%2FQrHwddyOD8y1ija1p3C%2FU2viWZE9YO6tKovJbTldplgpSh5Kl0%2BVLGsGAhOLcgWTssEdZ0lFaSxVN1WXxZ5A8Dlv6DDQ3PL1XbPUYHZtaWlsNnaxEjsdKcN9Ub%2BIc5PSg03ms27dH5OLJnr%2FyuRmUqmpJu5EWSRvou0fFhcx7CkUY314dTo%2BgEhhy%2BcOcG%2B0lBiYGHtXbaPvecXKAiAFVaFYFwQ%2BpTRWWsxoa9v57ntSpct%2FQWWl0L98%2FmasBK3iwJtvF8n448bgpSwHAPGBMhwLLfL%2B7CAN3Fe7b2a7OR5LANHuvmYkapdZeaRpxDCI7XU3LnkXolL4zWp8yzUgFXGNXo5r9Horo8LzeEBn2hNn8VY47OuwGy8nAGmEffk97Bpr7BwUQoaUeQnl%2BTYnvi1TSBm2dVxYjy3wc0WPRIu06Rmknj1Ox7IFIFd8pDuyGk4zymanzoeih7f%2FQkPDXPlldvTYppDRg7yp9jC9hiP9IiM%2Fr30WLbhvWuXGp2MAymnqp1WNVqCkmI%2F0wjUHyVuCi7hXkovtITgsUbquWuZvu3tpeVOT75IbO9cA7JxXPNU%2BTZs8Za%2F7hc%2Fv9PQlyg8dmvG3nX8rWV4BqAEqN0ZXaJom022x4lm1WFtfoTx6ta7Bf8xK7oRXEABq4IrSyJ2keVbg9%2BBbkWpIN%2FZidiK64JN6MvnZ3n0zflC6V9v%2F6xv4B1Ee8WrvhIOWAAAAAElFTkSuQmCC&logoColor=black"></picture></a>

<sub>Last reviewed commit: 278a5ab</sub>

<!-- /greptile_comment -->