### PR TITLE
docs: add per-module READMEs for all 8 src/ directories

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -65,6 +65,7 @@ Documented architectural decisions with context, rationale, and consequences.
 | [ADR-6: Linear Integration](adr/ADR-6-linear-integration.md)                   | Linear integration strategy and adapter design               |
 | [ADR-7: Validation Policy](adr/ADR-7-validation-policy.md)                     | Zod runtime validation policy and schema validation approach |
 | [ADR-8: CodeMachine CLI Integration](adr/ADR-8-codemachine-cli-integration.md) | CodeMachine CLI adapter design and binary resolution         |
+| [ADR-9: Documentation Architecture](adr/adr-009-documentation-architecture.md) | Documentation structure, conventions, and factual accuracy   |
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,14 +1,72 @@
 # Codemachine Pipeline Documentation
 
-Welcome to the canonical documentation for `codemachine-pipeline`.
+Welcome to the canonical documentation for `codemachine-pipeline` — an AI-powered
+feature pipeline that orchestrates code generation, research, and PR automation.
 
 ## Start Here
 
-- **Quick Start**: [guide/quick-start.md](guide/quick-start.md)
-- **Playbooks** (operational how-tos): [playbooks/init_playbook.md](playbooks/init_playbook.md)
-- **Reference** (architecture, config, API, CLI): [reference/architecture/component_index.md](reference/architecture/component_index.md)
+| Task | Document |
+|---|---|
+| **Getting Started** | [Quick Start](guide/quick-start.md) |
+| **Initialize a Repo** | [Init Playbook](playbooks/init_playbook.md) |
+| **CLI Commands** | [CLI Reference](reference/cli/cli-reference.md) |
+| **Configuration** | [RepoConfig Schema](reference/config/RepoConfig_schema.md) |
+| **Troubleshooting** | [Doctor Reference](reference/cli/doctor_reference.md) |
+
+## Architecture
+
+The pipeline follows a layered architecture with strict dependency direction:
+
+- **cli** — oclif commands and status rendering (top layer)
+- **workflows** — execution strategies, context aggregation, task planning
+- **adapters** — GitHub, Linear, agent provider, and HTTP boundaries
+- **persistence** — run directories, manifests, locks, hash verification
+- **telemetry** — logging, metrics, tracing, cost tracking
+- **core** — shared types, domain models, configuration schemas
+- **validation** — Zod schema validation and CLI path safety
+- **utils** — error handling, redaction, atomic writes, process management
+
+See [Component Index](reference/architecture/component_index.md) and
+[Execution Flow](reference/architecture/execution_flow.md) for details.
+
+## Playbooks
+
+### Core Operations
+
+- [Init Playbook](playbooks/init_playbook.md) — repository initialization
+- [Resume Playbook](playbooks/resume_playbook.md) — recover from interrupted runs
+- [Troubleshooting](playbooks/troubleshooting.md) — common issues and fixes
+
+### Workflows
+
+- [Research Playbook](playbooks/research_playbook.md) — research task execution
+- [PR Playbook](playbooks/pr_playbook.md) — pull request creation and management
+- [PRD Playbook](playbooks/prd_playbook.md) — product requirements generation
+- [Write Action Playbook](playbooks/write_action_playbook.md) — file write operations
+- [Validation Playbook](playbooks/validation_playbook.md) — queue and plan validation
+- [Traceability Playbook](playbooks/traceability_playbook.md) — audit trail tracking
+- [Patch Playbook](playbooks/patch_playbook.md) — patch application
+
+### Approval & Monitoring
+
+- [Approval Playbook](playbooks/approval_playbook.md) — human approval workflow
+- [Approval Gates](playbooks/approval_gates.md) — gate configuration
+- [Execution Telemetry](playbooks/execution_telemetry.md) — metrics and traces
+- [Observability Baseline](playbooks/observability_baseline.md) — monitoring setup
+- [Branch Protection Playbook](playbooks/branch_protection_playbook.md) — branch rules
+
+## Reference
+
+- [API Reference](reference/api/api-reference.md) — domain models and schemas
+- [Parallel Execution](reference/parallel-execution.md) — concurrent task execution
+- [Queue V2 Operations](reference/queue-v2-operations.md) — queue architecture
+- [Rate Limit Dashboard](reference/rate_limit_dashboard.md) — rate limit monitoring
+
+## Full Documentation Index
+
+For a comprehensive listing of all documents, see [README.md](README.md).
 
 ## Notes
 
-- Some pages are intentionally marked as TODO in `mkdocs.yml` and will be added in Phase 3 content creation.
+- Some pages are marked as TODO in `mkdocs.yml` — these will be added in a future content phase.
 - If you're troubleshooting a specific issue, start in `solutions/`.

--- a/docs/playbooks/init_playbook.md
+++ b/docs/playbooks/init_playbook.md
@@ -5,10 +5,20 @@
 The `codepipe init` command initializes the codemachine-pipeline in a repository by:
 
 - Detecting the git repository root
-- Creating the `.codepipe/` directory structure
+- Creating the `.codepipe/` directory structure (`.codepipe/`, `runs/`, `logs/`, `artifacts/`)
 - Generating a schema-validated `config.json` with defaults
 - Validating credentials and environment setup
 - Recording initialization telemetry
+
+The `Init.run()` method was decomposed (CDMCH-160) into focused step-extraction
+methods: `resolveProjectPaths()`, `initializeTelemetry()`, `shouldAbortFromPrompt()`,
+`scaffoldConfiguration()`, `validateNewConfiguration()`, `renderValidationFailure()`,
+`buildResultPayload()`, and `renderInitResult()`. Each handles one concern and the
+top-level `run()` coordinates the flow.
+
+After initialization, feature execution is coordinated by `PipelineOrchestrator`
+(extracted via CDMCH-177), which sequences context aggregation, research detection,
+PRD authoring, and task execution as a four-stage pipeline.
 
 This playbook documents exact command usage, approval workflows, and operational considerations for CI/homelab operators.
 
@@ -503,10 +513,25 @@ fi
 
 ---
 
+## Pipeline Orchestrator (Post-Init)
+
+After `codepipe init` creates the `.codepipe/` scaffold, feature runs are coordinated
+by `PipelineOrchestrator` (`src/workflows/pipelineOrchestrator.ts`, extracted in CDMCH-177).
+The orchestrator sequences four stages:
+
+1. **Context Aggregation** (`context_aggregation`) - Collects relevant repository files within the token budget
+2. **Research Detection** (`research_detection`) - Identifies unknowns from the aggregated context
+3. **PRD Authoring** (`prd_authoring`) - Drafts a Product Requirements Document from context and research
+4. **Task Execution** (`task_execution`) - Executes queued tasks via `CLIExecutionEngine` (skipped if approval required or `--skip-execution` is set)
+
+The orchestrator accepts a `maxParallel` parameter (from `--max-parallel` CLI flag)
+which is forwarded to the execution engine for bounded parallelism.
+
 ## Related Documentation
 
 - [Run Directory Schema](../reference/run_directory_schema.md) - Run directory structure and manifests
 - [Doctor Reference](../reference/cli/doctor_reference.md) - Environment diagnostics command
+- [Parallel Execution](../reference/parallel-execution.md) - Bounded parallelism and dependency resolution
 
 ---
 

--- a/docs/playbooks/init_playbook.md
+++ b/docs/playbooks/init_playbook.md
@@ -5,7 +5,7 @@
 The `codepipe init` command initializes the codemachine-pipeline in a repository by:
 
 - Detecting the git repository root
-- Creating the `.codepipe/` directory structure (`.codepipe/`, `runs/`, `logs/`, `artifacts/`)
+- Creating the `.codepipe/` directory structure (`.codepipe/`, `.codepipe/runs/`, `.codepipe/logs/`, `.codepipe/artifacts/`)
 - Generating a schema-validated `config.json` with defaults
 - Validating credentials and environment setup
 - Recording initialization telemetry
@@ -29,7 +29,7 @@ This playbook documents exact command usage, approval workflows, and operational
 Before running `codepipe init`, ensure:
 
 1. **Git Repository**: Current directory must be within a git repository
-2. **Node.js**: v24 LTS or higher (required)
+2. **Node.js**: v24 LTS recommended; v20.x acceptable (the doctor command warns on v20 and recommends upgrading to v24)
 3. **Filesystem Permissions**: Write access to create `.codepipe/` directory
 4. **Environment Variables** (optional but recommended):
    - `GITHUB_TOKEN` - GitHub Personal Access Token with `repo`, `workflow` scopes

--- a/docs/playbooks/resume_playbook.md
+++ b/docs/playbooks/resume_playbook.md
@@ -21,7 +21,8 @@ The resume system is decomposed into four modules:
 
 The coordinator delegates to the integrity checker and state verifier before
 attempting any task re-execution. If queue operations were interrupted, the
-queue recovery module rebuilds the queue index from the operations log.
+queue recovery module restores queue state from the persisted queue artifacts
+and revalidates consistency before continuing.
 
 ### Key Principles
 

--- a/docs/playbooks/resume_playbook.md
+++ b/docs/playbooks/resume_playbook.md
@@ -1,7 +1,7 @@
 # Resume Playbook
 
-**Version:** 1.0.0
-**Last Updated:** 2025-01-XX
+**Version:** 1.1.0
+**Last Updated:** 2026-03-18
 **Owner:** Platform Engineering
 
 ---
@@ -9,6 +9,19 @@
 ## Overview
 
 This playbook provides comprehensive guidance for resuming failed or paused AI Feature Pipeline runs. It maps error classifications to recovery actions, explains the resume coordinator's diagnostic system, and documents manual intervention procedures.
+
+### Architecture (v1.1.0)
+
+The resume system is decomposed into four modules:
+
+- **`resumeCoordinator.ts`** — top-level coordinator that orchestrates the resume flow
+- **`runStateVerifier.ts`** — verifies run state consistency before resuming
+- **`resumeIntegrityChecker.ts`** — validates artifact integrity (manifests, hashes)
+- **`resumeQueueRecovery.ts`** — recovers queue state for interrupted queue operations
+
+The coordinator delegates to the integrity checker and state verifier before
+attempting any task re-execution. If queue operations were interrupted, the
+queue recovery module rebuilds the queue index from the operations log.
 
 ### Key Principles
 

--- a/docs/reference/cli/doctor_reference.md
+++ b/docs/reference/cli/doctor_reference.md
@@ -4,11 +4,14 @@
 
 The `codepipe doctor` command runs comprehensive environment diagnostics to verify that your system meets all prerequisites for codemachine-pipeline operations. It validates:
 
-- Runtime environment (Node.js, git, npm, Docker)
+- Runtime environment (Node.js, git, npm, Docker, CodeMachine CLI)
 - Repository setup and permissions
 - Network connectivity
 - Configuration validity
-- Credential availability
+- Credential availability (GITHUB_TOKEN, LINEAR_API_KEY, Agent Endpoint)
+
+The Doctor command extends `TelemetryCommand` for automatic telemetry lifecycle
+management (logger, metrics, traces) via `runWithTelemetry()`.
 
 This reference documents all diagnostic checks, exit codes, and remediation procedures.
 
@@ -67,8 +70,8 @@ Environment Diagnostics Report
     → Set LINEAR_API_KEY with a valid Linear API key
 
 Summary:
-  Total checks: 11
-  Passed: 7
+  Total checks: 12
+  Passed: 8
   Warnings: 2
   Failed: 2
 
@@ -116,8 +119,8 @@ codepipe doctor --json
     }
   ],
   "summary": {
-    "total": 11,
-    "passed": 7,
+    "total": 12,
+    "passed": 8,
     "warnings": 2,
     "failed": 2
   },
@@ -154,15 +157,19 @@ Verbose mode includes:
 
 - Node.js v24.x (LTS) or higher
 
+**Warn Criteria:**
+
+- Node.js v20.x (acceptable but v24 recommended)
+
 **Fail Criteria:**
 
-- Node.js < v24.0.0
+- Node.js < v20.0.0
 - Node.js not installed
 
 **Remediation:**
 
 ```bash
-# Install Node.js v24 LTS
+# Install Node.js v24 LTS (recommended)
 # macOS (homebrew)
 brew install node@24
 
@@ -178,7 +185,7 @@ nvm use 24
 node --version
 ```
 
-**Exit Code Impact:** Failure → 20 (Environment Issue)
+**Exit Code Impact:** Failure → 20 (Environment Issue); Warning if v20.x
 
 ---
 
@@ -507,7 +514,39 @@ codepipe doctor
 
 ---
 
-### 11. Agent Endpoint
+### 11. CodeMachine CLI (Execution)
+
+**Check:** Verifies that the external CodeMachine CLI binary is available and optionally meets a minimum version requirement.
+
+**Pass Criteria:**
+
+- Binary found (via `CODEMACHINE_BIN_PATH`, npx, or global install) and `--version` succeeds
+- Version satisfies `execution.codemachine_cli_version` from config (if set)
+
+**Warn Criteria:**
+
+- Binary not found (optional dependency)
+- Binary found but `--version` fails
+- Version below configured minimum
+
+**Remediation:**
+
+```bash
+# Install CodeMachine CLI globally
+npm install -g codemachine@^0.8.0
+
+# Or set the binary path explicitly
+export CODEMACHINE_BIN_PATH=/path/to/codemachine
+
+# Verify
+codemachine --version
+```
+
+**Exit Code Impact:** Warning only (CodeMachine CLI is optional; the pipeline can use the built-in codemachine-cli strategy)
+
+---
+
+### 12. Agent Endpoint
 
 **Check:** Verifies agent service endpoint is configured.
 
@@ -624,10 +663,12 @@ codepipe doctor
 
 ```
 ❌ Node.js Version: Node.js v18.12.0 is below minimum required version
-  → Install Node.js v24 LTS or higher from https://nodejs.org/
+  → Install Node.js v20 or v24 LTS from https://nodejs.org/
 ```
 
 **Exit Code:** 20
+
+Note: Node.js v20 produces a warning (not a failure) recommending upgrade to v24.
 
 **Resolution:**
 

--- a/docs/reference/cli/doctor_reference.md
+++ b/docs/reference/cli/doctor_reference.md
@@ -55,6 +55,7 @@ Environment Diagnostics Report
   ✓ Git Repository: Git repository detected at /path/to/repo
   ✓ Filesystem Permissions: Write permissions verified
   ✓ RepoConfig: Configuration valid
+  ✓ CodeMachine CLI (Execution): CodeMachine CLI v0.8.2 (npx)
   ✓ Agent Endpoint: Configured: https://agent.example.com
 
 ⚠ Warnings:

