### PR TITLE
fix(cli): add missing async callback in cycle command runWithTelemetry

### DIFF
--- a/src/cli/commands/cycle.ts
+++ b/src/cli/commands/cycle.ts
@@ -151,6 +151,7 @@ export default class Cycle extends TelemetryCommand {
         verbose: typedFlags.verbose,
         runDirPath: settings.baseDir,
       },
+      async (ctx) => {
         const logger = ctx.logger;
         const metrics = ctx.metrics;
 


### PR DESCRIPTION
## Summary

- PR #873 (`feat(cli): add codepipe cycle command`) shipped with a missing `async (ctx) => {` callback declaration in the `runWithTelemetry` call, causing 3 TypeScript compilation errors that blocked the entire build and test suite.
- This restores the missing arrow function line, matching the pattern used by all sibling commands (plan.ts, approve.ts, validate.ts, etc.).

## Test Plan

- [x] `npx tsc --noEmit` passes (0 errors)
- [x] `npm test` passes (294/294 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal async handling in the CLI to ensure proper promise-based execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores the missing `async (ctx) => {` arrow function declaration that opens the `runWithTelemetry` callback in the `cycle` command. Without this line the second argument to `runWithTelemetry` was absent, leaving the callback body as dangling statements — a compile-time syntax error preventing the command from running at all.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single-line fix that restores a missing async callback declaration, no logic changes.

The change is a minimal, correct one-line addition that fixes a compile-time syntax error. The `async` keyword is required because the callback body uses `await` (e.g. `await adapter.fetchActiveCycle()`). The closing braces and parentheses all balance correctly after the fix. No new logic, no new imports, no other issues found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/cli/commands/cycle.ts | Adds missing `async (ctx) => {` arrow function opening for the `runWithTelemetry` callback — fixes a syntax error where the callback body was dangling as free statements. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as Cycle Command
    participant TCmd as TelemetryCommand
    participant Logger as StructuredLogger
    participant Metrics as MetricsCollector
    participant Linear as LinearAdapter
    participant Orch as CycleOrchestrator

    CLI->>TCmd: runWithTelemetry(options, async (ctx) => { ... })
    TCmd->>Logger: createCliLogger()
    TCmd->>Metrics: createRunMetricsCollector()
    TCmd->>TCmd: build TelemetryContext (ctx)
    TCmd->>CLI: execute(ctx)
    CLI->>Linear: fetchActiveCycle() [if no cycleId]
    Linear-->>CLI: cycleId
    CLI->>Linear: fetchCycleIssues(cycleId)
    Linear-->>CLI: snapshot
    alt dry-run
        CLI->>CLI: renderDryRun(payload)
    else real execution
        CLI->>Orch: orchestrator.run(ordered)
        Orch-->>CLI: result
        CLI->>CLI: renderCycleSummary / renderCycleJson
    end
    CLI-->>TCmd: { exitCode }
    TCmd->>TCmd: flushTelemetrySuccess()
    TCmd->>TCmd: process.exit(exitCode) if non-zero
```

<sub>Reviews (1): Last reviewed commit: ["fix(cli): add missing async callback in ..."](https://github.com/kinginyellows/codemachine-pipeline/commit/e2b93c77a16eca3a01d04cec53f7c833ac96dc5b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27344963)</sub>

<!-- /greptile_comment -->