### PR TITLE
fix: resolve cycle.ts lint errors and update CHANGELOG for v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,139 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-(Empty - all changes included in v1.0.0)
+## [1.1.0] - 2026-04-04
+
+### Added
+
+#### Cycle Command — Batch Linear Sprint Processing
+- `codepipe cycle` CLI command for batch processing all issues in a Linear cycle (#873)
+- CycleOrchestrator for sequential issue processing with skip logic (Done/Canceled/In Review auto-skipped) (#871)
+- Topological sort via Kahn's algorithm with Tarjan's SCC cycle detection for dependency-safe ordering (#870)
+- `fetchCycleIssues` with cursor-based pagination (250/page) and relation normalization (#869)
+- `fetchActiveCycle` for automatic active cycle resolution per team (#869)
+- Linear cycle and relation types: `LinearCycleIssue`, `LinearIssueRelation`, `LinearCycle`, `CycleSnapshot` (#868)
+- Cycle dashboard with live progress updates, dry-run preview, and JSON output (#872)
+- Per-issue run directory isolation and `report.json` audit trail (#871)
+
+#### Public Repository Preparation
+- CODE_OF_CONDUCT.md — Contributor Covenant v2.1 (#851)
+- Pull request template with summary, test plan, and checklist (#851)
+- Bug report and feature request issue templates (#840)
+- SECURITY.md with vulnerability disclosure policy (#826)
+- CONTRIBUTING.md updates with external contributor fork workflow (#840)
+- Per-module READMEs for all 8 `src/` directories (#867)
+
+#### CI & Infrastructure
+- Post-release install verification script `scripts/tooling/verify_install.sh` (#862)
+- Package version pruning workflow — weekly cleanup retaining 2 most recent pre-releases (#861)
+- Composite Node.js setup action for CI workflow DRY (#784, CDMCH-123)
+
+### Changed
+
+#### Architecture Refactoring (40+ module splits)
+- Decomposed `Resume.run()` god function into focused modules (CDMCH-253, #821)
+- Decomposed `Init.run()` god function into focused private methods (CDMCH-160, #671)
+- Extracted `PipelineOrchestrator` from `start.ts` (CDMCH-177, #776)
+- Split `taskPlanner` into `plannerDAG` + `plannerPersistence` (CDMCH-210, #670)
+- Split `RepoConfig` into schema, defaults, and loader modules (CDMCH-213, #668, #626)
+- Split `contextSummarizer` into budget, store, orchestration, and types (#634)
+- Split `cliExecutionEngine` into dependency resolver, telemetry recorder, artifact capture (#632)
+- Split `contextAggregator` into file discovery and document builder (#633)
+- Split `resumeCoordinator` into `runStateVerifier` + `resumeQueueRecovery` (#628)
+- Split `writeActionQueue` into store and rate-limiter modules (#629)
+- Split `validationRegistry` into store and orchestration layers (#630)
+- Split `RunDirectoryManager` into focused modules (#625)
+- Split `cli/status/data.ts` into domain modules (#631)
+- Extracted `branchComplianceChecker` from `branchProtection` adapter (#636)
+- Split `prdAuthoringEngine` into `prdStore` and authoring algorithm (#635)
+- Extracted command utilities from `autoFixEngine` into `commandRunner` (CDMCH-211, #669)
+- Extracted `RepoConfigLoader` from `RepoConfig` (CDMCH-213, #668)
+- Extracted `LinearAdapterTypes` from `LinearAdapter` (CDMCH-203, #765)
+- Extracted `resumeIntegrityChecker` from `runStateVerifier` (#667)
+- Consolidated spec generators/rendering into `specComposer` (#598, #600)
+
+#### Barrel Export & Import Cleanup
+- Removed `runDirectoryManager` barrel, updated all imports (CDMCH-243, #822)
+- Removed barrel re-exports from `validationRegistry` (CDMCH-252, #818)
+- Replaced models barrel with sub-barrel re-exports (CDMCH-216, #677)
+- Removed `specComposer` backward-compat re-exports (CDMCH-249, #819)
+- Redirected workflow imports to persistence barrel index (#603)
+
+#### Layer Boundary Enforcement
+- Fixed 6 architecture layer violations (findings 125-126, 135-139, #623)
+- Extracted shared types to break circular dependencies (findings 121-122, #622)
+- Fixed persistence → workflow layer inversion (findings 138, 143, #662)
+
+#### CI Migration
+- Migrated all workflows to GitHub-hosted runners (#855)
+- Added repository guards and fork checks for public repo security (#826)
+- Added `timeout-minutes` to all CI jobs (#826)
+
+#### Code Quality
+- Removed redundant comments from Zod schemas and workflow headers (CDMCH-179, CDMCH-187, #773)
+- Removed tautological JSDoc and enum member comments (#595, #596)
+- Removed AI-pattern noise across codebase (findings 191-209, #639, #661)
+- Deduplicated CLI command boilerplate across 17 findings (#637)
+- Replaced ternary chains with `statusDelta` helper (CDMCH-201, #738)
+- Replaced `generateRecommendations` if-else chain with Map lookup (CDMCH-185, #768)
+- Introduced `withLogging<T>()` wrapper to eliminate try/catch boilerplate (CDMCH-202, #772)
+- Extracted shared `mapExitToStatus()` and `buildStrategyResult()` helpers (CDMCH-190, #770)
+- Removed non-null assertions (#619)
+- Simplified boolean returns (#620)
+- Replaced `any` type assertions with `unknown` (#618)
+- Removed queue backward-compat shims (CDMCH-188, #790)
+- Declarative env checks and flattened PRCreate try-catch (CDMCH-148, CDMCH-149, #676)
+- Added injectable factory params to decouple CLI adapter creation (#602)
+- Extracted `fillTaskBatch` and `recordTaskOutcome` from execute loop (#601)
+
+#### Documentation
+- README expansion with CI/CD section and restructured support info (#840)
+- Private maintainer artifact removal (#837)
+- Public-facing reference cleanup (#838)
+- AGENTS.md alignment (#874)
+
+### Fixed
+
+#### Security Improvements
+- Replaced custom `parseCommandString` with `shell-quote` for POSIX-compliant command parsing (CDMCH-199, #785, #787)
+- Added Zod schema validation at all JSON deserialization boundaries — `PRMetadataSchema`, `CostTrackerStateSchema`, `RateLimitLedgerDataSchema`, `ApprovalsFileSchema`, and 5 more (findings 104, 108-114, #617)
+- Hardened input validation: `os.mkdtemp` private directories, branch name allowlist, symlink cycle detection, spec.json Zod validation (findings 105-107, 115-120, #621)
+- Consolidated secret redaction into `RedactionEngine` (CDMCH-168, #675)
+- URL-encoded path parameters in GitHub adapter to prevent injection (#587)
+- Filtered environment variables via allowlist in `autoFixEngine` (#587)
+- Replaced shell exec template literals with `execFileAsync` in `branchManager` and `patchManager` (#616)
+- Added `issueId` validation to all LinearAdapter public methods (CDMCH-161, #740)
+- Capped `retryAfterSeconds` from external API at 300s maximum (CDMCH-196, #739)
+- Added env var name validation and template substitution hardening (CDMCH-214, CDMCH-215, #673)
+- Made GitHub API version configurable (CDMCH-209, #674)
+- Added Zod schema validation for HTTP response parsing (#621)
+
+#### Bug Fixes
+- Flaky concurrent access test: added in-memory promise chain to serialize same-process callers in lockManager with AsyncLocalStorage reentrancy (CDMCH-232, #797)
+- Circular dependencies: extracted `DEFAULT_GITHUB_API_VERSION` to `configConstants`, resume types to `core/models/resumeTypes` (CDMCH-233, #797)
+- Redaction test fixtures: replaced non-matching placeholders with realistic `ghp_`/`ghs_` tokens (#857)
+- Integration test fixture metadata and telemetry expectations (#614, #672)
+- Removed unsupported `access:public` from `publishConfig` (#856)
+- CI drift loop from auto-formatter conflict in CLI reference generator
+- Resolved CI failures for v1.1.0 publish (CDMCH-231, #859)
+- Removed bundled dependency vulnerabilities (#853)
+- Sanitized secret-scanner false positives
+- Restored redaction fixtures after history rewrite
+- Fixed broken documentation paths and updated tests (#486)
+- ESLint `Record<string, unknown>` disable patterns (CDMCH-122, #763)
+- Batch tech debt fixes for cycle 8 sprint (CDMCH-119, CDMCH-118, CDMCH-135, CDMCH-126, #762)
+- Reduced cyclomatic complexity in god functions (findings 148-173, #638, #663)
+- High-priority security and architecture debt (8 fixes, #587)
+
+### Dependencies
+
+- Bumped `undici` 7.22.0 → 7.24.1 (#827)
+- Bumped `hono` 4.11.9 → 4.12.7 (#828)
+- Bumped `rollup` 4.56.0 → 4.59.0 (#831)
+- Bumped `express-rate-limit` 8.2.1 → 8.3.1 (#830)
+- Bumped `flatted` 3.3.3 → 3.4.1 (#833)
+- Bumped `basic-ftp` 5.1.0 → 5.2.0 (#829)
+- 8 additional minor/patch dependency updates (#864)
 
 ## [1.0.0] - 2026-02-14
 

--- a/src/adapters/linear/LinearAdapter.ts
+++ b/src/adapters/linear/LinearAdapter.ts
@@ -248,11 +248,9 @@ type RawCycleRelationNode = {
 };
 type RawLinearCycleIssue = LinearIssue & {
   labels: LinearIssue['labels'] | { nodes: LinearIssue['labels'] };
-  relations?:
-    | {
-        nodes?: Array<RawCycleRelationNode | null> | null;
-      }
-    | null;
+  relations?: {
+    nodes?: Array<RawCycleRelationNode | null> | null;
+  } | null;
 };
 type CycleQueryResponse = {
   data: {
@@ -559,16 +557,14 @@ export class LinearAdapter {
     LinearAdapter.validateCycleId(cycleId);
     try {
       let after: string | null = null;
-      let cycleSummary:
-        | {
-            id: string;
-            name: string;
-            number: number;
-            startsAt: string;
-            endsAt: string;
-            teamId: string;
-          }
-        | null = null;
+      let cycleSummary: {
+        id: string;
+        name: string;
+        number: number;
+        startsAt: string;
+        endsAt: string;
+        teamId: string;
+      } | null = null;
       const issues: LinearCycleIssue[] = [];
 
       do {
@@ -597,10 +593,12 @@ export class LinearAdapter {
             number: cycle.number,
             startsAt: cycle.startsAt,
             endsAt: cycle.endsAt,
-            teamId: cycle.team?.id ?? (() => {
-              this.logger.warn('Cycle has no team association', { cycleId: cycle.id });
-              return '';
-            })(),
+            teamId:
+              cycle.team?.id ??
+              (() => {
+                this.logger.warn('Cycle has no team association', { cycleId: cycle.id });
+                return '';
+              })(),
           };
         }
 
@@ -608,7 +606,9 @@ export class LinearAdapter {
 
         const pageInfo = cycle.issues.pageInfo;
         after =
-          pageInfo?.hasNextPage && typeof pageInfo.endCursor === 'string' ? pageInfo.endCursor : null;
+          pageInfo?.hasNextPage && typeof pageInfo.endCursor === 'string'
+            ? pageInfo.endCursor
+            : null;
       } while (after !== null);
 
       return {
@@ -736,9 +736,7 @@ export class LinearAdapter {
     }
   }
 
-  private normalizeCycleIssue(
-    node: RawLinearCycleIssue
-  ): LinearCycleIssue {
+  private normalizeCycleIssue(node: RawLinearCycleIssue): LinearCycleIssue {
     const relationNodes: Array<RawCycleRelationNode | null> =
       node.relations &&
       typeof node.relations === 'object' &&
@@ -746,8 +744,7 @@ export class LinearAdapter {
       Array.isArray(node.relations.nodes)
         ? node.relations.nodes
         : new Array<RawCycleRelationNode | null>();
-    const labels =
-      node.labels && 'nodes' in node.labels ? node.labels.nodes : node.labels;
+    const labels = node.labels && 'nodes' in node.labels ? node.labels.nodes : node.labels;
 
     return {
       ...node,

--- a/src/cli/commands/cycle.ts
+++ b/src/cli/commands/cycle.ts
@@ -15,16 +15,8 @@ import {
 } from '../cycleOutput';
 import { type CycleFlags, type CyclePayload } from '../cycleTypes';
 import { findGitRoot } from '../startHelpers';
-import {
-  resolveRunDirectorySettings,
-  requireConfig,
-} from '../utils/runDirectory';
-import {
-  CliError,
-  CliErrorCode,
-  formatErrorJson,
-  setJsonOutputMode,
-} from '../utils/cliErrors';
+import { resolveRunDirectorySettings, requireConfig } from '../utils/runDirectory';
+import { CliError, CliErrorCode, formatErrorJson, setJsonOutputMode } from '../utils/cliErrors';
 
 function containsPathTraversal(value: string): boolean {
   return value.includes('..') || value.includes('/') || value.includes('\\');
@@ -146,8 +138,8 @@ export default class Cycle extends TelemetryCommand {
     await fs.mkdir(path.join(settings.baseDir, '.cycle-command'), { recursive: true });
 
     await this.runWithTelemetry(
-      { 
-        jsonMode: typedFlags.json, 
+      {
+        jsonMode: typedFlags.json,
         verbose: typedFlags.verbose,
         runDirPath: settings.baseDir,
       },
@@ -157,8 +149,8 @@ export default class Cycle extends TelemetryCommand {
 
         // Resolve cycle ID inside telemetry context to catch API errors properly
         if (!cycleId) {
-          const adapter = new LinearAdapter({ apiKey: apiKey! });
-          const active = await adapter.fetchActiveCycle(teamId!);
+          const adapter = new LinearAdapter({ apiKey });
+          const active = await adapter.fetchActiveCycle(teamId!); // eslint-disable-line @typescript-eslint/no-unnecessary-type-assertion -- TS can't narrow across callback for let cycleId
           if (!active) {
             throw new CliError(
               'No active cycle found for the configured team.',
@@ -169,7 +161,7 @@ export default class Cycle extends TelemetryCommand {
         }
 
         // Validate cycle ID for path traversal
-        if (containsPathTraversal(cycleId!)) {
+        if (containsPathTraversal(cycleId)) {
           throw new CliError(
             'Cycle ID must not contain path traversal or path separator characters.',
             CliErrorCode.CONFIG_INVALID
@@ -177,17 +169,17 @@ export default class Cycle extends TelemetryCommand {
         }
 
         // Sanitize and create cycle directory
-        const sanitized = sanitizeCycleId(cycleId!);
+        const sanitized = sanitizeCycleId(cycleId);
         const cycleDir = path.join(settings.baseDir, `cycle-${sanitized}`);
         await fs.mkdir(cycleDir, { recursive: true });
 
         // Fetch cycle issues
         const adapter = new LinearAdapter({
-          apiKey: apiKey!,
+          apiKey,
           runDir: cycleDir,
           ...(logger ? { logger } : {}),
         });
-        const snapshot = await adapter.fetchCycleIssues(cycleId!);
+        const snapshot = await adapter.fetchCycleIssues(cycleId);
         const cycle = snapshot.cycle;
 
         logger?.info('Cycle fetched', {

--- a/src/cli/cycleOutput.ts
+++ b/src/cli/cycleOutput.ts
@@ -30,17 +30,23 @@ function formatDuration(ms: number): string {
 
 function statusIcon(status: CycleIssueResult['status']): string {
   switch (status) {
-    case 'completed': return CHECK;
-    case 'failed': return CROSS;
-    case 'skipped': return DASH;
+    case 'completed':
+      return CHECK;
+    case 'failed':
+      return CROSS;
+    case 'skipped':
+      return DASH;
   }
 }
 
 function statusLabel(status: CycleIssueResult['status']): string {
   switch (status) {
-    case 'completed': return 'done';
-    case 'failed': return 'FAILED';
-    case 'skipped': return 'skipped';
+    case 'completed':
+      return 'done';
+    case 'failed':
+      return 'FAILED';
+    case 'skipped':
+      return 'skipped';
   }
 }
 
@@ -53,7 +59,9 @@ export function renderDryRun(payload: CyclePayload, callbacks: OutputCallbacks):
 
   log('');
   log(`Cycle: ${payload.cycleName} (${payload.cycleId})`);
-  log(`Issues: ${payload.totalIssues} total | ${payload.processable} processable | ${payload.skipped} will skip`);
+  log(
+    `Issues: ${payload.totalIssues} total | ${payload.processable} processable | ${payload.skipped} will skip`
+  );
   log(line);
   log('');
   log('  #  Issue       Priority   State            Action');

--- a/src/cli/cycleTypes.ts
+++ b/src/cli/cycleTypes.ts
@@ -42,4 +42,3 @@ export function getCyclePayloadCounts(payload: CyclePayload): {
   const skipped = payload.orderedIssues.filter((i) => i.willSkip).length;
   return { totalIssues: total, processable: total - skipped, skipped };
 }
-

--- a/src/utils/githubApiUrl.ts
+++ b/src/utils/githubApiUrl.ts
@@ -47,12 +47,10 @@ export function classifyGitHubApiBaseUrl(baseUrl: string | undefined): GitHubApi
   try {
     const parsed = new URL(baseUrl);
     const normalizedPath = trimTrailingSlash(parsed.pathname);
-    return (
-      parsed.protocol === 'https:' &&
+    return parsed.protocol === 'https:' &&
       parsed.hostname === 'api.github.com' &&
       parsed.port === '' &&
       normalizedPath === '/'
-    )
       ? 'default'
       : 'custom';
   } catch {

--- a/src/workflows/cycleIssueOrderer.ts
+++ b/src/workflows/cycleIssueOrderer.ts
@@ -36,15 +36,11 @@ interface ComponentLevelEntry {
   priority: number;
 }
 
-function sortByPriorityDescending(
-  issues: LinearCycleIssue[]
-): LinearCycleIssue[] {
+function sortByPriorityDescending(issues: LinearCycleIssue[]): LinearCycleIssue[] {
   return [...issues].sort((a, b) => b.priority - a.priority);
 }
 
-function createIssueMap(
-  issues: LinearCycleIssue[]
-): Map<string, LinearCycleIssue> {
+function createIssueMap(issues: LinearCycleIssue[]): Map<string, LinearCycleIssue> {
   const issueMap = new Map<string, LinearCycleIssue>();
   for (const issue of issues) {
     issueMap.set(issue.identifier, issue);
@@ -91,9 +87,7 @@ function getZeroInDegreeIssues(
   issues: LinearCycleIssue[],
   inDegree: Map<string, number>
 ): LinearCycleIssue[] {
-  return sortByPriorityDescending(
-    issues.filter((issue) => inDegree.get(issue.identifier) === 0)
-  );
+  return sortByPriorityDescending(issues.filter((issue) => inDegree.get(issue.identifier) === 0));
 }
 
 function processCurrentLevel(
@@ -146,13 +140,8 @@ function performKahnTraversal(
   return { ordered, visited };
 }
 
-function getRemainingIds(
-  issues: LinearCycleIssue[],
-  visited: Set<string>
-): string[] {
-  return issues
-    .map((issue) => issue.identifier)
-    .filter((issueId) => !visited.has(issueId));
+function getRemainingIds(issues: LinearCycleIssue[], visited: Set<string>): string[] {
+  return issues.map((issue) => issue.identifier).filter((issueId) => !visited.has(issueId));
 }
 
 function buildRemainingAdjacency(
@@ -196,18 +185,12 @@ function findStronglyConnectedComponents(
     for (const neighborId of adjacency.get(nodeId) ?? new Set<string>()) {
       if (!indices.has(neighborId)) {
         visit(neighborId);
-        lowLinks.set(
-          nodeId,
-          Math.min(lowLinks.get(nodeId)!, lowLinks.get(neighborId)!)
-        );
+        lowLinks.set(nodeId, Math.min(lowLinks.get(nodeId)!, lowLinks.get(neighborId)!));
         continue;
       }
 
       if (onStack.has(neighborId)) {
-        lowLinks.set(
-          nodeId,
-          Math.min(lowLinks.get(nodeId)!, indices.get(neighborId)!)
-        );
+        lowLinks.set(nodeId, Math.min(lowLinks.get(nodeId)!, indices.get(neighborId)!));
       }
     }
 
@@ -236,10 +219,7 @@ function findStronglyConnectedComponents(
   return components;
 }
 
-function isCycleComponent(
-  nodeIds: string[],
-  adjacency: Map<string, Set<string>>
-): boolean {
+function isCycleComponent(nodeIds: string[], adjacency: Map<string, Set<string>>): boolean {
   return (
     nodeIds.length > 1 ||
     (nodeIds.length === 1 && adjacency.get(nodeIds[0])?.has(nodeIds[0]) === true)
@@ -250,12 +230,10 @@ function createComponents(
   remainingIds: string[],
   remainingAdjacency: Map<string, Set<string>>
 ): Component[] {
-  return findStronglyConnectedComponents(remainingIds, remainingAdjacency).map(
-    (nodeIds) => ({
-      nodeIds,
-      isCycle: isCycleComponent(nodeIds, remainingAdjacency),
-    })
-  );
+  return findStronglyConnectedComponents(remainingIds, remainingAdjacency).map((nodeIds) => ({
+    nodeIds,
+    isCycle: isCycleComponent(nodeIds, remainingAdjacency),
+  }));
 }
 
 function createComponentGraph(
@@ -300,9 +278,7 @@ function getComponentPriority(
   component: Component,
   issueMap: Map<string, LinearCycleIssue>
 ): number {
-  return Math.max(
-    ...component.nodeIds.map((nodeId) => issueMap.get(nodeId)!.priority)
-  );
+  return Math.max(...component.nodeIds.map((nodeId) => issueMap.get(nodeId)!.priority));
 }
 
 function getReadyComponents(
@@ -373,9 +349,7 @@ function orderRemainingComponents(
 
     for (const { index } of currentLevel) {
       appendComponent(components[index], issueMap, ordered, cycleInvolvedIds);
-      nextLevel.push(
-        ...unlockNeighborComponents(index, components, componentGraph, issueMap)
-      );
+      nextLevel.push(...unlockNeighborComponents(index, components, componentGraph, issueMap));
     }
 
     currentLevel = nextLevel.sort((a, b) => b.priority - a.priority);
@@ -401,18 +375,10 @@ export function orderCycleIssues(issues: LinearCycleIssue[]): OrderingResult {
   const graph = createGraph(issues);
   const { ordered, visited } = performKahnTraversal(issues, graph);
   const remainingIds = getRemainingIds(issues, visited);
-  const remainingAdjacency = buildRemainingAdjacency(
-    remainingIds,
-    graph.adjacency,
-    visited
-  );
+  const remainingAdjacency = buildRemainingAdjacency(remainingIds, graph.adjacency, visited);
   const components = createComponents(remainingIds, remainingAdjacency);
   const componentGraph = createComponentGraph(components, remainingAdjacency);
-  const remaining = orderRemainingComponents(
-    components,
-    componentGraph,
-    graph.issueMap
-  );
+  const remaining = orderRemainingComponents(components, componentGraph, graph.issueMap);
 
   return {
     ordered: [...ordered, ...remaining.ordered],

--- a/src/workflows/cycleOrchestrator.ts
+++ b/src/workflows/cycleOrchestrator.ts
@@ -14,11 +14,7 @@ import { PipelineOrchestrator } from './pipelineOrchestrator.js';
 import { formatLinearContext } from '../cli/startHelpers.js';
 import { serializeError } from '../utils/errors.js';
 import type { IssueSnapshot, LinearCycleIssue } from '../adapters/linear/LinearAdapterTypes.js';
-import type {
-  CycleOrchestratorConfig,
-  CycleIssueResult,
-  CycleResult,
-} from './cycleTypes.js';
+import type { CycleOrchestratorConfig, CycleIssueResult, CycleResult } from './cycleTypes.js';
 
 /**
  * Check if an issue should be skipped based on its workflow state.
@@ -211,7 +207,10 @@ export class CycleOrchestrator {
     return cycleResult;
   }
 
-  private async createIssueRunDirectory(issue: LinearCycleIssue, issuesDir: string): Promise<string> {
+  private async createIssueRunDirectory(
+    issue: LinearCycleIssue,
+    issuesDir: string
+  ): Promise<string> {
     const { repoConfig } = this.config;
 
     return createRunDirectory(issuesDir, issue.identifier, {

--- a/tests/unit/cycleIssueOrderer.spec.ts
+++ b/tests/unit/cycleIssueOrderer.spec.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { orderCycleIssues } from '../../src/workflows/cycleIssueOrderer';
-import type { LinearCycleIssue, LinearIssueRelation } from '../../src/adapters/linear/LinearAdapterTypes';
+import type {
+  LinearCycleIssue,
+  LinearIssueRelation,
+} from '../../src/adapters/linear/LinearAdapterTypes';
 
 function makeIssue(
   identifier: string,
@@ -25,10 +28,7 @@ function makeIssue(
   };
 }
 
-function blocksRelation(
-  blockerIdentifier: string,
-  blockedIdentifier: string
-): LinearIssueRelation {
+function blocksRelation(blockerIdentifier: string, blockedIdentifier: string): LinearIssueRelation {
   return {
     type: 'blocks',
     issue: { id: `id-${blockerIdentifier}`, identifier: blockerIdentifier },
@@ -79,10 +79,7 @@ describe('orderCycleIssues', () => {
     // A → B → D
     // A → C → D
     const issues = [
-      makeIssue('ENG-A', 1, [
-        blocksRelation('ENG-A', 'ENG-B'),
-        blocksRelation('ENG-A', 'ENG-C'),
-      ]),
+      makeIssue('ENG-A', 1, [blocksRelation('ENG-A', 'ENG-B'), blocksRelation('ENG-A', 'ENG-C')]),
       makeIssue('ENG-B', 3, [blocksRelation('ENG-B', 'ENG-D')]),
       makeIssue('ENG-C', 2, [blocksRelation('ENG-C', 'ENG-D')]),
       makeIssue('ENG-D', 4, []),
@@ -125,28 +122,29 @@ describe('orderCycleIssues', () => {
     // A ↔ B (cycle), B → C (downstream of cycle)
     const issues = [
       makeIssue('ENG-A', 3, [blocksRelation('ENG-A', 'ENG-B')]),
-      makeIssue('ENG-B', 2, [
-        blocksRelation('ENG-B', 'ENG-A'),
-        blocksRelation('ENG-B', 'ENG-C'),
-      ]),
+      makeIssue('ENG-B', 2, [blocksRelation('ENG-B', 'ENG-A'), blocksRelation('ENG-B', 'ENG-C')]),
       makeIssue('ENG-C', 4, []),
     ];
 
     const result = orderCycleIssues(issues);
     expect(result.hasCycle).toBe(true);
     expect(result.cycleInvolvedIds).toEqual(['ENG-A', 'ENG-B']);
-    expect(result.ordered.map((issue) => issue.identifier)).toEqual([
-      'ENG-A',
-      'ENG-B',
-      'ENG-C',
-    ]);
+    expect(result.ordered.map((issue) => issue.identifier)).toEqual(['ENG-A', 'ENG-B', 'ENG-C']);
   });
 
   it('ignores duplicate and related relations (only uses blocks)', () => {
     const issues = [
       makeIssue('ENG-1', 2, [
-        { type: 'duplicate', issue: { id: 'id-ENG-1', identifier: 'ENG-1' }, relatedIssue: { id: 'id-ENG-2', identifier: 'ENG-2' } },
-        { type: 'related', issue: { id: 'id-ENG-1', identifier: 'ENG-1' }, relatedIssue: { id: 'id-ENG-3', identifier: 'ENG-3' } },
+        {
+          type: 'duplicate',
+          issue: { id: 'id-ENG-1', identifier: 'ENG-1' },
+          relatedIssue: { id: 'id-ENG-2', identifier: 'ENG-2' },
+        },
+        {
+          type: 'related',
+          issue: { id: 'id-ENG-1', identifier: 'ENG-1' },
+          relatedIssue: { id: 'id-ENG-3', identifier: 'ENG-3' },
+        },
       ]),
       makeIssue('ENG-2', 4),
       makeIssue('ENG-3', 1),
@@ -194,11 +192,7 @@ describe('orderCycleIssues', () => {
   });
 
   it('preserves stable ordering for same-priority issues', () => {
-    const issues = [
-      makeIssue('ENG-1', 2),
-      makeIssue('ENG-2', 2),
-      makeIssue('ENG-3', 2),
-    ];
+    const issues = [makeIssue('ENG-1', 2), makeIssue('ENG-2', 2), makeIssue('ENG-3', 2)];
 
     const result = orderCycleIssues(issues);
     // All same priority — Array.sort is stable in V8, so input order preserved

--- a/tests/unit/cycleOrchestrator.spec.ts
+++ b/tests/unit/cycleOrchestrator.spec.ts
@@ -18,9 +18,11 @@ vi.mock('../../src/telemetry/executionTelemetry.js', () => ({
 }));
 
 vi.mock('../../src/persistence/runLifecycle.js', () => ({
-  createRunDirectory: vi.fn().mockImplementation(async (_issuesDir: string, identifier: string) =>
-    `/tmp/test-run/issues/${identifier}`
-  ),
+  createRunDirectory: vi
+    .fn()
+    .mockImplementation(
+      async (_issuesDir: string, identifier: string) => `/tmp/test-run/issues/${identifier}`
+    ),
 }));
 
 const mockExecute = vi.fn();
@@ -35,14 +37,16 @@ vi.mock('../../src/cli/startHelpers.js', () => ({
   formatLinearContext: vi.fn().mockReturnValue('# Linear Issue Context\n...'),
 }));
 
-function makeIssue(overrides: Partial<{
-  id: string;
-  identifier: string;
-  title: string;
-  stateType: string;
-  stateName: string;
-  priority: number;
-}> = {}): LinearCycleIssue {
+function makeIssue(
+  overrides: Partial<{
+    id: string;
+    identifier: string;
+    title: string;
+    stateType: string;
+    stateName: string;
+    priority: number;
+  }> = {}
+): LinearCycleIssue {
   return {
     id: overrides.id ?? 'issue-1',
     identifier: overrides.identifier ?? 'CDMCH-101',
@@ -165,10 +169,7 @@ describe('CycleOrchestrator', () => {
   it('processes all issues sequentially', async () => {
     const config = makeConfig();
     const orchestrator = new CycleOrchestrator(config);
-    const issues = [
-      makeIssue({ identifier: 'CDMCH-101' }),
-      makeIssue({ identifier: 'CDMCH-102' }),
-    ];
+    const issues = [makeIssue({ identifier: 'CDMCH-101' }), makeIssue({ identifier: 'CDMCH-102' })];
 
     const result = await orchestrator.run(issues);
 
@@ -201,10 +202,7 @@ describe('CycleOrchestrator', () => {
 
     mockExecute.mockRejectedValueOnce(new Error('Pipeline failed'));
 
-    const issues = [
-      makeIssue({ identifier: 'CDMCH-101' }),
-      makeIssue({ identifier: 'CDMCH-102' }),
-    ];
+    const issues = [makeIssue({ identifier: 'CDMCH-101' }), makeIssue({ identifier: 'CDMCH-102' })];
 
     const result = await orchestrator.run(issues);
 
@@ -219,19 +217,14 @@ describe('CycleOrchestrator', () => {
     const config = makeConfig({ failFast: false });
     const orchestrator = new CycleOrchestrator(config);
 
-    mockExecute
-      .mockRejectedValueOnce(new Error('Pipeline failed'))
-      .mockResolvedValueOnce({
-        context: { files: 5, totalTokens: 1000, warnings: [] },
-        research: { tasksDetected: 0, pending: 0 },
-        prd: { path: 'prd.md', hash: 'abc', diagnostics: { incompleteSections: [], warnings: [] } },
-        approvalRequired: false,
-      });
+    mockExecute.mockRejectedValueOnce(new Error('Pipeline failed')).mockResolvedValueOnce({
+      context: { files: 5, totalTokens: 1000, warnings: [] },
+      research: { tasksDetected: 0, pending: 0 },
+      prd: { path: 'prd.md', hash: 'abc', diagnostics: { incompleteSections: [], warnings: [] } },
+      approvalRequired: false,
+    });
 
-    const issues = [
-      makeIssue({ identifier: 'CDMCH-101' }),
-      makeIssue({ identifier: 'CDMCH-102' }),
-    ];
+    const issues = [makeIssue({ identifier: 'CDMCH-101' }), makeIssue({ identifier: 'CDMCH-102' })];
 
     const result = await orchestrator.run(issues);
 
@@ -270,10 +263,7 @@ describe('CycleOrchestrator', () => {
     const config = makeConfig({ onIssueComplete });
     const orchestrator = new CycleOrchestrator(config);
 
-    const issues = [
-      makeIssue({ identifier: 'CDMCH-101' }),
-      makeIssue({ identifier: 'CDMCH-102' }),
-    ];
+    const issues = [makeIssue({ identifier: 'CDMCH-101' }), makeIssue({ identifier: 'CDMCH-102' })];
 
     const result = await orchestrator.run(issues);
 
@@ -348,9 +338,7 @@ describe('CycleOrchestrator', () => {
 
     await orchestrator.run([makeIssue()]);
 
-    expect(mockExecute).toHaveBeenCalledWith(
-      expect.objectContaining({ skipExecution: true })
-    );
+    expect(mockExecute).toHaveBeenCalledWith(expect.objectContaining({ skipExecution: true }));
   });
 
   it('handles empty issue list', async () => {

--- a/tests/unit/cycleOutput.spec.ts
+++ b/tests/unit/cycleOutput.spec.ts
@@ -49,7 +49,9 @@ describe('cycleOutput', () => {
 
     renderDryRun(payload, { log, warn });
 
-    expect(log).toHaveBeenCalledWith(expect.stringContaining('Issues: 2 total | 1 processable | 1 will skip'));
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining('Issues: 2 total | 1 processable | 1 will skip')
+    );
     expect(log).toHaveBeenCalledWith(expect.stringContaining('Medium'));
     expect(log).toHaveBeenCalledWith(expect.stringContaining('Urgent'));
     expect(log).toHaveBeenCalledWith(expect.stringContaining('skip'));

--- a/tests/unit/linearAdapter.spec.ts
+++ b/tests/unit/linearAdapter.spec.ts
@@ -55,15 +55,17 @@ const DEFAULT_CYCLE_ISSUE_NODE = {
   relations: [] as Array<{ type: string; relatedIssue: { id: string; identifier: string } }>,
 };
 
-function makeCycleIssueNode(overrides: Partial<{
-  id: string;
-  identifier: string;
-  title: string;
-  stateType: string;
-  stateName: string;
-  priority: number;
-  relations: Array<{ type: string; relatedIssue: { id: string; identifier: string } }>;
-}> = {}) {
+function makeCycleIssueNode(
+  overrides: Partial<{
+    id: string;
+    identifier: string;
+    title: string;
+    stateType: string;
+    stateName: string;
+    priority: number;
+    relations: Array<{ type: string; relatedIssue: { id: string; identifier: string } }>;
+  }> = {}
+) {
   const issue = {
     ...DEFAULT_CYCLE_ISSUE_NODE,
     ...overrides,
@@ -102,9 +104,7 @@ describe('LinearAdapter cycle methods', () => {
   describe('fetchCycleIssues', () => {
     it('fetches cycle issues and transforms GraphQL response', async () => {
       const issueNode = makeCycleIssueNode({
-        relations: [
-          { type: 'blocks', relatedIssue: { id: 'issue-2', identifier: 'CDMCH-102' } },
-        ],
+        relations: [{ type: 'blocks', relatedIssue: { id: 'issue-2', identifier: 'CDMCH-102' } }],
       });
 
       mockPost.mockResolvedValueOnce({
@@ -211,15 +211,11 @@ describe('LinearAdapter cycle methods', () => {
         data: { data: { cycle: null } },
       });
 
-      await expect(adapter.fetchCycleIssues(VALID_CYCLE_ID)).rejects.toThrow(
-        /not found/
-      );
+      await expect(adapter.fetchCycleIssues(VALID_CYCLE_ID)).rejects.toThrow(/not found/);
     });
 
     it('rejects invalid cycle ID format', async () => {
-      await expect(adapter.fetchCycleIssues('not-a-uuid')).rejects.toThrow(
-        LinearAdapterError
-      );
+      await expect(adapter.fetchCycleIssues('not-a-uuid')).rejects.toThrow(LinearAdapterError);
       await expect(adapter.fetchCycleIssues('CDMCH-123')).rejects.toThrow(
         /Cycle IDs must be UUIDs/
       );
@@ -343,8 +339,14 @@ describe('LinearAdapter cycle methods', () => {
       expect(result.metadata.issueCount).toBe(2);
       expect(mockPost).toHaveBeenCalledTimes(2);
 
-      const firstRequest = mockPost.mock.calls[0]?.[1] as { query: string; variables: { after?: string | null } };
-      const secondRequest = mockPost.mock.calls[1]?.[1] as { query: string; variables: { after?: string | null } };
+      const firstRequest = mockPost.mock.calls[0]?.[1] as {
+        query: string;
+        variables: { after?: string | null };
+      };
+      const secondRequest = mockPost.mock.calls[1]?.[1] as {
+        query: string;
+        variables: { after?: string | null };
+      };
 
       expect(firstRequest.query).toContain('issues(first: 250, after: $after)');
       expect(firstRequest.variables.after).toBeNull();
@@ -401,7 +403,9 @@ describe('LinearAdapter cycle methods', () => {
       });
 
       await expect(adapter.fetchActiveCycle(VALID_TEAM_ID)).rejects.toThrow(/not found/);
-      expect((adapter as { logger: { error: ReturnType<typeof vi.fn> } }).logger.error).not.toHaveBeenCalled();
+      expect(
+        (adapter as { logger: { error: ReturnType<typeof vi.fn> } }).logger.error
+      ).not.toHaveBeenCalled();
     });
 
     it('propagates API errors', async () => {
@@ -423,9 +427,7 @@ describe('LinearAdapter cycle methods', () => {
       });
 
       // Should not throw on validation; the "not found" error comes after
-      await expect(adapter.fetchCycleIssues(VALID_CYCLE_ID)).rejects.toThrow(
-        /not found/
-      );
+      await expect(adapter.fetchCycleIssues(VALID_CYCLE_ID)).rejects.toThrow(/not found/);
     });
 
     it('rejects Linear issue identifier format', async () => {
@@ -435,9 +437,7 @@ describe('LinearAdapter cycle methods', () => {
     });
 
     it('rejects arbitrary strings', async () => {
-      await expect(adapter.fetchCycleIssues('hello world')).rejects.toThrow(
-        LinearAdapterError
-      );
+      await expect(adapter.fetchCycleIssues('hello world')).rejects.toThrow(LinearAdapterError);
     });
   });
 });


### PR DESCRIPTION
## Summary

Describe what this PR changes and why.

## Test Plan

How was this verified?

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist

- [ ] `npm run format:check && npm run lint` passes
- [ ] `npm test` passes
- [ ] `npm run docs:links:check` passes
- [ ] `npm run build` succeeds
- [ ] Documentation updated (if applicable)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/kinginyellows/codemachine-pipeline/pull/894" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 1.1.0 with new `codepipe cycle` CLI command and cycle orchestration features
  * Simplified codebase through type refactoring and import consolidation across modules
  * Enhanced security with stricter input validation and Zod schema enforcement at JSON boundaries
  * Updated CI/infrastructure scripts and migrated to GitHub-hosted runners
  * Bumped dependency versions and improved test fixtures for stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces the `codepipe cycle` command for batch-processing Linear sprint issues, adding `CycleOrchestrator`, topological issue ordering (Kahn + Tarjan SCC), paginated `fetchCycleIssues`/`fetchActiveCycle` on `LinearAdapter`, and a full rendering layer — all backed by comprehensive unit tests. The only findings are two minor style items with no impact on correctness or safety.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all remaining findings are P2 style suggestions with no impact on correctness or runtime behavior.

The implementation is thorough: UUID validation for cycle/team IDs, path-traversal checks, pagination, cursor-based paging, graceful cycle detection in the dependency orderer, and extensive unit test coverage. Both open findings (duplicate import, naming inconsistency) are stylistic-only and per the confidence guidance a 5/5 is appropriate when all findings are P2.

src/cli/commands/cycle.ts — duplicate import declarations on lines 7-8 are the only item worth a quick cleanup before merge.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/cli/commands/cycle.ts | New cycle CLI command; path-traversal validation, dry-run/plan-only/fail-fast flags, telemetry — two separate import declarations from the same module on lines 7-8 |
| src/workflows/cycleOrchestrator.ts | Sequential issue orchestration with skip logic, fail-fast, per-issue run directories, and report.json audit trail |
| src/workflows/cycleIssueOrderer.ts | Topological sort via Kahn's algorithm + Tarjan SCC for dependency-cycle detection and priority-aware ordering |
| src/adapters/linear/LinearAdapter.ts | Adds fetchCycleIssues (cursor-paginated, 250/page) and fetchActiveCycle with UUID validation and relation normalization |
| src/cli/cycleTypes.ts | CycleFlags, CyclePayload interfaces, getCyclePayloadCounts utility — minor hasCycles/hasCycle naming drift |
| src/cli/cycleOutput.ts | Rendering helpers for dry-run preview, live dashboard, summary table, and JSON output |
| src/utils/githubApiUrl.ts | GitHub API URL resolver with credential rejection, HTTPS enforcement, and /api/v3 path allowlist |
| tests/unit/cycleIssueOrderer.spec.ts | Tests for orderCycleIssues covering empty input, priority sort, linear chains, diamonds, full cycles, and stable ordering |
| tests/unit/cycleOrchestrator.spec.ts | Tests for shouldSkipIssue and CycleOrchestrator: skip logic, fail-fast, maxIssues, callbacks, negative limits, report writing |
| tests/unit/cycleOutput.spec.ts | Tests for all render functions: dry-run, dashboard update/header, summary totals, and JSON output |
| tests/unit/linearAdapter.spec.ts | Tests for fetchCycleIssues (pagination, relation normalization, error cases) and fetchActiveCycle |
| CHANGELOG.md | Adds v1.1.0 release notes for cycle command, public repo prep, architecture refactors, and CI changes |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CLI as cycle.ts (CLI)
    participant LA as LinearAdapter
    participant OI as cycleIssueOrderer
    participant CO as CycleOrchestrator
    participant PO as PipelineOrchestrator

    CLI->>LA: fetchActiveCycle(teamId) [if no --cycle flag]
    LA-->>CLI: { id, name, number }
    CLI->>LA: fetchCycleIssues(cycleId)
    note over LA: Paginated GraphQL (250/page)
    LA-->>CLI: CycleSnapshot
    CLI->>OI: orderCycleIssues(issues)
    note over OI: Kahn topo-sort + Tarjan SCC
    OI-->>CLI: { ordered, hasCycle, cycleInvolvedIds }
    CLI->>CO: orchestrator.run(ordered)
    loop each issue (up to maxIssues)
        CO->>CO: shouldSkipIssue(issue)
        alt skip
            CO-->>CO: record skipped result
        else process
            CO->>PO: pipeline.execute({ linearContextText, skipExecution })
            PO-->>CO: result
            CO-->>CO: record completed/failed result
        end
        CO-->>CLI: onIssueComplete callback
    end
    CO->>CO: write report.json
    CO-->>CLI: CycleResult
    CLI->>CLI: renderCycleSummary / renderCycleJson
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `src/cli/commands/cycle.ts`, line 7-8 ([link](https://github.com/kinginyellows/codemachine-pipeline/blob/5e64c378f2f05bfcac01fa3c038f6db8187ff3df/src/cli/commands/cycle.ts#L7-L8)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Duplicate import declarations from the same module**

   Both `shouldSkipIssue` and `CycleOrchestrator` are imported from `'../../workflows/cycleOrchestrator'` in two separate `import` statements. These should be merged into one declaration — particularly relevant given this PR's stated goal of fixing lint errors.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/cli/commands/cycle.ts
   Line: 7-8

   Comment:
   **Duplicate import declarations from the same module**

   Both `shouldSkipIssue` and `CycleOrchestrator` are imported from `'../../workflows/cycleOrchestrator'` in two separate `import` statements. These should be merged into one declaration — particularly relevant given this PR's stated goal of fixing lint errors.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fcli%2Fcommands%2Fcycle.ts%0ALine%3A%207-8%0A%0AComment%3A%0A**Duplicate%20import%20declarations%20from%20the%20same%20module**%0A%0ABoth%20%60shouldSkipIssue%60%20and%20%60CycleOrchestrator%60%20are%20imported%20from%20%60'..%2F..%2Fworkflows%2FcycleOrchestrator'%60%20in%20two%20separate%20%60import%60%20statements.%20These%20should%20be%20merged%20into%20one%20declaration%20%E2%80%94%20particularly%20relevant%20given%20this%20PR's%20stated%20goal%20of%20fixing%20lint%20errors.%0A%0A%60%60%60suggestion%0Aimport%20%7B%20shouldSkipIssue%2C%20CycleOrchestrator%20%7D%20from%20'..%2F..%2Fworkflows%2FcycleOrchestrator'%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=kinginyellows%2Fcodemachine-pipeline"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=1" height="20"></a>


2. `src/cli/cycleTypes.ts`, line 28 ([link](https://github.com/kinginyellows/codemachine-pipeline/blob/5e64c378f2f05bfcac01fa3c038f6db8187ff3df/src/cli/cycleTypes.ts#L28)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`hasCycles` vs `hasCycle` naming inconsistency**

   `CyclePayload.hasCycles` (plural) maps directly onto `OrderingResult.hasCycle` (singular) from `cycleIssueOrderer.ts`. Aligning the names would eliminate the need for the `hasCycles: hasCycle` mapping in `cycle.ts` line 216 and make the two types easier to cross-reference.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/cli/cycleTypes.ts
   Line: 28

   Comment:
   **`hasCycles` vs `hasCycle` naming inconsistency**

   `CyclePayload.hasCycles` (plural) maps directly onto `OrderingResult.hasCycle` (singular) from `cycleIssueOrderer.ts`. Aligning the names would eliminate the need for the `hasCycles: hasCycle` mapping in `cycle.ts` line 216 and make the two types easier to cross-reference.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <sub>Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!</sub>

   <a href="https://app.greptile.com/ide/codex?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fcli%2FcycleTypes.ts%0ALine%3A%2028%0A%0AComment%3A%0A**%60hasCycles%60%20vs%20%60hasCycle%60%20naming%20inconsistency**%0A%0A%60CyclePayload.hasCycles%60%20%28plural%29%20maps%20directly%20onto%20%60OrderingResult.hasCycle%60%20%28singular%29%20from%20%60cycleIssueOrderer.ts%60.%20Aligning%20the%20names%20would%20eliminate%20the%20need%20for%20the%20%60hasCycles%3A%20hasCycle%60%20mapping%20in%20%60cycle.ts%60%20line%20216%20and%20make%20the%20two%20types%20easier%20to%20cross-reference.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=kinginyellows%2Fcodemachine-pipeline"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=1" height="20"></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/codex?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fcli%2Fcommands%2Fcycle.ts%3A7-8%0A**Duplicate%20import%20declarations%20from%20the%20same%20module**%0A%0ABoth%20%60shouldSkipIssue%60%20and%20%60CycleOrchestrator%60%20are%20imported%20from%20%60'..%2F..%2Fworkflows%2FcycleOrchestrator'%60%20in%20two%20separate%20%60import%60%20statements.%20These%20should%20be%20merged%20into%20one%20declaration%20%E2%80%94%20particularly%20relevant%20given%20this%20PR's%20stated%20goal%20of%20fixing%20lint%20errors.%0A%0A%60%60%60suggestion%0Aimport%20%7B%20shouldSkipIssue%2C%20CycleOrchestrator%20%7D%20from%20'..%2F..%2Fworkflows%2FcycleOrchestrator'%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fcli%2FcycleTypes.ts%3A28%0A**%60hasCycles%60%20vs%20%60hasCycle%60%20naming%20inconsistency**%0A%0A%60CyclePayload.hasCycles%60%20%28plural%29%20maps%20directly%20onto%20%60OrderingResult.hasCycle%60%20%28singular%29%20from%20%60cycleIssueOrderer.ts%60.%20Aligning%20the%20names%20would%20eliminate%20the%20need%20for%20the%20%60hasCycles%3A%20hasCycle%60%20mapping%20in%20%60cycle.ts%60%20line%20216%20and%20make%20the%20two%20types%20easier%20to%20cross-reference.%0A%0A&repo=kinginyellows%2Fcodemachine-pipeline"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=1" height="20"></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: src/cli/commands/cycle.ts
Line: 7-8

Comment:
**Duplicate import declarations from the same module**

Both `shouldSkipIssue` and `CycleOrchestrator` are imported from `'../../workflows/cycleOrchestrator'` in two separate `import` statements. These should be merged into one declaration — particularly relevant given this PR's stated goal of fixing lint errors.

```suggestion
import { shouldSkipIssue, CycleOrchestrator } from '../../workflows/cycleOrchestrator';
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: src/cli/cycleTypes.ts
Line: 28

Comment:
**`hasCycles` vs `hasCycle` naming inconsistency**

`CyclePayload.hasCycles` (plural) maps directly onto `OrderingResult.hasCycle` (singular) from `cycleIssueOrderer.ts`. Aligning the names would eliminate the need for the `hasCycles: hasCycle` mapping in `cycle.ts` line 216 and make the two types easier to cross-reference.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: resolve cycle.ts lint errors and up..."](https://github.com/kinginyellows/codemachine-pipeline/commit/5e64c378f2f05bfcac01fa3c038f6db8187ff3df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27359886)</sub>

<!-- /greptile_comment -->