--- a/docs/reference/config/RepoConfig_schema.md
+++ b/docs/reference/config/RepoConfig_schema.md
@@ -23,6 +23,15 @@ The configuration file must be located at:
 .codepipe/config.json
 ```
 
+## Source Code Structure (CDMCH-213)
+
+The config implementation is split across three files:
+
+- **`RepoConfigSchema.ts`** — All Zod schemas and inferred TypeScript types
+- **`RepoConfigLoader.ts`** — Runtime loading, environment variable overrides, validation error formatting, and config history management
+- **`RepoConfigDefaults.ts`** — Default values and factory functions (`createDefaultConfig`, `DEFAULT_EXECUTION_CONFIG`)
+- **`RepoConfig.ts`** — Barrel re-export; existing consumers can continue to import from this single file
+
 ## Schema Structure
 
 ### Root Object
@@ -76,8 +85,9 @@ GitHub integration configuration and credentials.
 | `enabled`           | `boolean`  | ✓        | -                          | Enable GitHub integration                | -                       |
 | `token_env_var`     | `string`   | ✗        | `"GITHUB_TOKEN"`           | Environment variable name for GitHub PAT | `CODEPIPE_GITHUB_TOKEN` |
 | `api_base_url`      | `string`   | ✗        | `"https://api.github.com"` | GitHub API base URL (for Enterprise)     | -                       |
-| `required_scopes`   | `string[]` | ✗        | `["repo", "workflow"]`     | Required PAT scopes                      | -                       |
+| `required_scopes`   | `string[]` | ✗        | `["repo", "workflow"]`     | Required PAT scopes (enum: `repo`, `workflow`, `read:org`, `write:org`) | -                       |
 | `default_reviewers` | `string[]` | ✗        | `[]`                       | Default PR reviewers (GitHub usernames)  | -                       |
+| `api_version`       | `string`   | ✗        | From `configConstants`     | GitHub API version date (`YYYY-MM-DD`) for `X-GitHub-Api-Version` header | -                       |
 | `branch_protection` | `object`   | ✗        | See below                  | Branch protection settings awareness     | -                       |
 
 **branch_protection:**
@@ -197,6 +207,9 @@ _(Optional)_ CodeMachine CLI integration and execution settings. The entire `exe
 | `log_rotation_mb`       | `integer`                         | ✗        | `100`           | Log file rotation threshold in MB (1-10240)       | -                                   |
 | `log_rotation_keep`     | `integer`                         | ✗        | `3`             | Number of rotated log files to keep (1-20)        | -                                   |
 | `log_rotation_compress` | `boolean`                         | ✗        | `false`         | Compress rotated log files                        | -                                   |
+| `codemachine_cli_version` | `string`                        | ✗        | -               | Minimum required CodeMachine-CLI version (semver) | -                                   |
+| `codemachine_workflow_dir` | `string`                       | ✗        | -               | Path to workflow template overrides directory     | -                                   |
+| `env_credential_keys` | `string[]`                          | ✗        | `[]`            | Env var names to pipe to CodeMachine-CLI via stdin | -                                  |
 
 **Example:**
 
@@ -319,7 +332,7 @@ The CLI supports environment variable overrides following the `CODEPIPE_<SECTION
 
 ## Validation
 
-The schema is validated using Zod with the following rules:
+The schema is validated using Zod in `RepoConfigLoader.loadRepoConfig()` with the following rules:
 
 1. **Required fields** must be present
 2. **Type checking** ensures correct data types
@@ -365,11 +378,17 @@ See `.codepipe/templates/config.example.json` for a complete annotated example.
 
 - **ADR-2:** State Persistence - Defines run directory structure and deterministic storage
 - **ADR-5:** Approval Workflow - Defines human-in-the-loop gates and accountability
+- **CDMCH-213:** RepoConfigLoader extraction
+- **Source — Schema:** `src/core/config/RepoConfigSchema.ts`
+- **Source — Loader:** `src/core/config/RepoConfigLoader.ts`
+- **Source — Defaults:** `src/core/config/RepoConfigDefaults.ts`
+- **Source — Barrel:** `src/core/config/RepoConfig.ts`
 - **Migration Checklist:** `docs/reference/config/config_migrations.md`
 - **Example Config:** `.codepipe/templates/config.example.json`
 
 ## Schema Version History
 
-| Version | Date       | Changes                                             |
-| ------- | ---------- | --------------------------------------------------- |
-| 1.0.0   | 2025-12-15 | Initial schema with governance and history tracking |
+| Version | Date       | Changes                                                                    |
+| ------- | ---------- | -------------------------------------------------------------------------- |
+| 1.0.0   | 2025-12-15 | Initial schema with governance and history tracking                       |
+| 1.1.0   | 2026-03-18 | Add github.api_version, execution CLI version/workflow/credential fields, loader extraction (CDMCH-213) |

--- a/docs/reference/config/RepoConfig_schema.md
+++ b/docs/reference/config/RepoConfig_schema.md
@@ -1,7 +1,7 @@
 # RepoConfig Schema Documentation
 
-**Version:** 1.0.0
-**Last Updated:** 2025-12-15
+**Version:** 1.1.0
+**Last Updated:** 2026-03-18
 **Related ADRs:** ADR-2 (State Persistence), ADR-5 (Approval Workflow)
 
 ## Overview
@@ -25,7 +25,7 @@ The configuration file must be located at:
 
 ## Source Code Structure (CDMCH-213)
 
-The config implementation is split across three files:
+The config implementation is split across four files:
 
 - **`RepoConfigSchema.ts`** — All Zod schemas and inferred TypeScript types
 - **`RepoConfigLoader.ts`** — Runtime loading, environment variable overrides, validation error formatting, and config history management
@@ -87,7 +87,7 @@ GitHub integration configuration and credentials.
 | `api_base_url`      | `string`   | ✗        | `"https://api.github.com"` | GitHub API base URL (for Enterprise)     | -                       |
 | `required_scopes`   | `string[]` | ✗        | `["repo", "workflow"]`     | Required PAT scopes (enum: `repo`, `workflow`, `read:org`, `write:org`) | -                       |
 | `default_reviewers` | `string[]` | ✗        | `[]`                       | Default PR reviewers (GitHub usernames)  | -                       |
-| `api_version`       | `string`   | ✗        | From `configConstants`     | GitHub API version date (`YYYY-MM-DD`) for `X-GitHub-Api-Version` header | -                       |
+| `api_version`       | `string`   | ✗        | `"2022-11-28"`             | GitHub API version date (`YYYY-MM-DD`) for `X-GitHub-Api-Version` header | -                       |
 | `branch_protection` | `object`   | ✗        | See below                  | Branch protection settings awareness     | -                       |
 
 **branch_protection:**
@@ -391,4 +391,4 @@ See `.codepipe/templates/config.example.json` for a complete annotated example.
 | Version | Date       | Changes                                                                    |
 | ------- | ---------- | -------------------------------------------------------------------------- |
 | 1.0.0   | 2025-12-15 | Initial schema with governance and history tracking                       |
-| 1.1.0   | 2026-03-18 | Add github.api_version, execution CLI version/workflow/credential fields, loader extraction (CDMCH-213) |
+| 1.1.0   | 2026-03-18 | Add GitHub.api_version, execution CLI version/workflow/credential fields, loader extraction (CDMCH-213) |

--- a/docs/reference/config/github_adapter.md
+++ b/docs/reference/config/github_adapter.md
@@ -138,6 +138,23 @@ The GitHub adapter integrates with the `HttpClient` rate limit tracking:
 
 See `docs/reference/cli/rate_limit_reference.md` for detailed rate limit behavior.
 
+## Input Validation (CDMCH-174)
+
+The adapter validates path parameters at construction time and before API calls to prevent malformed inputs from reaching the GitHub API:
+
+### Owner / Repo Validation
+
+Both `owner` and `repo` are validated in the constructor:
+
+- **Owner** must match `^[a-zA-Z0-9]+(?:[-_][a-zA-Z0-9]+)*$` (alphanumerics with single hyphen or underscore separators).
+- **Repo** must match `^[a-zA-Z0-9._][a-zA-Z0-9._-]*$` (single safe path segment). Additionally, repos named `.`, `..`, or ending with `.` or `.git` are rejected.
+
+Invalid values throw a `GitHubAdapterError` with `ErrorType.PERMANENT`.
+
+### Pull Request Number Validation
+
+All methods accepting `pull_number` validate it is a positive integer before making API calls. Invalid values throw a `GitHubAdapterError` with `ErrorType.PERMANENT`.
+
 ## Operations
 
 ### Repository Operations
@@ -369,6 +386,22 @@ await adapter.enableAutoMerge(42, 'SQUASH');
 
 **GitHub Endpoint:** `POST /graphql` (mutation: `enablePullRequestAutoMerge`)
 
+#### Disable Auto-Merge
+
+Disables auto-merge for a pull request using GraphQL mutation.
+
+```typescript
+await adapter.disableAutoMerge(42);
+```
+
+**Parameters:**
+
+- `pull_number` - PR number (required, must be a positive integer)
+
+**Note:** This uses the GraphQL API wrapped in REST-like envelope metadata for consistent logging.
+
+**GitHub Endpoint:** `POST /graphql` (mutation: `disablePullRequestAutoMerge`)
+
 ### Workflow Operations
 
 #### Trigger Workflow Dispatch
@@ -401,7 +434,7 @@ await adapter.triggerWorkflow({
 
 ## Error Handling
 
-The adapter classifies errors into three taxonomies:
+The adapter classifies errors into three taxonomies. `GitHubAdapterError` extends `AdapterError` (from `utils/errors`) and errors are normalized through `createErrorNormalizer()`.
 
 ### Transient Errors (Retryable)
 
@@ -495,6 +528,7 @@ const adapter = new GitHubAdapter({
   repo: 'my-repo',
   token: process.env.GITHUB_TOKEN!,
   baseUrl: 'https://github.company.com/api/v3', // GitHub Enterprise
+  apiVersion: '2022-11-28', // X-GitHub-Api-Version header (default from configConstants)
   runDir: '.codepipe/runs/feature-123', // Rate limit ledger
   logger: customLogger, // Custom logger
   timeout: 60000, // 60 second timeout
@@ -512,6 +546,7 @@ The GitHub adapter integrates with `RepoConfig` for centralized configuration:
     "enabled": true,
     "token_env_var": "GITHUB_TOKEN",
     "api_base_url": "https://api.github.com",
+    "api_version": "2022-11-28",
     "required_scopes": ["repo", "workflow"],
     "default_reviewers": ["tech-lead", "security-team"],
     "branch_protection": {
@@ -525,9 +560,9 @@ The GitHub adapter integrates with `RepoConfig` for centralized configuration:
 **Loading from Config:**
 
 ```typescript
-import { loadRepoConfig } from './core/config/RepoConfig';
+import { loadRepoConfig } from './core/config/RepoConfig'; // re-exports from RepoConfigLoader
 
-const config = loadRepoConfig('.codepipe/config.json');
+const config = await loadRepoConfig('.codepipe/config.json');
 if (!config.success) {
   throw new Error('Invalid config');
 }
@@ -763,6 +798,7 @@ console.log('Merge blocked:', reasons);
 
 ## Changelog
 
-| Version | Date       | Changes                                                           |
-| ------- | ---------- | ----------------------------------------------------------------- |
-| 1.0.0   | 2025-12-17 | Initial GitHub adapter implementation with full REST API coverage |
+| Version | Date       | Changes                                                                             |
+| ------- | ---------- | ----------------------------------------------------------------------------------- |
+| 1.0.0   | 2025-12-17 | Initial GitHub adapter implementation with full REST API coverage                   |
+| 1.1.0   | 2026-03-18 | Add input validation (CDMCH-174), disableAutoMerge, apiVersion config, type extraction |

--- a/docs/reference/config/github_adapter.md
+++ b/docs/reference/config/github_adapter.md
@@ -1,7 +1,7 @@
 # GitHub Adapter
 
-**Version:** 1.0.0
-**Last Updated:** 2025-12-17
+**Version:** 1.1.0
+**Last Updated:** 2026-03-18
 
 This document describes the GitHub adapter implementation, which provides integration with GitHub's REST API for repository operations, pull request management, and deployment automation.
 

--- a/docs/reference/config/linear_adapter.md
+++ b/docs/reference/config/linear_adapter.md
@@ -8,7 +8,8 @@ The Linear Adapter provides integration with Linear's issue tracking system via 
 
 ### Core Components
 
-- **LinearAdapter**: Main adapter class implementing Linear GraphQL API integration
+- **LinearAdapter** (`LinearAdapter.ts`): Main adapter class implementing Linear GraphQL API integration
+- **LinearAdapterTypes** (`LinearAdapterTypes.ts`): Extracted type definitions and Zod schemas (CDMCH-203) — includes `LinearAdapterConfig`, `LinearIssue`, `LinearComment`, `SnapshotMetadata`, `IssueSnapshot`, `IssueSnapshotSchema`, `UpdateIssueParams`, and `PostCommentParams`
 - **HttpClient**: Shared HTTP client with rate-limit tracking and retry logic
 - **RateLimitLedger**: Persistence layer for rate limit envelope tracking
 - **Snapshot Cache**: File-based caching system with TTL support
@@ -89,6 +90,8 @@ Snapshots are stored in the run directory:
 - **Validation**: Age checked on every cache read
 
 ### Snapshot Structure
+
+Validated at load time using `IssueSnapshotSchema` (Zod schema defined in `LinearAdapterTypes.ts`).
 
 ```typescript
 {
@@ -178,8 +181,10 @@ Mutating operations (updates, comment posting) are gated behind `enablePreviewFe
 ```typescript
 const adapter = new LinearAdapter({
   apiKey: process.env.LINEAR_API_KEY!,
+  organization: 'acme-corp', // Optional workspace slug
   enablePreviewFeatures: true, // Opt-in required
   runDir: '.codepipe/runs/FEAT-123',
+  maxRetries: 3, // Optional, defaults to 3
 });
 ```
 
@@ -201,6 +206,20 @@ throw new LinearAdapterError(
   'updateIssue'
 );
 ```
+
+## Issue ID Validation (CDMCH-161)
+
+All public methods (`fetchIssueSnapshot`, `fetchIssue`, `fetchComments`, `updateIssue`, `postComment`) validate the `issueId` parameter via a shared private static `validateIssueId()` method before making any API calls. This fail-fast approach ensures malformed identifiers never reach the Linear API.
+
+**Accepted formats:**
+
+- **Linear identifier**: `^[A-Z][A-Z0-9]*-\d+$` (e.g., `ENG-123`, `PROJ-42`)
+- **UUID**: `^[a-f0-9]{8}(?:-[a-f0-9]{4}){3}-[a-f0-9]{12}$` (Linear's internal opaque IDs)
+
+**Constraints:**
+
+- Must be non-empty and at most 100 characters
+- Values not matching either format throw `LinearAdapterError` with `ErrorType.PERMANENT`
 
 ## GraphQL Operations
 
@@ -301,6 +320,8 @@ mutation PostComment($issueId: String!, $body: String!) {
 ```
 
 ## Error Taxonomy
+
+`LinearAdapterError` extends `AdapterError` (from `utils/errors`) and errors are normalized through `createErrorNormalizer()`.
 
 ### Transient Errors
 
@@ -410,6 +431,9 @@ Mock `HttpClient` methods to simulate:
 ### Test Fixtures
 
 ```typescript
+// Types are defined in LinearAdapterTypes.ts and re-exported from LinearAdapter.ts
+import type { LinearIssue } from './LinearAdapterTypes';
+
 const MOCK_LINEAR_ISSUE: LinearIssue = {
   id: 'linear-uuid-1234',
   identifier: 'ENG-123',
@@ -501,9 +525,11 @@ With 1,500 req/hour limit:
 - **IR-8 to IR-11**: Integration requirements for Linear adapter
 - **Section 3.4**: HTTP Clients & Adapter Responsibilities (Operational Architecture)
 - **Section 3.17.2**: Linear Outage Handling Scenario
+- **CDMCH-161**: Issue ID validation across all public methods
+- **CDMCH-203**: Type extraction to `LinearAdapterTypes.ts`
 
 ---
 
-**Document Version**: 1.0
-**Last Updated**: 2024-01-15
+**Document Version**: 1.1
+**Last Updated**: 2026-03-18
 **Authors**: CodeMachine Pipeline Team

--- a/docs/reference/parallel-execution.md
+++ b/docs/reference/parallel-execution.md
@@ -133,8 +133,7 @@ while (hasRemainingTasks()) {
 **Dependency Detection** (via `executionDependencyResolver.ts`):
 
 The resolver uses a single-pass bucket approach that selects up to `limit` ready
-tasks, excluding any tasks already in-flight. Priority order: running (resumed)
-> pending > retryable.
+tasks, excluding any tasks already in-flight. Priority order: `running (resumed) > pending > retryable`.
 
 ```typescript
 // From executionDependencyResolver.ts — getReadyTasks()
