### PR TITLE
fix cycle command telemetry callback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ Current command surface includes:
 - `start`
 - `status`
 - `doctor`
+- `cycle`
 - `health`
 - `approve`
 - `plan`

--- a/docs/reference/cli/cli-reference.md
+++ b/docs/reference/cli/cli-reference.md
@@ -103,7 +103,7 @@ codepipe cycle [FLAGS]
 | `--dry-run`    |       | boolean | Preview issue order without processing                      |         |
 | `--fail-fast`  |       | boolean | Stop on first issue failure                                 |         |
 | `--json`       |       | boolean | Output results in JSON format                               |         |
-| `--max-issues` |       | string  | Maximum number of issues to process                         | `30`    |
+| `--max-issues` |       | integer | Maximum number of issues to process                         | `30`    |
 | `--plan-only`  |       | boolean | Generate plans but skip execution                           |         |
 | `--verbose`    | `-v`  | boolean | Show detailed output                                        |         |
 

--- a/docs/reference/cli/cli-reference.md
+++ b/docs/reference/cli/cli-reference.md
@@ -5,13 +5,14 @@
 
 The `codepipe` CLI is the primary interface for managing feature development pipelines. This reference is auto-generated from the oclif command manifest.
 
-**Total commands:** 17
+**Total commands:** 18
 
 ## Table of Contents
 
 ### Core Commands
 
 - [`codepipe approve`](#codepipe-approve) — Approve or deny a feature pipeline gate
+- [`codepipe cycle`](#codepipe-cycle) — Run all issues in a Linear cycle through the pipeline
 - [`codepipe doctor`](#codepipe-doctor) — Run environment diagnostics and readiness checks
 - [`codepipe health`](#codepipe-health) — Quick runtime health check (config, disk, writable run dir)
 - [`codepipe init`](#codepipe-init) — Initialize codemachine-pipeline with schema-validated configuration
@@ -80,6 +81,39 @@ codepipe approve prd --approve --signer "user@example.com"
 codepipe approve spec --deny --signer "reviewer@example.com" --comment "Missing acceptance criteria"
 codepipe approve prd --approve --signer "user@example.com" --feature FEAT-abc123
 codepipe approve prd --approve --signer "user@example.com" --json
+```
+
+---
+
+#### codepipe cycle
+
+Run all issues in a Linear cycle through the pipeline
+
+##### Synopsis
+
+```bash
+codepipe cycle [FLAGS]
+```
+
+##### Options
+
+| Option         | Short | Type    | Description                                                 | Default |
+| -------------- | ----- | ------- | ----------------------------------------------------------- | ------- |
+| `--cycle`      | `-c`  | string  | Cycle ID (defaults to active cycle for the configured team) |         |
+| `--dry-run`    |       | boolean | Preview issue order without processing                      |         |
+| `--fail-fast`  |       | boolean | Stop on first issue failure                                 |         |
+| `--json`       |       | boolean | Output results in JSON format                               |         |
+| `--max-issues` |       | string  | Maximum number of issues to process                         | `30`    |
+| `--plan-only`  |       | boolean | Generate plans but skip execution                           |         |
+| `--verbose`    | `-v`  | boolean | Show detailed output                                        |         |
+
+##### Examples
+
+```bash
+codepipe cycle --cycle CYCLE-ID
+codepipe cycle --dry-run
+codepipe cycle --max-issues 10 --fail-fast
+codepipe cycle --json
 ```
 
 ---

--- a/src/adapters/linear/LinearAdapter.ts
+++ b/src/adapters/linear/LinearAdapter.ts
@@ -248,11 +248,9 @@ type RawCycleRelationNode = {
 };
 type RawLinearCycleIssue = LinearIssue & {
   labels: LinearIssue['labels'] | { nodes: LinearIssue['labels'] };
-  relations?:
-    | {
-        nodes?: Array<RawCycleRelationNode | null> | null;
-      }
-    | null;
+  relations?: {
+    nodes?: Array<RawCycleRelationNode | null> | null;
+  } | null;
 };
 type CycleQueryResponse = {
   data: {
@@ -559,16 +557,14 @@ export class LinearAdapter {
     LinearAdapter.validateCycleId(cycleId);
     try {
       let after: string | null = null;
-      let cycleSummary:
-        | {
-            id: string;
-            name: string;
-            number: number;
-            startsAt: string;
-            endsAt: string;
-            teamId: string;
-          }
-        | null = null;
+      let cycleSummary: {
+        id: string;
+        name: string;
+        number: number;
+        startsAt: string;
+        endsAt: string;
+        teamId: string;
+      } | null = null;
       const issues: LinearCycleIssue[] = [];
 
       do {
@@ -597,10 +593,12 @@ export class LinearAdapter {
             number: cycle.number,
             startsAt: cycle.startsAt,
             endsAt: cycle.endsAt,
-            teamId: cycle.team?.id ?? (() => {
-              this.logger.warn('Cycle has no team association', { cycleId: cycle.id });
-              return '';
-            })(),
+            teamId:
+              cycle.team?.id ??
+              (() => {
+                this.logger.warn('Cycle has no team association', { cycleId: cycle.id });
+                return '';
+              })(),
           };
         }
 
@@ -608,7 +606,9 @@ export class LinearAdapter {
 
         const pageInfo = cycle.issues.pageInfo;
         after =
-          pageInfo?.hasNextPage && typeof pageInfo.endCursor === 'string' ? pageInfo.endCursor : null;
+          pageInfo?.hasNextPage && typeof pageInfo.endCursor === 'string'
+            ? pageInfo.endCursor
+            : null;
       } while (after !== null);
 
       return {
@@ -736,9 +736,7 @@ export class LinearAdapter {
     }
   }
 
-  private normalizeCycleIssue(
-    node: RawLinearCycleIssue
-  ): LinearCycleIssue {
+  private normalizeCycleIssue(node: RawLinearCycleIssue): LinearCycleIssue {
     const relationNodes: Array<RawCycleRelationNode | null> =
       node.relations &&
       typeof node.relations === 'object' &&
@@ -746,8 +744,7 @@ export class LinearAdapter {
       Array.isArray(node.relations.nodes)
         ? node.relations.nodes
         : new Array<RawCycleRelationNode | null>();
-    const labels =
-      node.labels && 'nodes' in node.labels ? node.labels.nodes : node.labels;
+    const labels = node.labels && 'nodes' in node.labels ? node.labels.nodes : node.labels;
 
     return {
       ...node,

--- a/src/cli/commands/cycle.ts
+++ b/src/cli/commands/cycle.ts
@@ -15,16 +15,8 @@ import {
 } from '../cycleOutput';
 import { type CycleFlags, type CyclePayload } from '../cycleTypes';
 import { findGitRoot } from '../startHelpers';
-import {
-  resolveRunDirectorySettings,
-  requireConfig,
-} from '../utils/runDirectory';
-import {
-  CliError,
-  CliErrorCode,
-  formatErrorJson,
-  setJsonOutputMode,
-} from '../utils/cliErrors';
+import { resolveRunDirectorySettings, requireConfig } from '../utils/runDirectory';
+import { CliError, CliErrorCode, formatErrorJson, setJsonOutputMode } from '../utils/cliErrors';
 
 function containsPathTraversal(value: string): boolean {
   return value.includes('..') || value.includes('/') || value.includes('\\');
@@ -157,12 +149,6 @@ export default class Cycle extends TelemetryCommand {
 
         // Resolve cycle ID inside telemetry context to catch API errors properly
         if (!cycleId) {
-          if (!teamId) {
-            throw new CliError(
-              'No --cycle flag provided and no team_id configured. Set linear.team_id in .codepipe/config.json or pass --cycle.',
-              CliErrorCode.CONFIG_INVALID
-            );
-          }
           const adapter = new LinearAdapter({ apiKey });
           const active = await adapter.fetchActiveCycle(teamId);
           if (!active) {
@@ -184,6 +170,12 @@ export default class Cycle extends TelemetryCommand {
 
         // Sanitize and create cycle directory
         const sanitized = sanitizeCycleId(cycleId);
+        if (!sanitized) {
+          throw new CliError(
+            'Cycle ID contains no filesystem-safe characters after sanitizeCycleId processing.',
+            CliErrorCode.CONFIG_INVALID
+          );
+        }
         const cycleDir = path.join(settings.baseDir, `cycle-${sanitized}`);
         await fs.mkdir(cycleDir, { recursive: true });
 

--- a/src/cli/commands/cycle.ts
+++ b/src/cli/commands/cycle.ts
@@ -146,18 +146,25 @@ export default class Cycle extends TelemetryCommand {
     await fs.mkdir(path.join(settings.baseDir, '.cycle-command'), { recursive: true });
 
     await this.runWithTelemetry(
-      { 
-        jsonMode: typedFlags.json, 
+      {
+        jsonMode: typedFlags.json,
         verbose: typedFlags.verbose,
         runDirPath: settings.baseDir,
       },
+      async (ctx) => {
         const logger = ctx.logger;
         const metrics = ctx.metrics;
 
         // Resolve cycle ID inside telemetry context to catch API errors properly
         if (!cycleId) {
-          const adapter = new LinearAdapter({ apiKey: apiKey! });
-          const active = await adapter.fetchActiveCycle(teamId!);
+          if (!teamId) {
+            throw new CliError(
+              'No --cycle flag provided and no team_id configured. Set linear.team_id in .codepipe/config.json or pass --cycle.',
+              CliErrorCode.CONFIG_INVALID
+            );
+          }
+          const adapter = new LinearAdapter({ apiKey });
+          const active = await adapter.fetchActiveCycle(teamId);
           if (!active) {
             throw new CliError(
               'No active cycle found for the configured team.',
@@ -168,7 +175,7 @@ export default class Cycle extends TelemetryCommand {
         }
 
         // Validate cycle ID for path traversal
-        if (containsPathTraversal(cycleId!)) {
+        if (containsPathTraversal(cycleId)) {
           throw new CliError(
             'Cycle ID must not contain path traversal or path separator characters.',
             CliErrorCode.CONFIG_INVALID
@@ -176,17 +183,17 @@ export default class Cycle extends TelemetryCommand {
         }
 
         // Sanitize and create cycle directory
-        const sanitized = sanitizeCycleId(cycleId!);
+        const sanitized = sanitizeCycleId(cycleId);
         const cycleDir = path.join(settings.baseDir, `cycle-${sanitized}`);
         await fs.mkdir(cycleDir, { recursive: true });
 
         // Fetch cycle issues
         const adapter = new LinearAdapter({
-          apiKey: apiKey!,
+          apiKey,
           runDir: cycleDir,
           ...(logger ? { logger } : {}),
         });
-        const snapshot = await adapter.fetchCycleIssues(cycleId!);
+        const snapshot = await adapter.fetchCycleIssues(cycleId);
         const cycle = snapshot.cycle;
 
         logger?.info('Cycle fetched', {

--- a/src/cli/cycleOutput.ts
+++ b/src/cli/cycleOutput.ts
@@ -30,17 +30,23 @@ function formatDuration(ms: number): string {
 
 function statusIcon(status: CycleIssueResult['status']): string {
   switch (status) {
-    case 'completed': return CHECK;
-    case 'failed': return CROSS;
-    case 'skipped': return DASH;
+    case 'completed':
+      return CHECK;
+    case 'failed':
+      return CROSS;
+    case 'skipped':
+      return DASH;
   }
 }
 
 function statusLabel(status: CycleIssueResult['status']): string {
   switch (status) {
-    case 'completed': return 'done';
-    case 'failed': return 'FAILED';
-    case 'skipped': return 'skipped';
+    case 'completed':
+      return 'done';
+    case 'failed':
+      return 'FAILED';
+    case 'skipped':
+      return 'skipped';
   }
 }
 
@@ -53,7 +59,9 @@ export function renderDryRun(payload: CyclePayload, callbacks: OutputCallbacks):
 
   log('');
   log(`Cycle: ${payload.cycleName} (${payload.cycleId})`);
-  log(`Issues: ${payload.totalIssues} total | ${payload.processable} processable | ${payload.skipped} will skip`);
+  log(
+    `Issues: ${payload.totalIssues} total | ${payload.processable} processable | ${payload.skipped} will skip`
+  );
   log(line);
   log('');
   log('  #  Issue       Priority   State            Action');

--- a/src/cli/cycleTypes.ts
+++ b/src/cli/cycleTypes.ts
@@ -42,4 +42,3 @@ export function getCyclePayloadCounts(payload: CyclePayload): {
   const skipped = payload.orderedIssues.filter((i) => i.willSkip).length;
   return { totalIssues: total, processable: total - skipped, skipped };
 }
-

--- a/src/utils/githubApiUrl.ts
+++ b/src/utils/githubApiUrl.ts
@@ -47,12 +47,10 @@ export function classifyGitHubApiBaseUrl(baseUrl: string | undefined): GitHubApi
   try {
     const parsed = new URL(baseUrl);
     const normalizedPath = trimTrailingSlash(parsed.pathname);
-    return (
-      parsed.protocol === 'https:' &&
+    return parsed.protocol === 'https:' &&
       parsed.hostname === 'api.github.com' &&
       parsed.port === '' &&
       normalizedPath === '/'
-    )
       ? 'default'
       : 'custom';
   } catch {

--- a/src/workflows/cycleIssueOrderer.ts
+++ b/src/workflows/cycleIssueOrderer.ts
@@ -36,15 +36,11 @@ interface ComponentLevelEntry {
   priority: number;
 }
 
-function sortByPriorityDescending(
-  issues: LinearCycleIssue[]
-): LinearCycleIssue[] {
+function sortByPriorityDescending(issues: LinearCycleIssue[]): LinearCycleIssue[] {
   return [...issues].sort((a, b) => b.priority - a.priority);
 }
 
-function createIssueMap(
-  issues: LinearCycleIssue[]
-): Map<string, LinearCycleIssue> {
+function createIssueMap(issues: LinearCycleIssue[]): Map<string, LinearCycleIssue> {
   const issueMap = new Map<string, LinearCycleIssue>();
   for (const issue of issues) {
     issueMap.set(issue.identifier, issue);
@@ -91,9 +87,7 @@ function getZeroInDegreeIssues(
   issues: LinearCycleIssue[],
   inDegree: Map<string, number>
 ): LinearCycleIssue[] {
-  return sortByPriorityDescending(
-    issues.filter((issue) => inDegree.get(issue.identifier) === 0)
-  );
+  return sortByPriorityDescending(issues.filter((issue) => inDegree.get(issue.identifier) === 0));
 }
 
 function processCurrentLevel(
@@ -146,13 +140,8 @@ function performKahnTraversal(
   return { ordered, visited };
 }
 
-function getRemainingIds(
-  issues: LinearCycleIssue[],
-  visited: Set<string>
-): string[] {
-  return issues
-    .map((issue) => issue.identifier)
-    .filter((issueId) => !visited.has(issueId));
+function getRemainingIds(issues: LinearCycleIssue[], visited: Set<string>): string[] {
+  return issues.map((issue) => issue.identifier).filter((issueId) => !visited.has(issueId));
 }
 
 function buildRemainingAdjacency(
@@ -196,18 +185,12 @@ function findStronglyConnectedComponents(
     for (const neighborId of adjacency.get(nodeId) ?? new Set<string>()) {
       if (!indices.has(neighborId)) {
         visit(neighborId);
-        lowLinks.set(
-          nodeId,
-          Math.min(lowLinks.get(nodeId)!, lowLinks.get(neighborId)!)
-        );
+        lowLinks.set(nodeId, Math.min(lowLinks.get(nodeId)!, lowLinks.get(neighborId)!));
         continue;
       }
 
       if (onStack.has(neighborId)) {
-        lowLinks.set(
-          nodeId,
-          Math.min(lowLinks.get(nodeId)!, indices.get(neighborId)!)
-        );
+        lowLinks.set(nodeId, Math.min(lowLinks.get(nodeId)!, indices.get(neighborId)!));
       }
     }
 
@@ -236,10 +219,7 @@ function findStronglyConnectedComponents(
   return components;
 }
 
-function isCycleComponent(
-  nodeIds: string[],
-  adjacency: Map<string, Set<string>>
-): boolean {
+function isCycleComponent(nodeIds: string[], adjacency: Map<string, Set<string>>): boolean {
   return (
     nodeIds.length > 1 ||
     (nodeIds.length === 1 && adjacency.get(nodeIds[0])?.has(nodeIds[0]) === true)
@@ -250,12 +230,10 @@ function createComponents(
   remainingIds: string[],
   remainingAdjacency: Map<string, Set<string>>
 ): Component[] {
-  return findStronglyConnectedComponents(remainingIds, remainingAdjacency).map(
-    (nodeIds) => ({
-      nodeIds,
-      isCycle: isCycleComponent(nodeIds, remainingAdjacency),
-    })
-  );
+  return findStronglyConnectedComponents(remainingIds, remainingAdjacency).map((nodeIds) => ({
+    nodeIds,
+    isCycle: isCycleComponent(nodeIds, remainingAdjacency),
+  }));
 }
 
 function createComponentGraph(
@@ -300,9 +278,7 @@ function getComponentPriority(
   component: Component,
   issueMap: Map<string, LinearCycleIssue>
 ): number {
-  return Math.max(
-    ...component.nodeIds.map((nodeId) => issueMap.get(nodeId)!.priority)
-  );
+  return Math.max(...component.nodeIds.map((nodeId) => issueMap.get(nodeId)!.priority));
 }
 
 function getReadyComponents(
@@ -373,9 +349,7 @@ function orderRemainingComponents(
 
     for (const { index } of currentLevel) {
       appendComponent(components[index], issueMap, ordered, cycleInvolvedIds);
-      nextLevel.push(
-        ...unlockNeighborComponents(index, components, componentGraph, issueMap)
-      );
+      nextLevel.push(...unlockNeighborComponents(index, components, componentGraph, issueMap));
     }
 
     currentLevel = nextLevel.sort((a, b) => b.priority - a.priority);
@@ -401,18 +375,10 @@ export function orderCycleIssues(issues: LinearCycleIssue[]): OrderingResult {
   const graph = createGraph(issues);
   const { ordered, visited } = performKahnTraversal(issues, graph);
   const remainingIds = getRemainingIds(issues, visited);
-  const remainingAdjacency = buildRemainingAdjacency(
-    remainingIds,
-    graph.adjacency,
-    visited
-  );
+  const remainingAdjacency = buildRemainingAdjacency(remainingIds, graph.adjacency, visited);
   const components = createComponents(remainingIds, remainingAdjacency);
   const componentGraph = createComponentGraph(components, remainingAdjacency);
-  const remaining = orderRemainingComponents(
-    components,
-    componentGraph,
-    graph.issueMap
-  );
+  const remaining = orderRemainingComponents(components, componentGraph, graph.issueMap);
 
   return {
     ordered: [...ordered, ...remaining.ordered],

--- a/src/workflows/cycleOrchestrator.ts
+++ b/src/workflows/cycleOrchestrator.ts
@@ -14,11 +14,7 @@ import { PipelineOrchestrator } from './pipelineOrchestrator.js';
 import { formatLinearContext } from '../cli/startHelpers.js';
 import { serializeError } from '../utils/errors.js';
 import type { IssueSnapshot, LinearCycleIssue } from '../adapters/linear/LinearAdapterTypes.js';
-import type {
-  CycleOrchestratorConfig,
-  CycleIssueResult,
-  CycleResult,
-} from './cycleTypes.js';
+import type { CycleOrchestratorConfig, CycleIssueResult, CycleResult } from './cycleTypes.js';
 
 /**
  * Check if an issue should be skipped based on its workflow state.
@@ -211,7 +207,10 @@ export class CycleOrchestrator {
     return cycleResult;
   }
 
-  private async createIssueRunDirectory(issue: LinearCycleIssue, issuesDir: string): Promise<string> {
+  private async createIssueRunDirectory(
+    issue: LinearCycleIssue,
+    issuesDir: string
+  ): Promise<string> {
     const { repoConfig } = this.config;
 
     return createRunDirectory(issuesDir, issue.identifier, {

--- a/tests/unit/cycleIssueOrderer.spec.ts
+++ b/tests/unit/cycleIssueOrderer.spec.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { orderCycleIssues } from '../../src/workflows/cycleIssueOrderer';
-import type { LinearCycleIssue, LinearIssueRelation } from '../../src/adapters/linear/LinearAdapterTypes';
+import type {
+  LinearCycleIssue,
+  LinearIssueRelation,
+} from '../../src/adapters/linear/LinearAdapterTypes';
 
 function makeIssue(
   identifier: string,
@@ -25,10 +28,7 @@ function makeIssue(
   };
 }
 
-function blocksRelation(
-  blockerIdentifier: string,
-  blockedIdentifier: string
-): LinearIssueRelation {
+function blocksRelation(blockerIdentifier: string, blockedIdentifier: string): LinearIssueRelation {
   return {
     type: 'blocks',
     issue: { id: `id-${blockerIdentifier}`, identifier: blockerIdentifier },
@@ -79,10 +79,7 @@ describe('orderCycleIssues', () => {
     // A → B → D
     // A → C → D
     const issues = [
-      makeIssue('ENG-A', 1, [
-        blocksRelation('ENG-A', 'ENG-B'),
-        blocksRelation('ENG-A', 'ENG-C'),
-      ]),
+      makeIssue('ENG-A', 1, [blocksRelation('ENG-A', 'ENG-B'), blocksRelation('ENG-A', 'ENG-C')]),
       makeIssue('ENG-B', 3, [blocksRelation('ENG-B', 'ENG-D')]),
       makeIssue('ENG-C', 2, [blocksRelation('ENG-C', 'ENG-D')]),
       makeIssue('ENG-D', 4, []),
@@ -125,28 +122,29 @@ describe('orderCycleIssues', () => {
     // A ↔ B (cycle), B → C (downstream of cycle)
     const issues = [
       makeIssue('ENG-A', 3, [blocksRelation('ENG-A', 'ENG-B')]),
-      makeIssue('ENG-B', 2, [
-        blocksRelation('ENG-B', 'ENG-A'),
-        blocksRelation('ENG-B', 'ENG-C'),
-      ]),
+      makeIssue('ENG-B', 2, [blocksRelation('ENG-B', 'ENG-A'), blocksRelation('ENG-B', 'ENG-C')]),
       makeIssue('ENG-C', 4, []),
     ];
 
     const result = orderCycleIssues(issues);
     expect(result.hasCycle).toBe(true);
     expect(result.cycleInvolvedIds).toEqual(['ENG-A', 'ENG-B']);
-    expect(result.ordered.map((issue) => issue.identifier)).toEqual([
-      'ENG-A',
-      'ENG-B',
-      'ENG-C',
-    ]);
+    expect(result.ordered.map((issue) => issue.identifier)).toEqual(['ENG-A', 'ENG-B', 'ENG-C']);
   });
 
   it('ignores duplicate and related relations (only uses blocks)', () => {
     const issues = [
       makeIssue('ENG-1', 2, [
-        { type: 'duplicate', issue: { id: 'id-ENG-1', identifier: 'ENG-1' }, relatedIssue: { id: 'id-ENG-2', identifier: 'ENG-2' } },
-        { type: 'related', issue: { id: 'id-ENG-1', identifier: 'ENG-1' }, relatedIssue: { id: 'id-ENG-3', identifier: 'ENG-3' } },
+        {
+          type: 'duplicate',
+          issue: { id: 'id-ENG-1', identifier: 'ENG-1' },
+          relatedIssue: { id: 'id-ENG-2', identifier: 'ENG-2' },
+        },
+        {
+          type: 'related',
+          issue: { id: 'id-ENG-1', identifier: 'ENG-1' },
+          relatedIssue: { id: 'id-ENG-3', identifier: 'ENG-3' },
+        },
       ]),
       makeIssue('ENG-2', 4),
       makeIssue('ENG-3', 1),
@@ -194,11 +192,7 @@ describe('orderCycleIssues', () => {
   });
 
   it('preserves stable ordering for same-priority issues', () => {
-    const issues = [
-      makeIssue('ENG-1', 2),
-      makeIssue('ENG-2', 2),
-      makeIssue('ENG-3', 2),
-    ];
+    const issues = [makeIssue('ENG-1', 2), makeIssue('ENG-2', 2), makeIssue('ENG-3', 2)];
 
     const result = orderCycleIssues(issues);
     // All same priority — Array.sort is stable in V8, so input order preserved

--- a/tests/unit/cycleOrchestrator.spec.ts
+++ b/tests/unit/cycleOrchestrator.spec.ts
@@ -18,9 +18,11 @@ vi.mock('../../src/telemetry/executionTelemetry.js', () => ({
 }));
 
 vi.mock('../../src/persistence/runLifecycle.js', () => ({
-  createRunDirectory: vi.fn().mockImplementation(async (_issuesDir: string, identifier: string) =>
-    `/tmp/test-run/issues/${identifier}`
-  ),
+  createRunDirectory: vi
+    .fn()
+    .mockImplementation(
+      async (_issuesDir: string, identifier: string) => `/tmp/test-run/issues/${identifier}`
+    ),
 }));
 
 const mockExecute = vi.fn();
@@ -35,14 +37,16 @@ vi.mock('../../src/cli/startHelpers.js', () => ({
   formatLinearContext: vi.fn().mockReturnValue('# Linear Issue Context\n...'),
 }));
 
-function makeIssue(overrides: Partial<{
-  id: string;
-  identifier: string;
-  title: string;
-  stateType: string;
-  stateName: string;
-  priority: number;
-}> = {}): LinearCycleIssue {
+function makeIssue(
+  overrides: Partial<{
+    id: string;
+    identifier: string;
+    title: string;
+    stateType: string;
+    stateName: string;
+    priority: number;
+  }> = {}
+): LinearCycleIssue {
   return {
     id: overrides.id ?? 'issue-1',
     identifier: overrides.identifier ?? 'CDMCH-101',
@@ -165,10 +169,7 @@ describe('CycleOrchestrator', () => {
   it('processes all issues sequentially', async () => {
     const config = makeConfig();
     const orchestrator = new CycleOrchestrator(config);
-    const issues = [
-      makeIssue({ identifier: 'CDMCH-101' }),
-      makeIssue({ identifier: 'CDMCH-102' }),
-    ];
+    const issues = [makeIssue({ identifier: 'CDMCH-101' }), makeIssue({ identifier: 'CDMCH-102' })];
 
     const result = await orchestrator.run(issues);
 
@@ -201,10 +202,7 @@ describe('CycleOrchestrator', () => {
 
     mockExecute.mockRejectedValueOnce(new Error('Pipeline failed'));
 
-    const issues = [
-      makeIssue({ identifier: 'CDMCH-101' }),
-      makeIssue({ identifier: 'CDMCH-102' }),
-    ];
+    const issues = [makeIssue({ identifier: 'CDMCH-101' }), makeIssue({ identifier: 'CDMCH-102' })];
 
     const result = await orchestrator.run(issues);
 
@@ -219,19 +217,14 @@ describe('CycleOrchestrator', () => {
     const config = makeConfig({ failFast: false });
     const orchestrator = new CycleOrchestrator(config);
 
-    mockExecute
-      .mockRejectedValueOnce(new Error('Pipeline failed'))
-      .mockResolvedValueOnce({
-        context: { files: 5, totalTokens: 1000, warnings: [] },
-        research: { tasksDetected: 0, pending: 0 },
-        prd: { path: 'prd.md', hash: 'abc', diagnostics: { incompleteSections: [], warnings: [] } },
-        approvalRequired: false,
-      });
+    mockExecute.mockRejectedValueOnce(new Error('Pipeline failed')).mockResolvedValueOnce({
+      context: { files: 5, totalTokens: 1000, warnings: [] },
+      research: { tasksDetected: 0, pending: 0 },
+      prd: { path: 'prd.md', hash: 'abc', diagnostics: { incompleteSections: [], warnings: [] } },
+      approvalRequired: false,
+    });
 
-    const issues = [
-      makeIssue({ identifier: 'CDMCH-101' }),
-      makeIssue({ identifier: 'CDMCH-102' }),
-    ];
+    const issues = [makeIssue({ identifier: 'CDMCH-101' }), makeIssue({ identifier: 'CDMCH-102' })];
 
     const result = await orchestrator.run(issues);
 
@@ -270,10 +263,7 @@ describe('CycleOrchestrator', () => {
     const config = makeConfig({ onIssueComplete });
     const orchestrator = new CycleOrchestrator(config);
 
-    const issues = [
-      makeIssue({ identifier: 'CDMCH-101' }),
-      makeIssue({ identifier: 'CDMCH-102' }),
-    ];
+    const issues = [makeIssue({ identifier: 'CDMCH-101' }), makeIssue({ identifier: 'CDMCH-102' })];
 
     const result = await orchestrator.run(issues);
 
@@ -348,9 +338,7 @@ describe('CycleOrchestrator', () => {
 
     await orchestrator.run([makeIssue()]);
 
-    expect(mockExecute).toHaveBeenCalledWith(
-      expect.objectContaining({ skipExecution: true })
-    );
+    expect(mockExecute).toHaveBeenCalledWith(expect.objectContaining({ skipExecution: true }));
   });
 
   it('handles empty issue list', async () => {

--- a/tests/unit/cycleOutput.spec.ts
+++ b/tests/unit/cycleOutput.spec.ts
@@ -49,7 +49,9 @@ describe('cycleOutput', () => {
 
     renderDryRun(payload, { log, warn });
 
-    expect(log).toHaveBeenCalledWith(expect.stringContaining('Issues: 2 total | 1 processable | 1 will skip'));
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining('Issues: 2 total | 1 processable | 1 will skip')
+    );
     expect(log).toHaveBeenCalledWith(expect.stringContaining('Medium'));
     expect(log).toHaveBeenCalledWith(expect.stringContaining('Urgent'));
     expect(log).toHaveBeenCalledWith(expect.stringContaining('skip'));

--- a/tests/unit/linearAdapter.spec.ts
+++ b/tests/unit/linearAdapter.spec.ts
@@ -55,15 +55,17 @@ const DEFAULT_CYCLE_ISSUE_NODE = {
   relations: [] as Array<{ type: string; relatedIssue: { id: string; identifier: string } }>,
 };
 
-function makeCycleIssueNode(overrides: Partial<{
-  id: string;
-  identifier: string;
-  title: string;
-  stateType: string;
-  stateName: string;
-  priority: number;
-  relations: Array<{ type: string; relatedIssue: { id: string; identifier: string } }>;
-}> = {}) {
+function makeCycleIssueNode(
+  overrides: Partial<{
+    id: string;
+    identifier: string;
+    title: string;
+    stateType: string;
+    stateName: string;
+    priority: number;
+    relations: Array<{ type: string; relatedIssue: { id: string; identifier: string } }>;
+  }> = {}
+) {
   const issue = {
     ...DEFAULT_CYCLE_ISSUE_NODE,
     ...overrides,
@@ -102,9 +104,7 @@ describe('LinearAdapter cycle methods', () => {
   describe('fetchCycleIssues', () => {
     it('fetches cycle issues and transforms GraphQL response', async () => {
       const issueNode = makeCycleIssueNode({
-        relations: [
-          { type: 'blocks', relatedIssue: { id: 'issue-2', identifier: 'CDMCH-102' } },
-        ],
+        relations: [{ type: 'blocks', relatedIssue: { id: 'issue-2', identifier: 'CDMCH-102' } }],
       });
 
       mockPost.mockResolvedValueOnce({
@@ -211,15 +211,11 @@ describe('LinearAdapter cycle methods', () => {
         data: { data: { cycle: null } },
       });
 
-      await expect(adapter.fetchCycleIssues(VALID_CYCLE_ID)).rejects.toThrow(
-        /not found/
-      );
+      await expect(adapter.fetchCycleIssues(VALID_CYCLE_ID)).rejects.toThrow(/not found/);
     });
 
     it('rejects invalid cycle ID format', async () => {
-      await expect(adapter.fetchCycleIssues('not-a-uuid')).rejects.toThrow(
-        LinearAdapterError
-      );
+      await expect(adapter.fetchCycleIssues('not-a-uuid')).rejects.toThrow(LinearAdapterError);
       await expect(adapter.fetchCycleIssues('CDMCH-123')).rejects.toThrow(
         /Cycle IDs must be UUIDs/
       );
@@ -343,8 +339,14 @@ describe('LinearAdapter cycle methods', () => {
       expect(result.metadata.issueCount).toBe(2);
       expect(mockPost).toHaveBeenCalledTimes(2);
 
-      const firstRequest = mockPost.mock.calls[0]?.[1] as { query: string; variables: { after?: string | null } };
-      const secondRequest = mockPost.mock.calls[1]?.[1] as { query: string; variables: { after?: string | null } };
+      const firstRequest = mockPost.mock.calls[0]?.[1] as {
+        query: string;
+        variables: { after?: string | null };
+      };
+      const secondRequest = mockPost.mock.calls[1]?.[1] as {
+        query: string;
+        variables: { after?: string | null };
+      };
 
       expect(firstRequest.query).toContain('issues(first: 250, after: $after)');
       expect(firstRequest.variables.after).toBeNull();
@@ -401,7 +403,9 @@ describe('LinearAdapter cycle methods', () => {
       });
 
       await expect(adapter.fetchActiveCycle(VALID_TEAM_ID)).rejects.toThrow(/not found/);
-      expect((adapter as { logger: { error: ReturnType<typeof vi.fn> } }).logger.error).not.toHaveBeenCalled();
+      expect(
+        (adapter as { logger: { error: ReturnType<typeof vi.fn> } }).logger.error
+      ).not.toHaveBeenCalled();
     });
 
     it('propagates API errors', async () => {
@@ -423,9 +427,7 @@ describe('LinearAdapter cycle methods', () => {
       });
 
       // Should not throw on validation; the "not found" error comes after
-      await expect(adapter.fetchCycleIssues(VALID_CYCLE_ID)).rejects.toThrow(
-        /not found/
-      );
+      await expect(adapter.fetchCycleIssues(VALID_CYCLE_ID)).rejects.toThrow(/not found/);
     });
 
     it('rejects Linear issue identifier format', async () => {
@@ -435,9 +437,7 @@ describe('LinearAdapter cycle methods', () => {
     });
 
     it('rejects arbitrary strings', async () => {
-      await expect(adapter.fetchCycleIssues('hello world')).rejects.toThrow(
-        LinearAdapterError
-      );
+      await expect(adapter.fetchCycleIssues('hello world')).rejects.toThrow(LinearAdapterError);
     });
   });
 });


### PR DESCRIPTION
## Summary

Describe what this PR changes and why.

## Test Plan

How was this verified?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist

- [ ] `npm run format:check && npm run lint` passes
- [ ] `npm test` passes
- [ ] `npm run docs:links:check` passes
- [ ] `npm run build` succeeds
- [ ] Documentation updated (if applicable)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/889" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added complete CLI reference documentation for the new `codepipe cycle` command, including supported flags (`--cycle`, `--dry-run`, `--fail-fast`, `--json`, `--max-issues`, `--plan-only`, `--verbose`) and example usage.

* **Bug Fixes**
  * Improved error handling and validation messages when required configuration values are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a critical bug where the async callback was never properly passed as the second argument to `runWithTelemetry` in the `cycle` command, meaning the telemetry-wrapped execution body was never invoked. It also removes several now-unnecessary non-null assertions (`!`), adds a new safety guard for empty results from `sanitizeCycleId`, and applies project-wide Prettier formatting across all touched files (import grouping, multi-line type annotations, switch-case layout).

Key changes:
- **Core fix**: `async (ctx) => {` is now correctly supplied as the second argument to `runWithTelemetry`, making the entire cycle orchestration reachable.
- **Non-null assertion removal**: `apiKey!`, `cycleId!` assertions are safely removed because the outer guards (`if (!apiKey)`, `if (!cycleId && !teamId)`) ensure those paths exit before the callback is entered. However, `teamId!` → `teamId` introduces a TypeScript strict-mode type error (see inline comment).
- **New guard**: Empty `sanitized` string after `sanitizeCycleId()` now throws a `CliError` instead of silently creating a `cycle-` directory.
- **Docs**: Complete CLI reference entry for `codepipe cycle` added, with all flags correctly typed.

<h3>Confidence Score: 4/5</h3>

Nearly safe to merge — one TypeScript strict-mode compilation error needs resolving before `npm run build` can succeed.

The core telemetry callback fix is correct and the overall direction of the PR (removing `!` assertions, adding sanitization guard) is sound. One P1 remains: `teamId` is typed `string | undefined` and is passed without narrowing to `fetchActiveCycle(teamId: string)` inside the async closure, which will fail `tsc --strict`. The fix is a single line. All other changes are formatting or documentation and pose no risk.

`src/cli/commands/cycle.ts` line 153 — `teamId` type narrowing inside the async closure.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/cli/commands/cycle.ts | Core fix: properly passes the async callback as the second argument to `runWithTelemetry`; also removes non-null assertions and adds a `sanitizeCycleId` empty-result guard — but the removal of `teamId!` introduces a TypeScript strict-mode type error on the `fetchActiveCycle` call (line 153). |
| src/adapters/linear/LinearAdapter.ts | Formatting-only changes (multi-line type annotations and ternary layout reformatted); no logic changes. |
| src/workflows/cycleOrchestrator.ts | Formatting-only: import grouping and method signature reformatted; no logic changes. |
| docs/reference/cli/cli-reference.md | Adds `codepipe cycle` CLI reference documentation including all flags and examples; `--max-issues` type is now correctly listed as `integer` (previously flagged issue already addressed). |
| AGENTS.md | Adds `cycle` to the command surface list; straightforward documentation update. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as Cycle.run()
    participant Guard as Outer Guards
    participant Tel as runWithTelemetry()
    participant CB as async callback(ctx)
    participant LA as LinearAdapter
    participant Orch as CycleOrchestrator

    CLI->>Guard: check linear enabled, apiKey, teamId/cycleId
    Guard-->>CLI: exit if invalid

    CLI->>Tel: runWithTelemetry(options, async(ctx) => {...})
    Note over Tel,CB: BUG FIX: callback now correctly passed as 2nd arg

    Tel->>CB: invoke with telemetry context

    alt cycleId not provided
        CB->>LA: fetchActiveCycle(teamId)
        Note over CB,LA: teamId: string|undefined — type error in strict mode
        LA-->>CB: active cycle or null
    end

    CB->>LA: fetchCycleIssues(cycleId)
    LA-->>CB: snapshot

    CB->>Orch: orchestrator.run(ordered issues)
    Orch-->>CB: CycleResult

    CB-->>Tel: return exitCode
    Tel-->>CLI: done
```

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%201%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fcli%2Fcommands%2Fcycle.ts%3A153%0A**%60teamId%60%20type%20mismatch%20%E2%80%94%20TypeScript%20strict-mode%20compilation%20error**%0A%0A%60teamId%60%20is%20inferred%20as%20%60string%20%7C%20undefined%60%20from%20%60config.linear%3F.team_id%60%20%28the%20schema%20marks%20it%20%60z.string%28%29.optional%28%29%60%29.%20%60fetchActiveCycle%60%20is%20typed%20%60async%20fetchActiveCycle%28teamId%3A%20string%29%60%20%E2%80%94%20it%20does%20not%20accept%20%60undefined%60.%0A%0AThe%20previous%20code%20used%20%60teamId!%60%20to%20assert%20non-null.%20This%20PR%20removes%20that%20assertion%2C%20but%20the%20outer%20guard%20%28%60if%20%28!cycleId%20%26%26%20!teamId%29%60%29%20lives%20in%20the%20enclosing%20%60run%28%29%60%20scope%20and%20TypeScript%20does%20**not**%20carry%20the%20narrowing%20into%20the%20async%20closure%20because%20%60cycleId%60%20is%20a%20%60let%60%20variable%20%28its%20narrowing%20is%20always%20reset%20across%20closure%20boundaries%29.%0A%0AAs%20a%20result%2C%20inside%20%60if%20%28!cycleId%29%60%20TypeScript%20still%20sees%20%60teamId%3A%20string%20%7C%20undefined%60%2C%20and%20the%20call%20below%20fails%20with%3A%0A%0A%60%60%60%0AArgument%20of%20type%20'string%20%7C%20undefined'%20is%20not%20assignable%20to%20parameter%20of%20type%20'string'%0A%60%60%60%0A%0AThe%20cleanest%20fix%20that%20matches%20the%20PR's%20intent%20%28removing%20redundant%20%60!%60%20assertions%20while%20keeping%20correctness%29%20is%20to%20add%20an%20explicit%20narrowing%20guard%20immediately%20before%20the%20call%3A%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%20%20if%20%28!cycleId%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20if%20%28!teamId%29%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20throw%20new%20CliError%28%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20'No%20--cycle%20flag%20provided%20and%20no%20team_id%20configured.%20Set%20linear.team_id%20in%20.codepipe%2Fconfig.json%20or%20pass%20--cycle.'%2C%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20CliErrorCode.CONFIG_INVALID%0A%20%20%20%20%20%20%20%20%20%20%20%20%29%3B%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20%20%20const%20adapter%20%3D%20new%20LinearAdapter%28%7B%20apiKey%20%7D%29%3B%0A%20%20%20%20%20%20%20%20%20%20const%20active%20%3D%20await%20adapter.fetchActiveCycle%28teamId%29%3B%0A%60%60%60%0A%0AAlternatively%2C%20keeping%20%60teamId!%60%20%28non-null%20assertion%29%20would%20also%20compile%20cleanly%20and%20the%20runtime%20safety%20is%20identical.%0A%0A&repo=kinginyellows%2Fcodemachine-pipeline"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/cli/commands/cycle.ts
Line: 153

Comment:
**`teamId` type mismatch — TypeScript strict-mode compilation error**

`teamId` is inferred as `string | undefined` from `config.linear?.team_id` (the schema marks it `z.string().optional()`). `fetchActiveCycle` is typed `async fetchActiveCycle(teamId: string)` — it does not accept `undefined`.

The previous code used `teamId!` to assert non-null. This PR removes that assertion, but the outer guard (`if (!cycleId && !teamId)`) lives in the enclosing `run()` scope and TypeScript does **not** carry the narrowing into the async closure because `cycleId` is a `let` variable (its narrowing is always reset across closure boundaries).

As a result, inside `if (!cycleId)` TypeScript still sees `teamId: string | undefined`, and the call below fails with:

```
Argument of type 'string | undefined' is not assignable to parameter of type 'string'
```

The cleanest fix that matches the PR's intent (removing redundant `!` assertions while keeping correctness) is to add an explicit narrowing guard immediately before the call:

```suggestion
        if (!cycleId) {
          if (!teamId) {
            throw new CliError(
              'No --cycle flag provided and no team_id configured. Set linear.team_id in .codepipe/config.json or pass --cycle.',
              CliErrorCode.CONFIG_INVALID
            );
          }
          const adapter = new LinearAdapter({ apiKey });
          const active = await adapter.fetchActiveCycle(teamId);
```

Alternatively, keeping `teamId!` (non-null assertion) would also compile cleanly and the runtime safety is identical.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (2): Last reviewed commit: ["style: normalize cycle branch formatting"](https://github.com/kinginyellows/codemachine-pipeline/commit/1ccffec3692ac86acf2033083400a088c2643756) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=26862340)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->