@@ -525,7 +524,7 @@ if (inFlightTasks.size >= maxParallelTasks) {
 **Validation:**
 
 ```bash
-# Monitor in-flight tasks (should never exceed limit)
+# Monitor in-flight tasks (should never exceed configured capacity)
 watch -n 1 "codepipe status --json | jq '.in_progress_count'"
 ```
 

--- a/docs/reference/parallel-execution.md
+++ b/docs/reference/parallel-execution.md
@@ -8,29 +8,31 @@ The parallel execution system enables concurrent task execution with dependency-
 
 ### Core Components
 
-**1. Worker Pool Manager**
+**1. Execution Dependency Resolver** (`executionDependencyResolver.ts`)
 
-- Tracks in-flight tasks via Map structure
-- Enforces concurrency limits (1-10 tasks)
-- Manages worker capacity and availability
+- Extracted from the execution engine (PR #632) for single-responsibility
+- Selects ready tasks using a single-pass bucket approach (O(n))
+- Priority order: running (resumed) > pending > retryable
+- Applies exponential backoff for retries (capped at 60 seconds)
 
-**2. Dependency Graph Analyzer**
+**2. CLI Execution Engine** (`cliExecutionEngine.ts`)
 
-- Detects task dependencies from execution plan
-- Ensures prerequisites complete before dependent tasks
-- Prevents circular dependencies
+- Orchestrates task dispatch with bounded parallelism via `max_parallel_tasks`
+- Delegates ready-task selection to the dependency resolver
+- Tracks in-flight tasks via `Map<string, Promise<TaskOutcome>>`
+- Handles dry-run mode, graceful stop, and telemetry recording
 
-**3. Task Scheduler**
+**3. Execution Lock Manager** (extracted to `persistence/` layer)
 
-- Selects ready tasks (dependencies met, resources available)
-- Dispatches tasks to available workers
-- Handles task completion and failure
+- File-based locking via `withLock()` for concurrent queue access
+- Prevents race conditions on shared queue state
+- Used by queue task manager for atomic updates
 
 **4. Coordination Layer**
 
-- Synchronizes queue updates across workers
-- Prevents race conditions on shared state
+- Synchronizes queue updates across workers via WAL-based queue
 - Maintains ACID guarantees for task transitions
+- Telemetry recording via `ExecutionTelemetryRecorder`
 
 ## Configuration
 
@@ -68,9 +70,21 @@ export CODEPIPE_EXECUTION_TIMEOUT_MS=300000
 
 > **Note:** The `CODEPIPE_MAX_PARALLEL_TASKS`, `CODEPIPE_TASK_TIMEOUT_MS`, and `CODEPIPE_ENABLE_PARALLEL_EXECUTION` names shown in earlier drafts of this guide are not implemented. Use `CODEPIPE_RUNTIME_MAX_CONCURRENT_TASKS` and `CODEPIPE_EXECUTION_TIMEOUT_MS` instead, or set the values in the `execution` section of `.codepipe/config.json`.
 
-### Runtime Override
+### CLI Flag Override
 
-Override parallelism at command execution:
+The `start` and `resume` commands accept a `--max-parallel` flag to override parallelism at invocation:
+
+```bash
+# Force sequential execution
+codepipe start --prompt "my feature" --max-parallel 1
+
+# Enable high parallelism
+codepipe resume --max-parallel 8
+```
+
+### Environment Variable Override
+
+Override parallelism via environment variable:
 
 ```bash
 # Force sequential execution
@@ -116,23 +130,29 @@ while (hasRemainingTasks()) {
 
 ### Dependency Resolution
 
-**Dependency Detection:**
+**Dependency Detection** (via `executionDependencyResolver.ts`):
+
+The resolver uses a single-pass bucket approach that selects up to `limit` ready
+tasks, excluding any tasks already in-flight. Priority order: running (resumed)
+> pending > retryable.
 
 ```typescript
-// Task A depends on Task B if:
-// 1. Task A explicitly lists Task B in dependencies array
-// 2. Task A modifies files produced by Task B
-// 3. Task A is sequenced after Task B in execution plan
+// From executionDependencyResolver.ts — getReadyTasks()
+// Single pass: bucket tasks by priority
+const running: ExecutionTask[] = [];
+const pending: ExecutionTask[] = [];
+const retryable: ExecutionTask[] = [];
 
-function areDependenciesCompleted(task: ExecutionTask): boolean {
-  for (const depId of task.dependencies) {
-    const depTask = queue.getTask(depId);
-    if (depTask.status !== 'completed') {
-      return false;
-    }
-  }
-  return true;
+for (const task of tasks.values()) {
+  if (inFlight.has(task.task_id)) continue;
+  if (!areDependenciesCompleted(task, tasks)) continue;
+
+  if (task.status === 'running') running.push(task);
+  else if (task.status === 'pending') pending.push(task);
+  else if (canRetry(task)) retryable.push(task);
 }
+
+return [...running, ...pending, ...retryable].slice(0, limit);
 ```
 
 **Dependency Chain Example:**
@@ -152,30 +172,31 @@ Execution with max_parallel_tasks=2:
   t=20s: test-004 (waiting for code-003)
 ```
 
-### Worker Pool Management
+### Task Dispatch and Capacity Management
 
-**Worker Lifecycle:**
+**Task Lifecycle:**
 
-1. **Idle**: Worker available, waiting for task assignment
-2. **Running**: Worker executing task, in-flight
-3. **Completing**: Task finished, cleanup in progress
-4. **Failed**: Task failed, retry or move to next task
+1. **Pending**: Task waiting for dependencies and capacity
+2. **Running**: Task dispatched and in-flight
+3. **Completed**: Task finished successfully, artifacts captured
+4. **Failed**: Task failed; re-enqueued as pending if retries remain, otherwise permanently failed
 
-**Capacity Management:**
+**Capacity Management** (via `CLIExecutionEngine.fillTaskBatch()`):
 
 ```typescript
 // Track in-flight tasks
-const inFlightTasks = new Map<string, Promise<RunnerResult>>();
+const inFlight = new Map<string, Promise<TaskOutcome>>();
 
-// Enforce concurrency limit
-if (inFlightTasks.size >= maxParallelTasks) {
-  // Wait for capacity
-  await Promise.race(inFlightTasks.values());
+// Fill batch up to available capacity
+const capacity = maxParallelTasks - inFlight.size;
+const readyTasks = await getReadyTasks(runDir, new Set(inFlight.keys()), capacity);
+for (const task of readyTasks) {
+  inFlight.set(task.task_id, runTask(task));
 }
 
-// Dispatch task to available worker
-const promise = executionStrategy.execute(context, task);
-inFlightTasks.set(task.task_id, promise);
+// Wait for at least one task to complete
+const completed = await Promise.race(inFlight.values());
+inFlight.delete(completed.taskId);
 ```
 
 ## Best Practices
@@ -529,8 +550,9 @@ codepipe resume --validate-queue --dry-run
 
 ### Implementation Files
 
-- **Execution Engine**: `src/workflows/cliExecutionEngine.ts:232-391`
-- **Queue Store**: `src/workflows/queueStore.ts`
+- **Dependency Resolver**: `src/workflows/executionDependencyResolver.ts` (ready-task selection, retry backoff)
+- **Execution Engine**: `src/workflows/cliExecutionEngine.ts` (task dispatch, bounded parallelism)
+- **Queue Store**: `src/workflows/queue/queueStore.ts`
 - **Execution Strategy**: `src/workflows/executionStrategy.ts`
 - **Task Model**: `src/core/models/ExecutionTask.ts`
 

--- a/docs/reference/queue-v2-operations.md
+++ b/docs/reference/queue-v2-operations.md
@@ -13,7 +13,7 @@ The V2 queue system is organized in `src/workflows/queue/` with 13 files
 
 | File | Purpose |
 | --- | --- |
-| `index.ts` | Public barrel -- all external consumers import from here |
+| `index.ts` | Public barrel for queue consumers that prefer a stable entry point |
 | `queueStore.ts` | Core store: init, append, snapshot, re-exports |
 | `queueTaskManager.ts` | Task lifecycle: getNext, update, filter by status |
 | `queueV2Api.ts` | High-level V2 API: counts, ready tasks, compaction, export |
@@ -270,7 +270,7 @@ unset CODEPIPE_QUEUE_USE_SNAPSHOTS
 ps aux | grep codepipe
 
 # Step 2: Force cache invalidation
-node -e "require('./src/workflows/queue/queueCache.js').invalidateV2Cache()"
+node -e "require('./src/workflows/queue/queueCache.js').invalidateV2Cache('.codepipe/runs/FEATURE-ID')"
 
 # Step 3: Reduce snapshot retention (env var not yet implemented — manual workaround)
 export CODEPIPE_QUEUE_SNAPSHOT_KEEP=1
@@ -411,5 +411,5 @@ All queue files are in `src/workflows/queue/`:
 ### Related Documentation
 
 - [Execution Telemetry](../playbooks/execution_telemetry.md) - Metrics and observability
-- [Resume Playbook](../playbooks/patch_playbook.md) - Recovery procedures
+- [Resume Playbook](../playbooks/resume_playbook.md) - Recovery procedures
 - [Integration Testing](./integration_testing.md) - Queue validation tests

--- a/docs/reference/queue-v2-operations.md
+++ b/docs/reference/queue-v2-operations.md
@@ -6,56 +6,68 @@ Queue V2 delivers O(1) task operations (previously O(n²)) with 150x-12,500x sea
 
 ## Architecture
 
-The V2 queue system implements a 7-layer architecture for high-performance task management:
+The V2 queue system is organized in `src/workflows/queue/` with 13 files
+(consolidated from a flat layout; backward-compat shims removed in PR #790):
 
-### Layer 1: WAL (Write-Ahead Log)
+### File Layout
 
-- **Purpose**: O(1) append-only operations for task state changes
-- **Implementation**: `queueOperationsLog.ts` - JSONL format for durability
-- **Behavior**: Every task update appends a new operation record
-- **Performance**: Constant time regardless of queue size
+| File | Purpose |
+| --- | --- |
+| `index.ts` | Public barrel -- all external consumers import from here |
+| `queueStore.ts` | Core store: init, append, snapshot, re-exports |
+| `queueTaskManager.ts` | Task lifecycle: getNext, update, filter by status |
+| `queueV2Api.ts` | High-level V2 API: counts, ready tasks, compaction, export |
+| `queueMemoryIndex.ts` | O(1) in-memory HashMap index, dependency-aware ready-task selection |
+| `queueOperationsLog.ts` | WAL (Write-Ahead Log): JSONL append, batch append, replay |
+| `queueSnapshotManager.ts` | Atomic snapshot save/load with SHA-256 checksums |
+| `queueCompactionEngine.ts` | Threshold-based WAL compaction into snapshots |
+| `queueTypes.ts` | Type definitions, Zod schemas, type guards |
+| `queueCache.ts` | V2 index cache management, dependency graph builders, type converters |
+| `queueLoader.ts` | `loadQueue()` / `loadQueueV2()` with integrity verification on cold load |
+| `queueIntegrity.ts` | Integrity verification: snapshot checksums, WAL checksums, sequence continuity |
+| `queueValidation.ts` | JSONL parsing validation and manifest checksum consistency |
 
-### Layer 2: In-Memory Index
+### Layer Model
 
-- **Purpose**: O(1) task lookups by ID
-- **Implementation**: `queueMemoryIndex.ts` - HashMap-based index
-- **Behavior**: Maintains task state, dependency graph, and status counts
-- **Performance**: Instant task retrieval without file I/O
+**Layer 1: WAL (Write-Ahead Log)**
 
-### Layer 3: Snapshot Manager
+- **Implementation**: `queueOperationsLog.ts`
+- O(1) append-only operations for task state changes (JSONL format)
 
-- **Purpose**: Periodic snapshots for fast recovery
-- **Implementation**: Embedded in `queueStore.ts`
-- **Behavior**: Creates checkpoint files to avoid full WAL replay
-- **Performance**: Sub-second recovery for large queues
+**Layer 2: In-Memory Index**
 
-### Layer 4: Compaction Engine
+- **Implementation**: `queueMemoryIndex.ts`
+- O(1) task lookups by ID via HashMap, maintains status counts and dependency graph
 
-- **Purpose**: Threshold-based compaction to manage disk usage
+**Layer 3: Snapshot Manager**
+
+- **Implementation**: `queueSnapshotManager.ts` (extracted from `queueStore.ts`)
+- Atomic write-temp-rename pattern with SHA-256 checksums for fast recovery
+
+**Layer 4: Compaction Engine**
+
 - **Implementation**: `queueCompactionEngine.ts`
-- **Behavior**: Consolidates WAL operations when thresholds are exceeded
-- **Performance**: Automatic cleanup with minimal performance impact
+- Threshold-based compaction to manage disk usage
 
-### Layer 5: Unified API
+**Layer 5: Task Manager**
 
-- **Purpose**: Provides a stable, high-level API for all queue interactions.
-- **Implementation**: `queueStore.ts` - Public API functions
-- **Behavior**: Abstracts the underlying WAL and snapshot mechanism from the caller.
-- **Performance**: Zero overhead operation routing
+- **Implementation**: `queueTaskManager.ts`
+- Task lifecycle: retrieval, filtering, atomic status updates via WAL
 
-### Layer 6: Type System
+**Layer 6: Cache and Loader**
 
-- **Purpose**: Comprehensive Zod validation
-- **Implementation**: `queueTypes.ts` - Type definitions and schemas
-- **Behavior**: Runtime validation of all queue operations
-- **Performance**: Fast validation with schema caching
+- **Implementation**: `queueCache.ts`, `queueLoader.ts`
+- Process-local index cache with lazy hydration; integrity check on cold load
 
-### Layer 7: Performance Monitoring
+**Layer 7: Unified API**
 
-- **Purpose**: Regression detection and benchmarking
-- **Implementation**: `tests/performance/queueStore.perf.spec.ts`
-- **Behavior**: Continuous validation of O(1) guarantees
-- **Performance**: Benchmarks validate <100ms for 1000 tasks
+- **Implementation**: `queueStore.ts` (core), `queueV2Api.ts` (direct V2 access), `index.ts` (barrel)
+- Stable public API abstracting WAL/snapshot internals
+
+**Layer 8: Type System and Validation**
+
+- **Implementation**: `queueTypes.ts`, `queueIntegrity.ts`, `queueValidation.ts`
+- Zod schemas, type guards, runtime validation, integrity verification
 
 ## Configuration
 
@@ -64,11 +76,11 @@ Queue V2 is configured via environment variables and runtime settings:
 ### Compaction Thresholds
 
 ```typescript
-// Default thresholds (can be overridden)
+// Default thresholds (from queueTypes.ts createDefaultCompactionConfig)
 const COMPACTION_THRESHOLDS = {
-  maxOperations: 10000, // Trigger compaction after 10k operations
-  maxBytes: 10485760, // Trigger compaction after 10MB
-  minIntervalMs: 60000, // Minimum 60s between compactions
+  maxUpdates: 1000, // Trigger compaction after 1,000 WAL entries
+  maxBytes: 5242880, // Trigger compaction after 5MB
+  pruneCompleted: false, // Do not prune completed tasks by default
 };
 ```
 
@@ -258,7 +270,7 @@ unset CODEPIPE_QUEUE_USE_SNAPSHOTS
 ps aux | grep codepipe
 
 # Step 2: Force cache invalidation
-node -e "require('./src/workflows/queueStore.js').invalidateV2Cache()"
+node -e "require('./src/workflows/queue/queueCache.js').invalidateV2Cache()"
 
 # Step 3: Reduce snapshot retention (env var not yet implemented — manual workaround)
 export CODEPIPE_QUEUE_SNAPSHOT_KEEP=1
@@ -368,11 +380,21 @@ export CODEPIPE_QUEUE_SNAPSHOT_KEEP=1
 
 ### Implementation Files
 
-- **Core Queue**: `src/workflows/queueStore.ts` (1,690 lines)
-- **WAL Operations**: `src/workflows/queueOperationsLog.ts`
-- **Memory Index**: `src/workflows/queueMemoryIndex.ts`
-- **Compaction**: `src/workflows/queueCompactionEngine.ts`
-- **Type Definitions**: `src/workflows/queueTypes.ts`
+All queue files are in `src/workflows/queue/`:
+
+- **Barrel**: `index.ts` (public API surface)
+- **Core Store**: `queueStore.ts` (init, append, snapshot, re-exports)
+- **Task Manager**: `queueTaskManager.ts` (getNext, update, filter)
+- **V2 API**: `queueV2Api.ts` (counts, ready tasks, compaction, export)
+- **Memory Index**: `queueMemoryIndex.ts` (O(1) lookups, dependency resolution)
+- **WAL Operations**: `queueOperationsLog.ts` (append, batch, replay)
+- **Snapshot Manager**: `queueSnapshotManager.ts` (atomic save/load, checksums)
+- **Compaction**: `queueCompactionEngine.ts` (threshold-based compaction)
+- **Types**: `queueTypes.ts` (interfaces, Zod schemas, type guards)
+- **Cache**: `queueCache.ts` (V2 index cache, dependency graph, converters)
+- **Loader**: `queueLoader.ts` (loadQueue with integrity verification)
+- **Integrity**: `queueIntegrity.ts` (snapshot/WAL checksum, sequence validation)
+- **Validation**: `queueValidation.ts` (JSONL parsing, manifest checksums)
 
 ### Test Files
 

--- a/docs/reference/rate_limit_dashboard.md
+++ b/docs/reference/rate_limit_dashboard.md
@@ -88,7 +88,6 @@ Provider: github
   Remaining: 4850
   Reset: 2025-12-17T15:00:00.000Z (27m 49s)
   Cooldown: Inactive
-  Recent hits: 0
 
 Provider: linear
   Remaining: 8
@@ -96,12 +95,13 @@ Provider: linear
   ⚠ Cooldown: Active until 2025-12-17T14:45:00.000Z (12m 49s)
   ⚠ Manual Acknowledgement Required: 3 consecutive rate limit hits
      Action: Review rate limit strategy and clear cooldown manually when ready
-  Recent hits: 3
 
 Warnings:
   • One or more providers are in cooldown. Consider throttling requests or waiting for reset.
   • One or more providers require manual acknowledgement due to repeated rate limit hits.
     Review your rate limit strategy and use `codepipe rate-limits clear <provider>` when ready.
+
+Note: Use `--verbose` to display recent hit counts, last error details, and last updated timestamps per provider.
 ```
 
 #### JSON Output Schema
@@ -179,7 +179,7 @@ These metrics are emitted by the HTTP client and complement rate limit reporting
 
 ### Metric Collection
 
-Metrics are collected via the `RateLimitReporter.exportMetrics()` method, typically invoked by:
+Metrics are collected via the static `RateLimitReporter.exportMetrics()` method (also exported as `exportRateLimitMetrics()`), typically invoked by:
 
 1. **CLI commands** (`codepipe rate-limits`, `codepipe status`)
 2. **Workflow orchestrator** (periodic snapshots during execution)
@@ -191,7 +191,7 @@ Metrics are collected via the `RateLimitReporter.exportMetrics()` method, typica
 import { createRunMetricsCollector } from './telemetry/metrics';
 import { exportRateLimitMetrics } from './telemetry/rateLimitReporter';
 
-const metrics = createRunMetricsCollector(runDir, featureId);
+const metrics = createRunMetricsCollector(runDir, runId);
 await exportRateLimitMetrics(runDir, metrics);
 await metrics.flush(); // Writes to metrics/prometheus.txt
 ```
@@ -500,7 +500,7 @@ Warnings:
 
 **Implementation Notes:**
 
-- Status command reads `rate_limits.json` via `generateRateLimitReport()`
+- Status command reads `rate_limits.json` via `RateLimitReporter.generateReport()` (also exported as `generateRateLimitReport()`)
 - Displays condensed summary in human mode, full details in `--verbose`
 - JSON mode includes `rate_limits` field with structured data
 

--- a/docs/reference/rate_limit_dashboard.md
+++ b/docs/reference/rate_limit_dashboard.md
@@ -191,7 +191,7 @@ Metrics are collected via the static `RateLimitReporter.exportMetrics()` method 
 import { createRunMetricsCollector } from './telemetry/metrics';
 import { exportRateLimitMetrics } from './telemetry/rateLimitReporter';
 
-const metrics = createRunMetricsCollector(runDir, runId);
+const metrics = createRunMetricsCollector(runDir, featureId);
 await exportRateLimitMetrics(runDir, metrics);
 await metrics.flush(); // Writes to metrics/prometheus.txt
 ```

--- a/src/adapters/README.md
+++ b/src/adapters/README.md
@@ -24,7 +24,7 @@ From the barrel (`index.ts`):
 ### Agents
 
 - `AgentAdapter` / `createAgentAdapter` — LLM agent provider orchestration
-- `ManifestLoader` / `createManifestLoader` — agent manifest loading and validation
+- `ManifestLoader` / `createManifestLoader` — agent manifest loading and validation (factory wrappers; direct constructor use is equally valid)
 - Types: `AgentManifest`, `AgentSessionRequest`, `AgentSessionResponse`, `ProviderRequirements`, etc.
 
 ### HTTP

--- a/src/adapters/README.md
+++ b/src/adapters/README.md
@@ -1,0 +1,55 @@
+# Adapters
+
+External service integration boundary. Provides typed adapters for GitHub, Linear,
+HTTP, agent providers, and the CodeMachine CLI binary. Higher layers never make
+raw API calls — all external communication goes through adapters.
+
+## Key Exports
+
+From the barrel (`index.ts`):
+
+### GitHub
+
+- `GitHubAdapter` / `createGitHubAdapter` — GitHub API integration (repos, branches, PRs, workflows)
+- `BranchProtectionAdapter` — branch protection rule management
+- `GitHubAdapterError`, `BranchProtectionError` — error classes
+- Types: `GitHubAdapterConfig`, `RepositoryInfo`, `CreateBranchParams`, `PullRequest`, `StatusCheck`, `MergeResult`, etc.
+
+### Linear
+
+- `LinearAdapter` — Linear issue tracking integration
+- `LinearAdapterError` — error class
+- Types: `LinearAdapterConfig`, `IssueSnapshot`, `LinearIssue`, `LinearComment`, `UpdateIssueParams`, etc.
+
+### Agents
+
+- `AgentAdapter` / `createAgentAdapter` — LLM agent provider orchestration
+- `ManifestLoader` / `createManifestLoader` — agent manifest loading and validation
+- Types: `AgentManifest`, `AgentSessionRequest`, `AgentSessionResponse`, `ProviderRequirements`, etc.
+
+### HTTP
+
+- `HttpClient` — rate-limit-aware HTTP client with retries
+- `HttpError` — typed HTTP error with error taxonomy
+- `ErrorType`, `Provider` — enums for error classification and provider identification
+
+### CodeMachine CLI
+
+- `CodeMachineCLIAdapter` — wraps the CodeMachine binary for CLI-based execution
+- `resolveBinary` / `clearBinaryCache` — binary resolution and caching
+- Types: `AvailabilityResult`, `BinaryResolutionResult`, `CodeMachineExecutionResult`
+
+## Structure
+
+- `github/` — GitHub API adapter and branch protection
+- `linear/` — Linear API adapter and types
+- `agents/` — agent provider adapter and manifest loader
+- `http/` — generic HTTP client
+- `codemachine/` — CodeMachine CLI binary adapter
+- `index.ts` — barrel re-exports
+
+## Dependencies
+
+Imports from: `core`, `utils`, `validation`, `telemetry`
+
+Depended on by: `cli`, `workflows`

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -31,10 +31,12 @@ Status dashboard rendering and data loading:
 
 - `types.ts` — `StatusPayload` and sub-payload interfaces (machine-readable API contract)
 - `renderers.ts` — human-readable status output formatting
-- `data/` — 10 data-loading functions that populate status payloads:
+- `data/` — data-loading functions that populate status payloads:
   - `planData.ts`, `branchData.ts`, `telemetryData.ts`, `validationData.ts`,
     `integrationsData.ts`, `rateLimitsData.ts`, `prMetadataData.ts`,
-    `researchData.ts`, `branchRefreshData.ts`, `types.ts`
+    `researchData.ts`, `branchRefreshData.ts`
+  - `types.ts` — shared types (`DataLogger` interface)
+  - `index.ts` — barrel re-exports
 
 ### PR (`pr/`)
 

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -1,0 +1,58 @@
+# CLI
+
+oclif-based command-line interface for codemachine-pipeline. Defines all user-facing
+commands, status rendering, PR workflows, and CLI-specific utilities.
+
+## Key Exports
+
+The barrel (`index.ts`) re-exports only `run` from `@oclif/core`. Individual
+commands are loaded by oclif's convention-based discovery, not barrel-exported.
+
+## Structure
+
+### Commands (`commands/`)
+
+oclif command classes discovered by convention:
+
+- `init.ts` — initialize a new pipeline run
+- `start.ts` — execute the pipeline (exit codes: 0=success, 1=failed, 30=approval required)
+- `resume.ts` — resume an interrupted run
+- `approve.ts` — approve a pending gate
+- `status.ts` — show run status (supports `--json` for machine-readable output)
+- `doctor.ts` — diagnostic health checks
+- `pr/` — PR-related subcommands
+- `research/` — research subcommands
+- `context/` — context management subcommands
+- `status/` — status subcommands
+
+### Status (`status/`)
+
+Status dashboard rendering and data loading:
+
+- `types.ts` — `StatusPayload` and sub-payload interfaces (machine-readable API contract)
+- `renderers.ts` — human-readable status output formatting
+- `data/` — 10 data-loading functions that populate status payloads:
+  - `planData.ts`, `branchData.ts`, `telemetryData.ts`, `validationData.ts`,
+    `integrationsData.ts`, `rateLimitsData.ts`, `prMetadataData.ts`,
+    `researchData.ts`, `branchRefreshData.ts`, `types.ts`
+
+### PR (`pr/`)
+
+Pull request workflow helpers.
+
+### Utilities
+
+- `startHelpers.ts` — start command helper functions
+- `startOutput.ts` — start command output formatting
+- `resumePayloadBuilder.ts` — builds resume payloads
+- `resumeOutput.ts` — resume output formatting
+- `resumeTypes.ts` — resume-specific types
+- `telemetryCommand.ts` — base command class with telemetry
+- `diagnostics.ts` — diagnostic utilities
+- `utils/` — shared CLI utilities
+
+## Dependencies
+
+Imports from: `core`, `adapters`, `persistence`, `telemetry`, `workflows`, `utils`
+
+Depended on by: (top layer — nothing imports `cli`)

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -18,8 +18,11 @@ oclif command classes discovered by convention:
 - `start.ts` — execute the pipeline (exit codes: 0=success, 1=failed, 30=approval required)
 - `resume.ts` — resume an interrupted run
 - `approve.ts` — approve a pending gate
-- `status.ts` — show run status (supports `--json` for machine-readable output)
 - `doctor.ts` — diagnostic health checks
+- `health.ts` — health check command for automation and readiness probes
+- `plan.ts` — create or inspect persisted execution plans
+- `rate-limits.ts` — inspect and clear provider rate limit state
+- `validate.ts` — run repository validation commands
 - `pr/` — PR-related subcommands
 - `research/` — research subcommands
 - `context/` — context management subcommands

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -33,6 +33,7 @@ import { PipelineOrchestrator, PrerequisiteError } from '../../workflows/pipelin
 import { emitStartSummary, outputDryRunPlan, type StartResultPayload } from '../startOutput.js';
 import type { RepoConfig } from '../../core/config/RepoConfig';
 
+/** Input shape for computing the start command exit code */
 type StartExitCodeInput = {
   approvalRequired: boolean;
   execution?:
@@ -43,6 +44,17 @@ type StartExitCodeInput = {
     | undefined;
 };
 
+/**
+ * Compute the exit code for the start command.
+ *
+ * Exit code semantics:
+ * - 0: all tasks completed successfully
+ * - 1: one or more tasks failed
+ * - 30: approval gate requires human intervention (non-standard)
+ *
+ * @param result - Execution result with approval and failure state
+ * @returns Numeric exit code
+ */
 export function getStartExitCode(result: StartExitCodeInput): number {
   if (result.approvalRequired) {
     return 30;

--- a/src/cli/status/data/branchData.ts
+++ b/src/cli/status/data/branchData.ts
@@ -10,11 +10,12 @@ import type { DataLogger } from './types';
  *
  * Reads the persisted branch protection report, generates a summary
  * (blockers, review status, auto-merge), and attaches any validation
- * mismatch data. Returns undefined when no report exists or on ENOENT.
+ * mismatch data. Returns undefined when no report exists or when loading fails
+ * after logging any unexpected file error.
  *
  * @param baseDir - Project base directory.
  * @param featureId - Feature branch identifier.
- * @param logger - Optional logger for non-ENOENT errors.
+ * @param logger - Optional logger for unexpected file errors.
  */
 export async function loadBranchProtectionStatus(
   baseDir: string,

--- a/src/cli/status/data/branchData.ts
+++ b/src/cli/status/data/branchData.ts
@@ -5,6 +5,17 @@ import type { StatusBranchProtectionPayload } from '../types';
 import { logIfUnexpectedFileError } from './types';
 import type { DataLogger } from './types';
 
+/**
+ * Load branch protection compliance status for a feature run.
+ *
+ * Reads the persisted branch protection report, generates a summary
+ * (blockers, review status, auto-merge), and attaches any validation
+ * mismatch data. Returns undefined when no report exists or on ENOENT.
+ *
+ * @param baseDir - Project base directory.
+ * @param featureId - Feature branch identifier.
+ * @param logger - Optional logger for non-ENOENT errors.
+ */
 export async function loadBranchProtectionStatus(
   baseDir: string,
   featureId: string,

--- a/src/cli/status/data/integrationsData.ts
+++ b/src/cli/status/data/integrationsData.ts
@@ -169,6 +169,17 @@ async function loadLinearIntegration(
   }
 }
 
+/**
+ * Load GitHub and/or Linear integration status based on enabled adapters.
+ *
+ * Loads rate-limit data, PR metadata (GitHub), and issue status (Linear) in
+ * parallel when both adapters are enabled. Returns undefined when no
+ * integrations are configured.
+ *
+ * @param settings - Run directory settings including adapter configuration.
+ * @param featureId - Feature branch identifier.
+ * @param logger - Optional logger for load errors.
+ */
 export async function loadIntegrationsStatus(
   settings: RunDirectorySettings,
   featureId: string,

--- a/src/cli/status/data/planData.ts
+++ b/src/cli/status/data/planData.ts
@@ -14,6 +14,13 @@ import {
 import { logIfUnexpectedFileError } from './types';
 import type { DataLogger } from './types';
 
+/**
+ * Read and parse the run manifest for a feature from disk.
+ *
+ * @param baseDir - Project base directory containing `.codepipe/`.
+ * @param featureId - Feature branch identifier.
+ * @returns The parsed manifest and its path, or an error message on failure.
+ */
 export async function loadManifestSnapshot(
   baseDir: string,
   featureId: string
@@ -32,6 +39,18 @@ export async function loadManifestSnapshot(
   }
 }
 
+/**
+ * Load the run manifest, optionally recording a trace span.
+ *
+ * When both a trace manager and parent span are provided, the manifest load is
+ * wrapped in a `status.load_manifest` span with feature and error attributes.
+ * Otherwise falls back to {@link loadManifestSnapshot}.
+ *
+ * @param traceManager - Optional OpenTelemetry-compatible trace manager.
+ * @param parentSpan - Optional parent span for context propagation.
+ * @param baseDir - Project base directory.
+ * @param featureId - Feature branch identifier.
+ */
 export function loadManifestWithTracing(
   traceManager: TraceManager | undefined,
   parentSpan: ActiveSpan | undefined,
@@ -59,6 +78,16 @@ export function loadManifestWithTracing(
   return loadManifestSnapshot(baseDir, featureId);
 }
 
+/**
+ * Load traceability link coverage for a feature run.
+ *
+ * Returns undefined if no trace summary exists or if an unexpected error
+ * occurs (ENOENT is silently ignored).
+ *
+ * @param baseDir - Project base directory.
+ * @param featureId - Feature branch identifier.
+ * @param logger - Optional logger for non-ENOENT errors.
+ */
 export async function loadTraceabilityStatus(
   baseDir: string,
   featureId: string,
@@ -91,6 +120,16 @@ export async function loadTraceabilityStatus(
   }
 }
 
+/**
+ * Load the execution plan summary and DAG metadata for a feature run.
+ *
+ * Returns a payload with `plan_exists: false` when no plan file is found or
+ * when an unexpected read error occurs.
+ *
+ * @param baseDir - Project base directory.
+ * @param featureId - Feature branch identifier.
+ * @param logger - Optional logger for non-ENOENT errors.
+ */
 export async function loadPlanStatus(
   baseDir: string,
   featureId: string,

--- a/src/cli/status/data/prMetadataData.ts
+++ b/src/cli/status/data/prMetadataData.ts
@@ -6,8 +6,9 @@ import type { PRMetadata } from '../../pr/shared';
 /**
  * Load pull-request metadata from `pr.json` in the run directory.
  *
- * Returns null when the file does not exist (ENOENT). Throws on any other
- * read error so the caller can decide how to handle it.
+ * Returns null when the file does not exist (ENOENT) or when `pr.json`
+ * contains malformed JSON. Throws on any other read error so the caller can
+ * decide how to handle it.
  *
  * @param runDir - Absolute path to the feature's run directory.
  */

--- a/src/cli/status/data/prMetadataData.ts
+++ b/src/cli/status/data/prMetadataData.ts
@@ -3,6 +3,14 @@ import { join } from 'node:path';
 import { safeJsonParse } from '../../../utils/safeJson';
 import type { PRMetadata } from '../../pr/shared';
 
+/**
+ * Load pull-request metadata from `pr.json` in the run directory.
+ *
+ * Returns null when the file does not exist (ENOENT). Throws on any other
+ * read error so the caller can decide how to handle it.
+ *
+ * @param runDir - Absolute path to the feature's run directory.
+ */
 export async function loadPRMetadata(runDir: string): Promise<PRMetadata | null> {
   const prPath = join(runDir, 'pr.json');
   try {

--- a/src/cli/status/data/rateLimitsData.ts
+++ b/src/cli/status/data/rateLimitsData.ts
@@ -3,6 +3,17 @@ import { RateLimitReporter } from '../../../telemetry/rateLimitReporter';
 import type { StatusRateLimitsPayload } from '../types';
 import type { DataLogger } from './types';
 
+/**
+ * Load the API rate-limit ledger for all providers in a feature run.
+ *
+ * Generates a report via {@link RateLimitReporter}, maps each provider's
+ * state into the status payload format, and assembles cooldown/ack warnings.
+ * Returns undefined when no rate-limit data has been recorded yet.
+ *
+ * @param baseDir - Project base directory.
+ * @param featureId - Feature branch identifier.
+ * @param logger - Optional logger for non-ENOENT errors.
+ */
 export async function loadRateLimitsStatus(
   baseDir: string,
   featureId: string,

--- a/src/cli/status/data/researchData.ts
+++ b/src/cli/status/data/researchData.ts
@@ -19,6 +19,20 @@ function isStructuredLogger(logger: DataLogger | undefined): logger is Structure
   );
 }
 
+/**
+ * Load research task tracking status for a feature run.
+ *
+ * Checks for a `research/` directory, instantiates a research coordinator,
+ * and collects diagnostics (task counts by state) plus stale-task detection.
+ * Returns undefined when the research directory does not exist. Falls back
+ * to a zero-count payload with a warning when telemetry dependencies
+ * (StructuredLogger, MetricsCollector) are unavailable.
+ *
+ * @param baseDir - Project base directory.
+ * @param featureId - Feature branch identifier.
+ * @param logger - Optional logger; must be a full StructuredLogger for coordinator use.
+ * @param metrics - Optional metrics collector for the research coordinator.
+ */
 export async function loadResearchStatus(
   baseDir: string,
   featureId: string,

--- a/src/cli/status/data/telemetryData.ts
+++ b/src/cli/status/data/telemetryData.ts
@@ -7,6 +7,17 @@ import { truncateSummary } from '../renderers';
 import type { StatusContextPayload } from '../types';
 import type { DataLogger } from './types';
 
+/**
+ * Enrich a context payload with summarization metadata from `summarization.json`.
+ *
+ * Reads chunk generation counts, cache hits, and token usage from the
+ * context directory and merges them into the payload. ENOENT is silently
+ * ignored (the file may not exist yet).
+ *
+ * @param payload - Context payload to mutate in place.
+ * @param contextDir - Absolute path to the run's `context/` directory.
+ * @param logger - Optional logger for non-ENOENT read errors.
+ */
 export async function attachSummarizationMetadata(
   payload: StatusContextPayload,
   contextDir: string,
@@ -55,6 +66,17 @@ export async function attachSummarizationMetadata(
   }
 }
 
+/**
+ * Enrich a context payload with cost telemetry from `telemetry/costs.json`.
+ *
+ * Reads aggregated token counts and USD cost, then merges them into
+ * `payload.summarization`. Budget warnings are placed in
+ * `payload.budget_warnings`. ENOENT is silently ignored.
+ *
+ * @param payload - Context payload to mutate in place.
+ * @param runDir - Absolute path to the feature's run directory.
+ * @param logger - Optional logger for non-ENOENT read errors.
+ */
 export async function attachCostTelemetry(
   payload: StatusContextPayload,
   runDir: string,
@@ -112,6 +134,17 @@ export async function attachCostTelemetry(
   }
 }
 
+/**
+ * Load the full context-window status for a feature run.
+ *
+ * Reads `context/summary.json`, parses it as a ContextDocument, then enriches
+ * the result with summarization metadata and cost telemetry. Returns undefined
+ * when no context summary file exists.
+ *
+ * @param baseDir - Project base directory.
+ * @param featureId - Feature branch identifier.
+ * @param logger - Optional logger for non-ENOENT errors.
+ */
 export async function loadContextStatus(
   baseDir: string,
   featureId: string,

--- a/src/cli/status/data/telemetryData.ts
+++ b/src/cli/status/data/telemetryData.ts
@@ -70,7 +70,9 @@ export async function attachSummarizationMetadata(
  * Enrich a context payload with cost telemetry from `telemetry/costs.json`.
  *
  * Reads aggregated token counts and USD cost, then merges them into
- * `payload.summarization`. Budget warnings are placed in
+ * `payload.summarization`. If `tokens_used` was previously populated from
+ * summarization metadata, the aggregated cost telemetry values replace it.
+ * Budget warnings are placed in
  * `payload.budget_warnings`. ENOENT is silently ignored.
  *
  * @param payload - Context payload to mutate in place.
@@ -139,7 +141,8 @@ export async function attachCostTelemetry(
  *
  * Reads `context/summary.json`, parses it as a ContextDocument, then enriches
  * the result with summarization metadata and cost telemetry. Returns undefined
- * when no context summary file exists.
+ * when no context summary file exists, or `{ error: string }` when the file
+ * cannot be read or parsed.
  *
  * @param baseDir - Project base directory.
  * @param featureId - Feature branch identifier.

--- a/src/cli/status/data/validationData.ts
+++ b/src/cli/status/data/validationData.ts
@@ -83,11 +83,12 @@ async function readPlanValidation(
  *
  * Reads `queue_validation.json` and `plan_validation.json` in parallel,
  * combines their pass/fail status and any integrity warnings. Returns
- * undefined when neither validation file exists.
+ * undefined when neither validation file produces a readable validation result,
+ * including missing, unreadable, or malformed files.
  *
  * @param baseDir - Project base directory.
  * @param featureId - Feature branch identifier.
- * @param logger - Optional logger for non-ENOENT errors.
+ * @param logger - Optional logger for unexpected validation file read errors.
  */
 export async function loadValidationStatus(
   baseDir: string,

--- a/src/cli/status/data/validationData.ts
+++ b/src/cli/status/data/validationData.ts
@@ -78,6 +78,17 @@ async function readPlanValidation(
   }
 }
 
+/**
+ * Load queue and plan validation results for a feature run.
+ *
+ * Reads `queue_validation.json` and `plan_validation.json` in parallel,
+ * combines their pass/fail status and any integrity warnings. Returns
+ * undefined when neither validation file exists.
+ *
+ * @param baseDir - Project base directory.
+ * @param featureId - Feature branch identifier.
+ * @param logger - Optional logger for non-ENOENT errors.
+ */
 export async function loadValidationStatus(
   baseDir: string,
   featureId: string,

--- a/src/cli/status/renderers.ts
+++ b/src/cli/status/renderers.ts
@@ -1,10 +1,33 @@
+/**
+ * Human-readable renderers for the status dashboard.
+ *
+ * Converts a {@link StatusPayload} into formatted terminal output, section by
+ * section. Used by `codepipe status` when `--json` is not set.
+ *
+ * @module
+ */
+
 import type { StatusPayload, StatusFlags, StatusBranchProtectionPayload } from './types';
 
+/** Callbacks for emitting output lines and warnings. */
 export interface RenderCallbacks {
+  /** Write an informational line to stdout. */
   log: (msg: string) => void;
+  /** Write a warning line to stderr or a highlighted stream. */
   warn: (msg: string) => void;
 }
 
+/**
+ * Render the full status dashboard as human-readable terminal output.
+ *
+ * Iterates through every section (header, queue, approvals, context, plan,
+ * validation, traceability, branch protection, rate limits, integrations,
+ * research, footer) and writes formatted lines via the provided callbacks.
+ *
+ * @param payload - Fully assembled status data.
+ * @param flags - CLI flags controlling verbosity and cost display.
+ * @param callbacks - Output callbacks for log and warn lines.
+ */
 export function renderHumanReadable(
   payload: StatusPayload,
   flags: StatusFlags,
@@ -451,6 +474,13 @@ function renderBranchProtection(
   }
 }
 
+/**
+ * Truncate a summary string, appending an ellipsis if it exceeds the limit.
+ *
+ * @param summary - The full summary text.
+ * @param maxLength - Maximum character length (default 240).
+ * @returns The original string if within the limit, or a truncated version.
+ */
 export function truncateSummary(summary: string, maxLength = 240): string {
   if (summary.length <= maxLength) {
     return summary;

--- a/src/cli/status/types.ts
+++ b/src/cli/status/types.ts
@@ -1,196 +1,357 @@
+/**
+ * Status dashboard types.
+ *
+ * These interfaces define the JSON contract emitted by `codepipe status --json`.
+ * Every property is documented so consumers can rely on the schema without
+ * reading source code.
+ *
+ * @module
+ */
+
 export type { RunManifest } from '../../persistence/manifestManager';
 export type { ValidationMismatch } from '../../workflows/branchProtectionReporter';
 
+/** Default manifest filename within a run directory. */
 export const MANIFEST_FILE = 'manifest.json';
+/** Path to the run-directory schema documentation. */
 export const MANIFEST_SCHEMA_DOC = 'docs/reference/run_directory_schema.md';
+/** Path to the default manifest template. */
 export const MANIFEST_TEMPLATE = '.codepipe/templates/run_manifest.json';
 
+/** CLI flags parsed from `codepipe status` invocation. */
 export type StatusFlags = {
+  /** Feature branch identifier to inspect (auto-detected when omitted). */
   feature?: string;
+  /** Emit machine-readable JSON instead of human-readable text. */
   json: boolean;
+  /** Include verbose details (checksums, timestamps, preview data). */
   verbose: boolean;
+  /** Include cost/telemetry section in output. */
   'show-costs': boolean;
 };
 
+/** Result of attempting to read a run manifest from disk. */
 export interface ManifestLoadResult {
+  /** Parsed manifest, present only when the read succeeded. */
   manifest?: import('../../persistence/manifestManager').RunManifest;
+  /** Absolute path where the manifest was expected. */
   manifestPath: string;
+  /** Human-readable error message when the manifest could not be loaded. */
   error?: string;
 }
 
+/** Top-level JSON payload returned by `codepipe status --json`. */
 export interface StatusPayload {
+  /** Feature branch identifier, or null when not detected. */
   feature_id: string | null;
+  /** Human-readable title from the manifest or issue tracker. */
   title?: string;
+  /** Origin of the feature (e.g. "linear", "github"). */
   source?: string;
+  /** Current pipeline status from the manifest, or "unknown" if unreadable. */
   status: import('../../persistence/manifestManager').RunManifest['status'] | 'unknown';
+  /** Absolute path to the run manifest file. */
   manifest_path: string;
+  /** Relative path to the run-directory schema documentation. */
   manifest_schema_doc: string;
+  /** Relative path to the manifest template file. */
   manifest_template: string;
+  /** Name of the last completed pipeline step, or null. */
   last_step: string | null;
+  /** Details of the last recorded error, or null if none. */
   last_error:
     | import('../../persistence/manifestManager').RunManifest['execution']['last_error']
     | null;
+  /** Task queue state (pending/completed/failed counts), or null. */
   queue: import('../../persistence/manifestManager').RunManifest['queue'] | null;
+  /** Approval gate state (pending/completed gates), or null. */
   approvals: import('../../persistence/manifestManager').RunManifest['approvals'] | null;
+  /** Telemetry metadata (costs file path, etc.), or null. */
   telemetry: import('../../persistence/manifestManager').RunManifest['telemetry'] | null;
+  /** Pipeline lifecycle timestamps, or null. */
   timestamps: import('../../persistence/manifestManager').RunManifest['timestamps'] | null;
+  /** Path to the configuration file used for this run. */
   config_reference: string;
+  /** Configuration validation errors. */
   config_errors: string[];
+  /** Configuration validation warnings. */
   config_warnings: string[];
+  /** Advisory notes displayed in the footer. */
   notes: string[];
+  /** Error message when the manifest file could not be read. */
   manifest_error?: string;
+  /** Context-window summary (files, tokens, summaries). */
   context?: StatusContextPayload;
+  /** Traceability link coverage (PRD -> spec -> tasks). */
   traceability?: StatusTraceabilityPayload;
+  /** Execution plan DAG summary. */
   plan?: StatusPlanPayload;
+  /** Queue and plan validation results. */
   validation?: StatusValidationPayload;
+  /** Branch protection compliance status. */
   branch_protection?: StatusBranchProtectionPayload;
+  /** GitHub and Linear integration status. */
   integrations?: StatusIntegrationsPayload;
+  /** API rate-limit ledger across all providers. */
   rate_limits?: StatusRateLimitsPayload;
+  /** Research task tracking summary. */
   research?: StatusResearchPayload;
 }
 
+/** Context-window statistics and summarization metadata. */
 export interface StatusContextPayload {
+  /** Number of files included in the context window. */
   files?: number;
+  /** Total token count across all context files. */
   total_tokens?: number;
+  /** Number of chunk summaries generated. */
   summaries?: number;
+  /** Preview of the first few summaries (up to 5, truncated). */
   summaries_preview?: Array<{
+    /** Relative path of the summarized file. */
     file_path: string;
+    /** Unique identifier for the summary chunk. */
     chunk_id: string;
+    /** ISO-8601 timestamp when the summary was generated. */
     generated_at: string;
+    /** Truncated summary text. */
     summary: string;
   }>;
+  /** Summarization run metadata (tokens, cost, cache stats). */
   summarization?: {
+    /** ISO-8601 timestamp of the last summarization run. */
     updated_at?: string;
+    /** Number of summary chunks newly generated. */
     chunks_generated?: number;
+    /** Number of summary chunks served from cache. */
     chunks_cached?: number;
+    /** Token usage breakdown for the summarization step. */
     tokens_used?: {
+      /** Prompt tokens consumed. */
       prompt?: number;
+      /** Completion tokens consumed. */
       completion?: number;
+      /** Combined prompt + completion tokens. */
       total?: number;
     };
+    /** Estimated cost in USD for the summarization step. */
     cost_usd?: number;
   };
+  /** Non-fatal warnings from the summarization process. */
   warnings?: string[];
+  /** Warnings related to token/cost budget limits. */
   budget_warnings?: string[];
+  /** Fatal error message when context data could not be loaded. */
   error?: string;
 }
 
+/** Traceability link coverage across the PRD -> spec -> task chain. */
 export interface StatusTraceabilityPayload {
+  /** Absolute path to the traceability map file. */
   trace_path: string;
+  /** Total number of traceability links recorded. */
   total_links: number;
+  /** Number of PRD goals with at least one link. */
   prd_goals_mapped: number;
+  /** Number of spec requirements with at least one link. */
   spec_requirements_mapped: number;
+  /** Number of execution tasks with at least one link. */
   execution_tasks_mapped: number;
+  /** ISO-8601 timestamp of the last traceability update. */
   last_updated: string;
+  /** Number of unlinked items (gaps in coverage). */
   outstanding_gaps: number;
 }
 
+/** Execution plan (DAG) summary. */
 export interface StatusPlanPayload {
+  /** Absolute path to the plan.json file. */
   plan_path: string;
+  /** Whether a plan file exists on disk. */
   plan_exists: boolean;
+  /** Total number of tasks in the plan. */
   total_tasks?: number;
+  /** Number of entry-point tasks (no dependencies). */
   entry_tasks?: number;
+  /** Number of tasks blocked by unmet dependencies. */
   blocked_tasks?: number;
+  /** Count of tasks grouped by type (e.g. "code", "test"). */
   task_type_breakdown?: Record<string, number>;
+  /** DAG structural metadata. */
   dag_metadata?: {
+    /** Number of independent parallel execution paths. */
     parallel_paths?: number;
+    /** Depth of the longest dependency chain (critical path). */
     critical_path_depth?: number;
+    /** ISO-8601 timestamp when the DAG was generated. */
     generated_at: string;
   };
+  /** SHA-256 checksum of the plan file. */
   checksum?: string;
+  /** ISO-8601 timestamp of the last plan update. */
   last_updated?: string;
 }
 
+/** Queue and plan validation results. */
 export interface StatusValidationPayload {
+  /** Whether any validation data was found on disk. */
   has_validation_data: boolean;
+  /** Whether the task queue passed validation. */
   queue_valid?: boolean;
+  /** Whether the execution plan passed validation. */
   plan_valid?: boolean;
+  /** Integrity warnings from queue or plan validation. */
   integrity_warnings?: string[];
 }
 
+/** Branch protection rule compliance for the target branch. */
 export interface StatusBranchProtectionPayload {
+  /** Whether branch protection rules are enabled. */
   protected: boolean;
+  /** Whether the branch currently satisfies all protection rules. */
   compliant: boolean;
+  /** Number of outstanding blockers preventing merge. */
   blockers_count: number;
+  /** Human-readable descriptions of each blocker. */
   blockers: string[];
+  /** Required status checks that have not yet passed. */
   missing_checks: string[];
+  /** Pull-request review gate status. */
   reviews_status: {
+    /** Number of approving reviews required by the ruleset. */
     required: number;
+    /** Number of approving reviews received so far. */
     completed: number;
+    /** Whether the review requirement is met. */
     satisfied: boolean;
   };
+  /** Branch freshness relative to the base branch. */
   branch_status: {
+    /** Whether the branch includes the latest base-branch commits. */
     up_to_date: boolean;
+    /** Whether the branch is considered stale. */
     stale: boolean;
   };
+  /** Auto-merge configuration for the pull request. */
   auto_merge: {
+    /** Whether auto-merge is permitted by the repository settings. */
     allowed: boolean;
+    /** Whether auto-merge has been enabled on this PR. */
     enabled: boolean;
   };
+  /** ISO-8601 timestamp when branch protection was last evaluated. */
   evaluated_at?: string;
+  /** Mismatch between execution-task validations and required checks. */
   validation_mismatch?: import('../../workflows/branchProtectionReporter').ValidationMismatch;
 }
 
+/** GitHub and Linear integration status. */
 export interface StatusIntegrationsPayload {
+  /** GitHub integration state, present when the GitHub adapter is enabled. */
   github?: {
+    /** Whether the GitHub adapter is configured and active. */
     enabled: boolean;
+    /** Current GitHub API rate-limit snapshot. */
     rate_limit?: {
+      /** Remaining API calls before the limit resets. */
       remaining: number;
+      /** ISO-8601 timestamp when the rate limit resets. */
       reset_at: string;
+      /** Whether requests are currently being throttled. */
       in_cooldown: boolean;
     };
+    /** Associated pull-request status, if one exists. */
     pr_status?: {
+      /** PR number on the repository. */
       number: number;
+      /** PR state (e.g. "open", "closed", "merged"). */
       state: string;
+      /** Whether the PR can be merged, or null if unknown. */
       mergeable: boolean | null;
+      /** URL to the pull request on GitHub. */
       url: string;
     };
+    /** Non-fatal warnings from the GitHub integration. */
     warnings: string[];
   };
+  /** Linear integration state, present when the Linear adapter is enabled. */
   linear?: {
+    /** Whether the Linear adapter is configured and active. */
     enabled: boolean;
+    /** Current Linear API rate-limit snapshot. */
     rate_limit?: {
+      /** Remaining API calls before the limit resets. */
       remaining: number;
+      /** ISO-8601 timestamp when the rate limit resets. */
       reset_at: string;
+      /** Whether requests are currently being throttled. */
       in_cooldown: boolean;
     };
+    /** Associated Linear issue status, if one exists. */
     issue_status?: {
+      /** Linear issue identifier (e.g. "PROJ-123"). */
       identifier: string;
+      /** Current issue state in the Linear workflow. */
       state: string;
+      /** URL to the issue on Linear. */
       url: string;
     };
+    /** Non-fatal warnings from the Linear integration. */
     warnings: string[];
   };
 }
 
+/** API rate-limit ledger across all configured providers. */
 export interface StatusRateLimitsPayload {
+  /** Per-provider rate-limit state keyed by provider name. */
   providers: Record<
     string,
     {
+      /** Remaining API calls before the limit resets. */
       remaining: number;
+      /** ISO-8601 timestamp when the rate limit resets. */
       reset_at: string;
+      /** Whether the provider is currently in cooldown. */
       in_cooldown: boolean;
+      /** Whether a manual acknowledgement is needed to resume. */
       manual_ack_required: boolean;
+      /** Number of consecutive rate-limit hits. */
       recent_hit_count: number;
     }
   >;
+  /** Aggregate summary across all providers. */
   summary: {
+    /** Whether any provider is currently in cooldown. */
     any_in_cooldown: boolean;
+    /** Whether any provider requires manual acknowledgement. */
     any_requires_ack: boolean;
+    /** Count of providers currently in cooldown. */
     providers_in_cooldown: number;
   };
+  /** Human-readable rate-limit warnings. */
   warnings: string[];
 }
 
+/** Research task tracking summary. */
 export interface StatusResearchPayload {
+  /** Total number of research tasks across all states. */
   total_tasks: number;
+  /** Tasks awaiting execution. */
   pending_tasks: number;
+  /** Tasks currently being executed. */
   in_progress_tasks: number;
+  /** Tasks that completed successfully. */
   completed_tasks: number;
+  /** Tasks that terminated with an error. */
   failed_tasks: number;
+  /** Tasks served from a cached result. */
   cached_tasks: number;
+  /** Completed tasks whose cached results have expired. */
   stale_tasks: number;
+  /** Absolute path to the research output directory. */
   research_dir: string;
+  /** Absolute path to the JSONL task snapshot file. */
   tasks_file: string;
+  /** Non-fatal warnings from the research coordinator. */
   warnings: string[];
 }

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -49,6 +49,8 @@ Zod-validated domain model schemas, re-exported via 5 sub-barrels:
 
 ## Dependencies
 
-Imports from: `utils`, `validation`
+Imports from: `utils`
+
+Note: `core/validation/` is an internal subdirectory, not the top-level `src/validation/` module.
 
 Depended on by: `adapters`, `cli`, `persistence`, `telemetry`, `workflows`

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -3,7 +3,9 @@
 Shared domain models, configuration, error types, and validation schemas.
 Provides the foundational type system used across all other modules.
 
-## Key Exports
+## Key Public Files
+
+This module has no barrel `index.ts`. Consumers import files by direct path.
 
 ### Shared Types (`sharedTypes.ts`)
 

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -1,0 +1,54 @@
+# Core
+
+Shared domain models, configuration, error types, and validation schemas.
+Provides the foundational type system used across all other modules.
+
+## Key Exports
+
+### Shared Types (`sharedTypes.ts`)
+
+- `SerializedError` — structured error representation for logging/telemetry
+- `ErrorType` — error taxonomy enum (TRANSIENT, PERMANENT, HUMAN_ACTION_REQUIRED)
+- `Provider` — HTTP provider enum (GITHUB, LINEAR, GRAPHITE, CODEMACHINE, CUSTOM)
+- `CommonLogContext` / `LogContext` — structured logging context types
+- `isSerializedError` — type guard
+
+### Errors (`errors.ts`)
+
+- `HttpError` — core HTTP error class with error taxonomy, redaction, and serialization
+
+### Models (`models/`)
+
+Zod-validated domain model schemas, re-exported via 5 sub-barrels:
+
+- `feature-types` — `Feature`, `RunArtifact`, `PlanArtifact`
+- `task-types` — `ResearchTask`, `Specification`, `ExecutionTask`
+- `artifact-types` — `ContextDocument`, `RateLimitEnvelope`, `ArtifactBundle`, `TraceLink`
+- `deployment-types` — `ApprovalRecord`, `DeploymentRecord`, `BranchProtectionReport`, `PRMetadata`
+- `integration-types` — `IntegrationCredential`, `AgentProviderCapability`, `NotificationEvent`
+
+### Configuration (`config/`)
+
+- `RepoConfig` — repository configuration loading and access
+- `RepoConfigLoader` — config file discovery and parsing
+- `RepoConfigSchema` — Zod schema definition
+- `RepoConfigDefaults` — default configuration values
+- `configConstants` — configuration constants
+
+### Validation (`validation/`)
+
+- `validationCommandConfig.ts` — validation command configuration
+
+## Structure
+
+- `sharedTypes.ts` — shared type definitions and enums
+- `errors.ts` — core error classes
+- `models/` — domain model schemas (5 sub-barrels)
+- `config/` — repository configuration (schema, loader, defaults)
+- `validation/` — validation command config
+
+## Dependencies
+
+Imports from: `utils`, `validation`
+
+Depended on by: `adapters`, `cli`, `persistence`, `telemetry`, `workflows`

--- a/src/core/config/RepoConfigLoader.ts
+++ b/src/core/config/RepoConfigLoader.ts
@@ -22,7 +22,7 @@ import {
 } from './RepoConfigSchema';
 import {
   ALLOW_UNSAFE_CUSTOM_GITHUB_API_BASE_URL_ENV,
-  hasCustomGitHubApiBaseUrl,
+  classifyGitHubApiBaseUrl,
 } from '../../utils/githubApiUrl.js';
 
 /**
@@ -121,9 +121,16 @@ export async function loadRepoConfig(configPath: string): Promise<ValidationResu
       }
     }
 
-    if (
-      config.github.enabled &&
-      hasCustomGitHubApiBaseUrl(config.github.api_base_url) &&
+    const githubApiBaseUrlStatus = config.github.enabled
+      ? classifyGitHubApiBaseUrl(config.github.api_base_url)
+      : 'default';
+
+    if (githubApiBaseUrlStatus === 'invalid') {
+      warnings.push(
+        'github.api_base_url is not a valid URL. Fix the configured value before enabling a custom GitHub API endpoint.'
+      );
+    } else if (
+      githubApiBaseUrlStatus === 'custom' &&
       process.env[ALLOW_UNSAFE_CUSTOM_GITHUB_API_BASE_URL_ENV] !== '1'
     ) {
       warnings.push(

--- a/src/persistence/README.md
+++ b/src/persistence/README.md
@@ -1,0 +1,50 @@
+# Persistence
+
+File-system persistence for run state. Manages run directories, manifest I/O,
+file locks, hash manifests, branch protection storage, and research task caching.
+
+## Key Exports
+
+From the barrel (`index.ts`):
+
+### Lock Management
+
+- `acquireLock` / `releaseLock` / `withLock` / `isLocked` — file-based locking with stale lock detection
+
+### Manifest I/O
+
+- `writeManifest` / `readManifest` / `updateManifest` — run manifest persistence
+- `setLastStep` / `setCurrentStep` / `setLastError` / `clearLastError` — manifest state helpers
+- `getRunState` / `markApprovalRequired` / `markApprovalCompleted` — run state queries
+
+### Run Directory Lifecycle
+
+- `createRunDirectory` / `getRunDirectoryPath` / `getSubdirectoryPath` — directory management
+- `ensureSubdirectories` / `runDirectoryExists` / `listRunDirectories` — directory utilities
+- `generateHashManifest` / `verifyRunDirectoryIntegrity` — integrity verification
+- `registerCleanupHook` / `isEligibleForCleanup` — cleanup lifecycle
+
+### Research Store
+
+- `saveTask` / `loadTask` / `listTaskIds` / `findCachedTask` — research task caching
+- `isCachedTaskFresh` — cache freshness check
+
+### Hash Manifest
+
+- `computeFileHash` / `createHashManifest` / `verifyHashManifest` — file integrity verification
+- `saveHashManifest` / `loadHashManifest` — manifest persistence
+
+## Structure
+
+- `lockManager.ts` — file-based lock acquisition with stale detection
+- `manifestManager.ts` — run manifest read/write/update
+- `runLifecycle.ts` — run directory creation, path resolution, cleanup
+- `researchStore.ts` — research task file storage and caching
+- `hashManifest.ts` — file hash computation and verification
+- `branchProtectionStore.ts` — branch protection report persistence
+
+## Dependencies
+
+Imports from: `core`, `utils`, `validation`
+
+Depended on by: `cli`, `workflows`

--- a/src/telemetry/README.md
+++ b/src/telemetry/README.md
@@ -14,6 +14,7 @@ From the barrel (`index.ts`):
 - `ExecutionTelemetry` / `createExecutionTelemetry` — execution-level telemetry aggregation
 - `createRateLimitLedger` — rate limit tracking ledger
 - `RateLimitReporter` — rate limit dashboard reporting
+- `ExecutionLogWriter` / `createExecutionLogWriter` — execution event log formatting (from `logWriters.ts`)
 
 ## Structure
 

--- a/src/telemetry/README.md
+++ b/src/telemetry/README.md
@@ -1,0 +1,34 @@
+# Telemetry
+
+Structured logging, metrics collection, distributed tracing, cost tracking,
+and rate limit monitoring for the pipeline.
+
+## Key Exports
+
+From the barrel (`index.ts`):
+
+- `createCliLogger` / `StructuredLogger` / `LogLevel` — JSON-line logging with secret redaction
+- `MetricsCollector` / `StandardMetrics` / `MetricType` — typed metrics with labels
+- `TraceManager` / `withSpan` / `SpanKind` / `SpanStatusCode` — distributed tracing
+- `CostTracker` / `loadOrCreateCostTracker` — LLM cost tracking with budget enforcement
+- `ExecutionTelemetry` / `createExecutionTelemetry` — execution-level telemetry aggregation
+- `createRateLimitLedger` — rate limit tracking ledger
+- `RateLimitReporter` — rate limit dashboard reporting
+
+## Structure
+
+- `logger.ts` — structured logger with NDJSON persistence and secret redaction
+- `metrics.ts` — metrics collector with standard metric names
+- `traces.ts` — trace manager with span lifecycle
+- `costTracker.ts` — per-provider cost tracking and budget warnings
+- `executionTelemetry.ts` — execution-scoped telemetry
+- `executionMetrics.ts` — execution metrics factory
+- `rateLimitLedger.ts` — rate limit state tracking
+- `rateLimitReporter.ts` — rate limit reporting and formatting
+- `logWriters.ts` — log output writers
+
+## Dependencies
+
+Imports from: `core`, `utils`, `validation`
+
+Depended on by: `adapters`, `cli`, `workflows`

--- a/src/utils/README.md
+++ b/src/utils/README.md
@@ -6,10 +6,10 @@ and GitHub API URL resolution.
 
 ## Key Exports
 
-The barrel (`index.ts`) exports only error utilities:
+The barrel (`index.ts`) exports error utilities and process helpers:
 
 - `classifyError` / `getErrorMessage` / `serializeError` / `wrapError` — error classification and serialization
-- `isProcessRunning` — process existence check
+- `isProcessRunning` / `ProcessStatus` — process existence helpers
 
 Most files are imported by direct path rather than through the barrel:
 

--- a/src/utils/README.md
+++ b/src/utils/README.md
@@ -1,0 +1,39 @@
+# Utils
+
+Low-level, layer-agnostic utilities. Provides error handling, safe JSON parsing,
+secret redaction, atomic file writes, environment filtering, process management,
+and GitHub API URL resolution.
+
+## Key Exports
+
+The barrel (`index.ts`) exports only error utilities:
+
+- `classifyError` / `getErrorMessage` / `serializeError` / `wrapError` — error classification and serialization
+- `isProcessRunning` — process existence check
+
+Most files are imported by direct path rather than through the barrel:
+
+- `safeJson.ts` — safe JSON parse/stringify with error handling
+- `redaction.ts` — `RedactionEngine` for secret redaction (GitHub tokens, API keys, JWTs)
+- `atomicWrite.ts` — atomic file writes via write-to-temp-then-rename
+- `envFilter.ts` — environment variable filtering
+- `processRunner.ts` — child process execution
+- `processExists.ts` — process existence detection
+- `githubApiUrl.ts` — GitHub API URL resolution with security validation
+
+## Structure
+
+- `errors.ts` — error classification, serialization, and wrapping
+- `safeJson.ts` — safe JSON operations
+- `redaction.ts` — secret redaction engine
+- `atomicWrite.ts` — atomic file write operations
+- `envFilter.ts` — environment variable filtering
+- `processRunner.ts` — process spawning and execution
+- `processExists.ts` — process existence checking
+- `githubApiUrl.ts` — GitHub API base URL resolution (security-sensitive: validates URLs, rejects embedded credentials)
+
+## Dependencies
+
+Imports from: `core`
+
+Depended on by: `adapters`, `persistence`, `telemetry`, `workflows`

--- a/src/utils/githubApiUrl.ts
+++ b/src/utils/githubApiUrl.ts
@@ -1,4 +1,17 @@
+/**
+ * GitHub API URL Resolution
+ *
+ * Resolves and validates the GitHub API base URL with security checks:
+ * - Rejects URLs with embedded credentials (username/password)
+ * - Rejects URLs with query strings or fragments
+ * - Requires explicit opt-in for custom (GitHub Enterprise) hosts
+ * - Enforces HTTPS for all custom hosts
+ */
+
+/** Default GitHub API base URL for github.com */
 export const DEFAULT_GITHUB_API_BASE_URL = 'https://api.github.com';
+
+/** Environment variable that must be set to '1' to allow custom GitHub API hosts */
 export const ALLOW_UNSAFE_CUSTOM_GITHUB_API_BASE_URL_ENV =
   'CODEPIPE_ALLOW_UNSAFE_GITHUB_API_BASE_URL';
 
@@ -10,6 +23,12 @@ function trimTrailingSlash(pathname: string): string {
   return pathname.replace(/\/+$/, '') || '/';
 }
 
+/**
+ * Check whether the given base URL differs from the default GitHub API URL.
+ *
+ * @param baseUrl - GitHub API base URL to check
+ * @returns true if the URL points to a non-default host (e.g., GitHub Enterprise)
+ */
 export function hasCustomGitHubApiBaseUrl(baseUrl: string | undefined): boolean {
   if (!baseUrl) {
     return false;
@@ -29,6 +48,21 @@ export function hasCustomGitHubApiBaseUrl(baseUrl: string | undefined): boolean 
   }
 }
 
+/**
+ * Resolve and validate the GitHub API base URL.
+ *
+ * Security validation rules:
+ * 1. Rejects URLs with embedded credentials (username:password@host)
+ * 2. Rejects URLs with query strings or hash fragments
+ * 3. For non-default hosts, requires CODEPIPE_ALLOW_UNSAFE_GITHUB_API_BASE_URL=1
+ * 4. Enforces HTTPS for custom hosts
+ *
+ * @param baseUrl - GitHub API base URL, or undefined to use the default
+ * @returns Normalized base URL string
+ * @throws {Error} If the URL contains credentials, query strings, or fragments
+ * @throws {Error} If a custom host is used without explicit opt-in
+ * @throws {Error} If a custom host does not use HTTPS
+ */
 export function resolveGitHubApiBaseUrl(baseUrl: string | undefined): string {
   const candidate = baseUrl ?? DEFAULT_GITHUB_API_BASE_URL;
   const parsed = new URL(candidate);

--- a/src/utils/githubApiUrl.ts
+++ b/src/utils/githubApiUrl.ts
@@ -24,27 +24,39 @@ function trimTrailingSlash(pathname: string): string {
 }
 
 /**
- * Check whether the given base URL differs from the default GitHub API URL.
+ * Classification of a configured GitHub API base URL.
+ *
+ * - `default`: the canonical `https://api.github.com/` endpoint
+ * - `custom`: a valid non-default host/path, typically GitHub Enterprise
+ * - `invalid`: malformed input that cannot be parsed as a URL
+ */
+export type GitHubApiBaseUrlStatus = 'default' | 'custom' | 'invalid';
+
+/**
+ * Classify a configured GitHub API base URL for early config warnings.
  *
  * @param baseUrl - GitHub API base URL to check
- * @returns true if the URL points to a non-default host (e.g., GitHub Enterprise)
+ * @returns `default` for the canonical GitHub host, `custom` for valid
+ * non-default hosts/paths, or `invalid` when the value cannot be parsed
  */
-export function hasCustomGitHubApiBaseUrl(baseUrl: string | undefined): boolean {
+export function classifyGitHubApiBaseUrl(baseUrl: string | undefined): GitHubApiBaseUrlStatus {
   if (!baseUrl) {
-    return false;
+    return 'default';
   }
 
   try {
     const parsed = new URL(baseUrl);
     const normalizedPath = trimTrailingSlash(parsed.pathname);
-    return !(
+    return (
       parsed.protocol === 'https:' &&
       parsed.hostname === 'api.github.com' &&
       parsed.port === '' &&
       normalizedPath === '/'
-    );
+    )
+      ? 'default'
+      : 'custom';
   } catch {
-    return false;
+    return 'invalid';
   }
 }
 
@@ -56,12 +68,15 @@ export function hasCustomGitHubApiBaseUrl(baseUrl: string | undefined): boolean 
  * 2. Rejects URLs with query strings or hash fragments
  * 3. For non-default hosts, requires CODEPIPE_ALLOW_UNSAFE_GITHUB_API_BASE_URL=1
  * 4. Enforces HTTPS for custom hosts
+ * 5. Allows only `/` or `/api/v3` paths so REST and GraphQL endpoints stay aligned
  *
  * @param baseUrl - GitHub API base URL, or undefined to use the default
  * @returns Normalized base URL string
  * @throws {Error} If the URL contains credentials, query strings, or fragments
  * @throws {Error} If a custom host is used without explicit opt-in
  * @throws {Error} If a custom host does not use HTTPS
+ * @throws {Error} If a custom host uses a path other than `/` or `/api/v3`
+ * @throws {TypeError} If the URL string is malformed and cannot be parsed
  */
 export function resolveGitHubApiBaseUrl(baseUrl: string | undefined): string {
   const candidate = baseUrl ?? DEFAULT_GITHUB_API_BASE_URL;
@@ -95,6 +110,12 @@ export function resolveGitHubApiBaseUrl(baseUrl: string | undefined): string {
 
   if (parsed.protocol !== 'https:') {
     throw new Error('GitHub API base URL must use https for custom hosts');
+  }
+
+  if (normalizedPath !== '/' && normalizedPath !== '/api/v3') {
+    throw new Error(
+      'GitHub API base URL must use either the root path or /api/v3 for custom hosts'
+    );
   }
 
   return `${parsed.origin}${normalizedPath === '/' ? '/' : `${normalizedPath}/`}`;

--- a/src/validation/README.md
+++ b/src/validation/README.md
@@ -1,0 +1,37 @@
+# Validation
+
+Generic Zod schema validation utilities and CLI path validation. Provides
+two validation modes: throw-on-failure for hard boundaries and result-union
+for soft boundaries.
+
+## Key Exports
+
+This module has no barrel `index.ts` — consumers import files directly.
+
+### From `helpers.ts`
+
+- `validateOrThrow(schema, data)` — validates and throws `ValidationError` on failure
+- `validateOrResult(schema, data)` — returns `ValidationSuccess<T>` or `ValidationFailure`
+- `ValidationSuccess` / `ValidationFailure` / `ValidationResult` — discriminated union types
+
+### From `errors.ts`
+
+- `ValidationError` — structured error with CLI/JSON formatting
+- `fromZodError(zodError)` — converts `ZodError` to `ValidationError`
+- `ValidationIssue` — single validation issue with path and context
+
+### From `cliPath.ts`
+
+- `validateCliPath(path)` — validates filesystem paths for safe process spawning (prevents shell injection via metacharacters, path traversal)
+
+## Structure
+
+- `helpers.ts` — generic Zod validation wrappers
+- `errors.ts` — validation error model with CLI output formatting
+- `cliPath.ts` — CLI path safety validation
+
+## Dependencies
+
+Imports from: (none outside itself)
+
+Depended on by: `core`, `persistence`, `telemetry`, `adapters`

--- a/src/workflows/README.md
+++ b/src/workflows/README.md
@@ -49,7 +49,7 @@ Most internal modules are imported by direct path (not through the barrel).
 
 ### Queue
 
-- `queue/` — 8-file queue subsystem
+- `queue/` — 13-file queue subsystem
   - `queueStore.ts` — persistent queue storage
   - `queueTaskManager.ts` — task lifecycle management
   - `queueV2Api.ts` — V2 queue API
@@ -57,7 +57,12 @@ Most internal modules are imported by direct path (not through the barrel).
   - `queueOperationsLog.ts` — operation audit log
   - `queueSnapshotManager.ts` — queue state snapshots
   - `queueCompactionEngine.ts` — log compaction
+  - `queueCache.ts` — query result caching
+  - `queueLoader.ts` — queue initialization and loading
+  - `queueIntegrity.ts` — integrity verification
+  - `queueValidation.ts` — queue state validation
   - `queueTypes.ts` — queue type definitions
+  - `index.ts` — barrel re-exports
 
 ### Spec
 

--- a/src/workflows/README.md
+++ b/src/workflows/README.md
@@ -1,0 +1,104 @@
+# Workflows
+
+Core business logic for the codemachine pipeline. Orchestrates execution
+strategies, context aggregation, spec composition, task planning, resume
+coordination, write actions, and queue management.
+
+## Key Exports
+
+The barrel (`index.ts`) exports only the public strategy contract:
+
+- `ExecutionStrategy` — pluggable execution strategy interface
+- `ExecutionContext` — context passed to strategy `execute()`
+- `ExecutionStrategyResult` — result shape with status, recoverable flag
+- `CodeMachineCLIStrategy` / `createCodeMachineCLIStrategy` — primary execution strategy
+- `CodeMachineEngineTypeSchema` / `CODEMACHINE_STRATEGY_NAMES` — strategy type definitions
+
+Most internal modules are imported by direct path (not through the barrel).
+
+## Structure
+
+### Execution Engine
+
+- `cliExecutionEngine.ts` — main execution engine orchestrating task runs
+- `executionDependencyResolver.ts` — resolves task execution order and parallelism
+- `executionTelemetryRecorder.ts` — records telemetry during execution
+- `executionArtifactCapture.ts` — captures execution artifacts
+- `executionStrategy.ts` — strategy interface definitions
+- `executionStrategyBuilder.ts` — builds strategy instances from config
+- `codeMachineStrategy.ts` — legacy CodeMachine strategy (fallback)
+- `codeMachineCLIStrategy.ts` — preferred CLI-based strategy
+- `strategyHelpers.ts` — shared strategy utilities
+
+### Resume
+
+- `resumeCoordinator.ts` — coordinates resume from interrupted runs
+- `runStateVerifier.ts` — verifies run state consistency
+- `resumeIntegrityChecker.ts` — validates integrity before resume
+- `resumeQueueRecovery.ts` — recovers queue state during resume
+- `resumeTypes.ts` — resume-specific type definitions
+
+### Context
+
+- `contextAggregator.ts` — aggregates context from multiple sources
+- `contextSummarizer.ts` — summarizes large context for LLM consumption
+- `contextBudget.ts` — manages token budget allocation
+- `contextRanking.ts` — ranks context items by relevance
+- `contextDocumentBuilder.ts` — builds structured context documents
+- `contextFileDiscovery.ts` — discovers relevant files for context
+
+### Queue
+
+- `queue/` — 8-file queue subsystem
+  - `queueStore.ts` — persistent queue storage
+  - `queueTaskManager.ts` — task lifecycle management
+  - `queueV2Api.ts` — V2 queue API
+  - `queueMemoryIndex.ts` — in-memory index for fast lookups
+  - `queueOperationsLog.ts` — operation audit log
+  - `queueSnapshotManager.ts` — queue state snapshots
+  - `queueCompactionEngine.ts` — log compaction
+  - `queueTypes.ts` — queue type definitions
+
+### Spec
+
+- `specComposer.ts` — composes specification documents
+- `specParsing.ts` — parses spec format
+- `specMetadata.ts` — spec metadata extraction
+- `specMarkdown.ts` — markdown rendering for specs
+- `specStore.ts` — spec persistence
+
+### Task Planning
+
+- `taskPlanner.ts` — high-level task planning
+- `plannerDAG.ts` — directed acyclic graph for task dependencies
+- `plannerPersistence.ts` — plan state persistence
+- `taskPlannerGraph.ts` — graph-based planning
+- `taskPlannerTypes.ts` — planning type definitions
+- `taskMapper.ts` — maps tasks between representations
+- `planDiffer.ts` — diffs plan changes
+
+### Other
+
+- `pipelineOrchestrator.ts` — top-level pipeline orchestration
+- `commandRunner.ts` — shell command execution
+- `summaryOrchestration.ts` — context chunk processing
+- `summaryStore.ts` — summary persistence
+- `summarizerClients/` — LLM summarizer client implementations
+- `deployment/` — deployment-related workflows
+- `writeActionQueue.ts` / `writeActionStore.ts` / `writeActionRateLimiter.ts` — write action management
+- `branchManager.ts` / `branchComplianceChecker.ts` / `branchProtectionReporter.ts` — branch management
+- `approvalRegistry.ts` — approval gate tracking
+- `validationRegistry.ts` / `validationStore.ts` — validation management
+- `traceabilityMapper.ts` — maps artifacts to traceability links
+- `linearIssueLoader.ts` — loads Linear issue context
+- `researchCoordinator.ts` / `researchDetection.ts` — research task coordination
+- `prdStore.ts` / `prdAuthoringEngine.ts` — PRD management
+- `autoFixEngine.ts` — automated fix application
+- `resultNormalizer.ts` — normalizes execution results
+- `patchManager.ts` — manages code patches
+
+## Dependencies
+
+Imports from: `core`, `utils`, `validation`, `telemetry`, `persistence`, `adapters`
+
+Depended on by: `cli`

--- a/src/workflows/codeMachineStrategy.ts
+++ b/src/workflows/codeMachineStrategy.ts
@@ -1,3 +1,11 @@
+/**
+ * CodeMachine Strategy (Legacy)
+ *
+ * Legacy execution strategy that delegates task execution to the CodeMachine
+ * binary. This is the fallback strategy — prefer CodeMachineCLIStrategy for
+ * new deployments. Handles tasks whose task_type is not marked as native-only.
+ */
+
 import * as path from 'node:path';
 import type { ExecutionTask } from '../core/models/ExecutionTask.js';
 import type { ExecutionConfig } from '../core/config/RepoConfig.js';
@@ -16,11 +24,18 @@ import { normalizeResult } from './resultNormalizer.js';
 import { buildStrategyResult } from './strategyHelpers.js';
 import type { StructuredLogger } from '../telemetry/logger.js';
 
+/** Configuration options for the CodeMachine strategy */
 export interface CodeMachineStrategyOptions {
+  /** Execution configuration from RepoConfig */
   config: ExecutionConfig;
+  /** Optional structured logger */
   logger?: StructuredLogger;
 }
 
+/**
+ * Legacy execution strategy using the CodeMachine binary.
+ * Delegates to `runCodeMachine()` for task execution and normalizes results.
+ */
 export class CodeMachineStrategy implements ExecutionStrategy {
   readonly name = 'codemachine';
 
@@ -90,6 +105,7 @@ export class CodeMachineStrategy implements ExecutionStrategy {
   }
 }
 
+/** Factory function to create a CodeMachineStrategy instance */
 export function createCodeMachineStrategy(
   options: CodeMachineStrategyOptions
 ): CodeMachineStrategy {

--- a/src/workflows/executionStrategy.ts
+++ b/src/workflows/executionStrategy.ts
@@ -1,24 +1,50 @@
+/**
+ * Execution Strategy Contract
+ *
+ * Defines the pluggable strategy pattern for task execution. The execution
+ * engine selects a strategy via `canHandle()` and delegates work via
+ * `execute()`. Implementations include CodeMachineCLIStrategy (preferred)
+ * and CodeMachineStrategy (legacy fallback).
+ */
+
 import type { ExecutionTask } from '../core/models/ExecutionTask.js';
 
+/** Runtime context passed to strategy `execute()` */
 export interface ExecutionContext {
+  /** Absolute path to the run directory */
   runDir: string;
+  /** Absolute path to the workspace root */
   workspaceDir: string;
+  /** Absolute path to the log file for this execution */
   logPath: string;
+  /** Maximum execution time in milliseconds before timeout */
   timeoutMs: number;
 }
 
+/** Result returned by a strategy after task execution */
 export interface ExecutionStrategyResult {
+  /** Whether the task completed successfully */
   success: boolean;
+  /** Terminal status of the execution */
   status: 'completed' | 'failed' | 'timeout' | 'killed';
+  /** Human-readable summary of the execution outcome */
   summary: string;
+  /** Error message if the execution failed */
   errorMessage?: string;
+  /** Whether the failure is recoverable via retry */
   recoverable: boolean;
+  /** Wall-clock execution duration in milliseconds */
   durationMs: number;
+  /** Paths to artifacts produced during execution */
   artifacts: string[];
 }
 
+/** Pluggable execution strategy for running tasks */
 export interface ExecutionStrategy {
+  /** Unique name identifying this strategy */
   readonly name: string;
+  /** Returns true if this strategy can execute the given task */
   canHandle(task: ExecutionTask): boolean;
+  /** Executes the task and returns a result */
   execute(task: ExecutionTask, context: ExecutionContext): Promise<ExecutionStrategyResult>;
 }

--- a/src/workflows/summaryOrchestration.ts
+++ b/src/workflows/summaryOrchestration.ts
@@ -1,3 +1,11 @@
+/**
+ * Summary Orchestration
+ *
+ * Processes file content into LLM-generated summaries via chunk-based
+ * summarization. Supports single-file and multi-chunk processing with
+ * caching, cost tracking, and secret redaction.
+ */
+
 import type { ContextSummary } from '../core/models/ContextDocument';
 import { RedactionEngine, type StructuredLogger } from '../telemetry/logger';
 import type { CostTracker } from '../telemetry/costTracker';
@@ -12,6 +20,7 @@ import {
   type SummarizerConfig,
 } from './summarizerClients/types';
 
+/** Aggregated result from processing one or more file chunks */
 export interface ChunkProcessResult {
   summaries: ContextSummary[];
   chunksGenerated: number;
@@ -20,6 +29,20 @@ export interface ChunkProcessResult {
   completionTokens: number;
 }
 
+/**
+ * Process a single file as one chunk, with caching support.
+ *
+ * @param relativePath - File path relative to workspace root
+ * @param fileHash - SHA hash of the file content (used for cache key)
+ * @param content - File content to summarize
+ * @param contextDir - Directory for cached summaries
+ * @param client - LLM summarizer client
+ * @param config - Summarizer configuration (forceFresh, etc.)
+ * @param redactor - Secret redaction engine applied to summaries
+ * @param costTracker - Optional cost tracker for LLM usage
+ * @param logger - Structured logger
+ * @param warnings - Mutable array; failure messages are appended here
+ */
 export async function processSingleChunk(
   relativePath: string,
   fileHash: string,
@@ -89,6 +112,24 @@ export async function processSingleChunk(
   return result;
 }
 
+/**
+ * Process a file that has been split into multiple chunks.
+ *
+ * Each chunk is processed independently with its own cache key. Cached
+ * chunks are reused if the file hash matches. Cost and token usage are
+ * aggregated across all chunks.
+ *
+ * @param relativePath - File path relative to workspace root
+ * @param fileHash - SHA hash of the full file content
+ * @param chunks - Array of file chunks with index, total, and content
+ * @param contextDir - Directory for cached summaries
+ * @param client - LLM summarizer client
+ * @param config - Summarizer configuration
+ * @param redactor - Secret redaction engine applied to summaries
+ * @param costTracker - Optional cost tracker for LLM usage
+ * @param logger - Structured logger
+ * @param warnings - Mutable array; failure messages are appended here
+ */
 export async function processMultipleChunks(
   relativePath: string,
   fileHash: string,

--- a/tests/unit/githubApiUrl.spec.ts
+++ b/tests/unit/githubApiUrl.spec.ts
@@ -1,8 +1,8 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import {
   ALLOW_UNSAFE_CUSTOM_GITHUB_API_BASE_URL_ENV,
+  classifyGitHubApiBaseUrl,
   DEFAULT_GITHUB_API_BASE_URL,
-  hasCustomGitHubApiBaseUrl,
   resolveGitHubApiBaseUrl,
 } from '../../src/utils/githubApiUrl.js';
 
@@ -11,9 +11,14 @@ describe('githubApiUrl', () => {
     delete process.env[ALLOW_UNSAFE_CUSTOM_GITHUB_API_BASE_URL_ENV];
   });
 
-  it('treats the default GitHub API URL as non-custom even with a trailing slash', () => {
-    expect(hasCustomGitHubApiBaseUrl(DEFAULT_GITHUB_API_BASE_URL)).toBe(false);
-    expect(hasCustomGitHubApiBaseUrl(`${DEFAULT_GITHUB_API_BASE_URL}/`)).toBe(false);
+  it('classifies the default GitHub API URL even with a trailing slash', () => {
+    expect(classifyGitHubApiBaseUrl(DEFAULT_GITHUB_API_BASE_URL)).toBe('default');
+    expect(classifyGitHubApiBaseUrl(`${DEFAULT_GITHUB_API_BASE_URL}/`)).toBe('default');
+  });
+
+  it('classifies malformed URLs separately from custom enterprise URLs', () => {
+    expect(classifyGitHubApiBaseUrl('not a url')).toBe('invalid');
+    expect(classifyGitHubApiBaseUrl('https://github.example.com/api/v3')).toBe('custom');
   });
 
   it('rejects custom GitHub API base URLs without explicit opt-in', () => {
@@ -35,6 +40,14 @@ describe('githubApiUrl', () => {
 
     expect(resolveGitHubApiBaseUrl('https://github.example.com/api/v3')).toBe(
       'https://github.example.com/api/v3/'
+    );
+  });
+
+  it('rejects custom GitHub API base URLs that use unsupported paths', () => {
+    process.env[ALLOW_UNSAFE_CUSTOM_GITHUB_API_BASE_URL_ENV] = '1';
+
+    expect(() => resolveGitHubApiBaseUrl('https://github.example.com/custom/api/v3')).toThrow(
+      'GitHub API base URL must use either the root path or /api/v3 for custom hosts'
     );
   });
 


### PR DESCRIPTION
## Summary

Describe what this PR changes and why.

## Test Plan

How was this verified?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist

- [ ] `npm run format:check && npm run lint` passes
- [ ] `npm test` passes
- [ ] `npm run docs:links:check` passes
- [ ] `npm run build` succeeds
- [ ] Documentation updated (if applicable)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/867" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Major docs expansion: ADR index, enhanced landing/index, expanded playbooks (init/resume), module READMEs (core, cli, workflows, persistence, telemetry, adapters, utils, validation), queue v2 & parallel-execution guides, and extended config/adapter references. Updated doctor diagnostics and rate-limit reporting notes (use --verbose for recent hits). Node.js guidance: v20 warned, v24 recommended.

* **New Features**
  * Published formal status --json schema and clarified CLI start exit-code semantics.
  * Documented secure GitHub API base-url rules and added a --max-parallel CLI flag for bounded parallel runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds per-module READMEs to all 8 `src/` directories, expands several reference docs and playbooks, and ships a small batch of code improvements alongside the documentation work.

**Key changes:**

- **8 new module READMEs** (`src/cli`, `src/core`, `src/adapters`, `src/persistence`, `src/telemetry`, `src/utils`, `src/validation`, `src/workflows`) — each accurately documents public exports, internal structure, and the dependency layer they occupy.
- **`src/utils/githubApiUrl.ts`** — `hasCustomGitHubApiBaseUrl` (boolean) is replaced by `classifyGitHubApiBaseUrl` (tri-state: `default | custom | invalid`), enabling the config loader to emit an explicit warning for malformed URLs. A new path restriction (`/` or `/api/v3` only) is added to `resolveGitHubApiBaseUrl` for custom hosts, preventing misaligned REST/GraphQL base paths.
- **`src/core/config/RepoConfigLoader.ts`** — adopts the new classifier and adds a dedicated warning branch for `'invalid'` URLs.
- **`src/cli/status/types.ts`** — every field in the `codepipe status --json` payload now has inline JSDoc, formalising the machine-readable API contract.
- **JSDoc additions** throughout `src/cli/status/data/`, `src/cli/status/renderers.ts`, `src/workflows/executionStrategy.ts`, `src/workflows/codeMachineStrategy.ts`, `src/workflows/summaryOrchestration.ts`, and `src/cli/commands/start.ts`.
- **Reference docs updated** to reflect: queue subsystem reorganised under `src/workflows/queue/`, RepoConfig loader extraction (CDMCH-213), Node.js v20 warn / v24 recommended policy, `--max-parallel` CLI flag, `disableAutoMerge` GraphQL operation, and corrected rate-limit dashboard output.
- **`src/cli/README.md`** addresses previous review feedback: `status.ts` duplicate removed, all four previously-missing commands (`health.ts`, `plan.ts`, `rate-limits.ts`, `validate.ts`) are now listed.
- **`tests/unit/githubApiUrl.spec.ts`** updated and extended to cover the new classifier and path restriction.

<h3>Confidence Score: 5/5</h3>

- Safe to merge — all code changes are well-tested and no bugs were found.
- The code changes are narrow (URL classifier rename + one new path guard), fully covered by updated and new unit tests, and the previous CLI README concerns raised in prior review threads have been addressed. Documentation additions are factually consistent with the codebase as verified by direct file inspection.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/utils/githubApiUrl.ts | Renames `hasCustomGitHubApiBaseUrl` → `classifyGitHubApiBaseUrl` (boolean → tri-state), adds new `/api/v3`-only path restriction for custom hosts, and adds JSDoc throughout. Logic is sound; early-return for default URL ensures path restriction only applies to custom hosts. |
| src/core/config/RepoConfigLoader.ts | Adopts `classifyGitHubApiBaseUrl` and adds an `'invalid'` branch that emits a warning for malformed `api_base_url` values. Classification is intentionally skipped when GitHub is disabled, which is correct. |
| tests/unit/githubApiUrl.spec.ts | Test suite updated to use `classifyGitHubApiBaseUrl`; two new test cases added covering `'invalid'` classification and the path restriction. Coverage looks complete for the changed behaviour. |
| src/cli/status/types.ts | All interface fields in the `codepipe status --json` payload now have inline JSDoc, formalising the schema contract. No logic changes; purely additive documentation. |
| src/cli/README.md | New module README; accurately lists all oclif commands (`health.ts`, `plan.ts`, `rate-limits.ts`, `validate.ts` are now included). `status` is correctly listed once as the `status/` directory. Addresses issues raised in previous review threads. |
| docs/reference/queue-v2-operations.md | Accurately reflects the queue subsystem being reorganised into `src/workflows/queue/` (13 files). Fixes an incorrect "Resume Playbook" link that previously pointed to `patch_playbook.md`. |
| src/workflows/README.md | Comprehensive new README documenting workflows barrel exports, execution engine, resume modules, context, queue subsystem, spec, task planning, and all other internal modules. Consistent with codebase layout. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[resolveGitHubApiBaseUrl called] --> B{Credentials\nin URL?}
    B -- Yes --> ERR1[throw: embedded credentials]
    B -- No --> C{Query string\nor fragment?}
    C -- Yes --> ERR2[throw: query/fragment]
    C -- No --> D{isDefaultGitHubApi?\nhttps + api.github.com\n+ port '' + path /}
    D -- Yes --> RET1[return DEFAULT_GITHUB_API_BASE_URL]
    D -- No: custom host --> E{ALLOW_UNSAFE\nenv var set?}
    E -- No --> ERR3[throw: opt-in required]
    E -- Yes --> F{protocol\n= https?}
    F -- No --> ERR4[throw: HTTPS required]
    F -- Yes --> G{path = /\nor /api/v3?}
    G -- No --> ERR5[throw: unsupported path]
    G -- Yes --> RET2[return normalised URL]

    style RET1 fill:#90EE90
    style RET2 fill:#90EE90
    style ERR1 fill:#FFB6B6
    style ERR2 fill:#FFB6B6
    style ERR3 fill:#FFB6B6
    style ERR4 fill:#FFB6B6
    style ERR5 fill:#FFB6B6
```

<sub>Reviews (5): Last reviewed commit: ["fix(config): distinguish invalid GitHub ..."](https://github.com/kinginyellows/codemachine-pipeline/commit/bcdb8cadbc61d3a0562d88643f8aeb6c6311a146) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25668656)</sub>

<!-- /greptile_comment -->