### PR TITLE
ci: verify actionlint download checksum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,13 @@ jobs:
           esac
           archive="actionlint_${ACTIONLINT_VERSION}_${os}_${arch}.tar.gz"
           url="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${archive}"
+          case "$os/$arch" in
+            linux/amd64) checksum="023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757" ;;
+            linux/arm64) checksum="401942f9c24ed71e4fe71b76c7d638f66d8633575c4016efd2977ce7c28317d0" ;;
+            *) echo "Unsupported platform: $os/$arch" >&2; exit 1 ;;
+          esac
           curl -fsSL "$url" -o actionlint.tar.gz
+          printf '%s  %s\n' "$checksum" actionlint.tar.gz | sha256sum -c -
           tar -xzf actionlint.tar.gz actionlint
           chmod +x actionlint
 


### PR DESCRIPTION
## **User description**
### Motivation
- @devin: Address a supply-chain risk where the CI `workflow_lint` job downloaded and executed an `actionlint` release tarball without any integrity verification on self-hosted runners, allowing a tampered binary to cause RCE. 
- Ensure the workflow fails closed on unsupported platforms or checksum mismatches while preserving the existing install flow and pinned `ACTIONLINT_VERSION`.

### Description
- Updated `.github/workflows/ci.yml` `Install actionlint` step to add pinned SHA-256 checksums for `linux/amd64` and `linux/arm64` and to verify the downloaded tarball with `sha256sum -c` before extracting. 
- Kept the existing `ACTIONLINT_VERSION`, download URL, extraction, and execution steps, and added an explicit error path for unsupported platforms.

### Testing
- Verified the new install snippet by downloading the v1.7.7 Linux tarball(s) and checking the SHA-256 sums locally with the same `sha256sum -c` command, which succeeded. 
- Ran the installed `actionlint` against `./github/workflows/ci.yml` and observed successful lint execution. 
- Ran `npx prettier --check .github/workflows/ci.yml`, which passed; running the repository-level `npm run format:check -- .github/workflows/ci.yml` surfaced pre-existing Prettier warnings in unrelated TypeScript files and is out of scope for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa951fee5483219efca16ee4406d9c)


___

## **CodeAnt-AI Description**
Verify the CI actionlint download before running it

### What Changed
- CI now checks the downloaded `actionlint` archive against a pinned SHA-256 value before extracting it
- The install step stops on unsupported platforms instead of continuing with an unverified download
- Workflow linting still uses the same pinned `actionlint` version and download flow after verification

### Impact
`✅ Safer workflow linting`
`✅ Fewer CI runs blocked by bad downloads`
`✅ Clearer failures on unsupported runners`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=SCUulypAHO_qEe_JxV5gsO1n6LsVpxiC9IiSdaXxb1M&org=KingInYellows)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow with platform-aware integrity verification for build tools, supporting multiple architectures with SHA256 checksum validation to ensure secure and reliable builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds SHA-256 checksum verification to the `Install actionlint` step in the `workflow_lint` CI job, pinning expected digests for `linux/amd64` and `linux/arm64` and verifying with `sha256sum -c` before extracting the tarball.

- Hardcoded checksums for `linux/amd64` and `linux/arm64` are injected via a `case` block and piped to `sha256sum -c -` after download, with an explicit `exit 1` for unsupported platforms.
- The `workflow_lint` job carries a pre-existing `continue-on-error: true` that causes a checksum-mismatch failure to be surfaced only as a warning annotation rather than a blocking failure, contradicting the stated goal of failing closed on tampered binaries.
- The hardcoded digest values should be confirmed against the official `actionlint_1.7.7_checksums.txt` release artifact before merging.

<h3>Confidence Score: 3/5</h3>

The checksum step will detect a tampered tarball but cannot block the workflow from passing due to the job-level `continue-on-error: true`, leaving the supply-chain protection incomplete.

The change introduces checksum verification that is structurally correct — `set -euo pipefail` plus `sha256sum -c -` will exit non-zero on a mismatch — but the job-level `continue-on-error: true` absorbs that failure and marks the job green regardless. A supply-chain attack that swaps the binary would be silently tolerated by CI. Additionally, the hardcoded digest values need to be confirmed against the upstream release artifact before they can be trusted as the source of truth.

.github/workflows/ci.yml — specifically the `continue-on-error: true` on the `workflow_lint` job and the two hardcoded SHA-256 values that need verification against the official release checksums file.

<details open><summary><h3>Security Review</h3></summary>

- **Ineffective integrity enforcement** (`.github/workflows/ci.yml` line 51): `continue-on-error: true` on the `workflow_lint` job means a `sha256sum` mismatch exits the step non-zero but is promoted to a warning at the job level — a tampered binary would not block CI or prevent merging.
- **Unverified hardcoded checksums** (`.github/workflows/ci.yml` lines 73–74): The pinned digests for the `actionlint` v1.7.7 tarballs should be cross-referenced against the official `actionlint_1.7.7_checksums.txt` release artifact; if sourced from memory or a secondary location, the integrity check could silently validate the wrong value.
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Adds SHA-256 checksum verification for the actionlint tarball download, but the job-level `continue-on-error: true` means a mismatch won't block the workflow, and the hardcoded checksums need verification against the upstream release artifact. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Runner as GitHub Runner
    participant GH as github.com/rhysd/actionlint
    participant Shell as Bash step (set -euo pipefail)

    Runner->>Shell: Execute "Install actionlint" step
    Shell->>Shell: Detect os/arch via uname
    Shell->>Shell: case os/arch select checksum
    Shell->>GH: curl -fsSL download tarball
    GH-->>Shell: actionlint.tar.gz
    Shell->>Shell: printf checksum | sha256sum -c -
    alt Checksum matches
        Shell->>Shell: tar -xzf actionlint.tar.gz
        Shell->>Shell: chmod +x actionlint
        Shell-->>Runner: Step succeeds
    else Checksum mismatch
        Shell-->>Runner: Step exits non-zero
        Note over Runner: continue-on-error true, job marked success
    end
    Runner->>Shell: Execute Lint GitHub workflows step
    Shell->>Shell: ./actionlint -color
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/ci.yml`, line 51 ([link](https://github.com/kinginyellows/codemachine-pipeline/blob/4d61f3a6ad410b02bbb67cad4bbae89e5d4e5c61/.github/workflows/ci.yml#L51)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **`continue-on-error: true` negates the checksum security guarantee**

   The `workflow_lint` job has `continue-on-error: true` at the job level. Even though `set -euo pipefail` ensures `sha256sum -c -` failure exits the step non-zero, a job-level `continue-on-error: true` marks the job as "succeeded" regardless — so a tampered binary that produces a checksum mismatch will not cause the workflow run to fail. The PR description says it should "fail closed on checksum mismatches," but in practice a mismatch only produces a warning annotation and the PR can still be merged.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/ci.yml
   Line: 51

   Comment:
   **`continue-on-error: true` negates the checksum security guarantee**

   The `workflow_lint` job has `continue-on-error: true` at the job level. Even though `set -euo pipefail` ensures `sha256sum -c -` failure exits the step non-zero, a job-level `continue-on-error: true` marks the job as "succeeded" regardless — so a tampered binary that produces a checksum mismatch will not cause the workflow run to fail. The PR description says it should "fail closed on checksum mismatches," but in practice a mismatch only produces a warning annotation and the PR can still be merged.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fcodemachine-pipeline%22%20on%20the%20existing%20branch%20%22codex%2Fpropose-fix-for-unverified-actionlint-download%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fpropose-fix-for-unverified-actionlint-download%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fci.yml%0ALine%3A%2051%0A%0AComment%3A%0A**%60continue-on-error%3A%20true%60%20negates%20the%20checksum%20security%20guarantee**%0A%0AThe%20%60workflow_lint%60%20job%20has%20%60continue-on-error%3A%20true%60%20at%20the%20job%20level.%20Even%20though%20%60set%20-euo%20pipefail%60%20ensures%20%60sha256sum%20-c%20-%60%20failure%20exits%20the%20step%20non-zero%2C%20a%20job-level%20%60continue-on-error%3A%20true%60%20marks%20the%20job%20as%20%22succeeded%22%20regardless%20%E2%80%94%20so%20a%20tampered%20binary%20that%20produces%20a%20checksum%20mismatch%20will%20not%20cause%20the%20workflow%20run%20to%20fail.%20The%20PR%20description%20says%20it%20should%20%22fail%20closed%20on%20checksum%20mismatches%2C%22%20but%20in%20practice%20a%20mismatch%20only%20produces%20a%20warning%20annotation%20and%20the%20PR%20can%20still%20be%20merged.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fcodemachine-pipeline%22%20on%20the%20existing%20branch%20%22codex%2Fpropose-fix-for-unverified-actionlint-download%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fpropose-fix-for-unverified-actionlint-download%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Fci.yml%3A51%0A**%60continue-on-error%3A%20true%60%20negates%20the%20checksum%20security%20guarantee**%0A%0AThe%20%60workflow_lint%60%20job%20has%20%60continue-on-error%3A%20true%60%20at%20the%20job%20level.%20Even%20though%20%60set%20-euo%20pipefail%60%20ensures%20%60sha256sum%20-c%20-%60%20failure%20exits%20the%20step%20non-zero%2C%20a%20job-level%20%60continue-on-error%3A%20true%60%20marks%20the%20job%20as%20%22succeeded%22%20regardless%20%E2%80%94%20so%20a%20tampered%20binary%20that%20produces%20a%20checksum%20mismatch%20will%20not%20cause%20the%20workflow%20run%20to%20fail.%20The%20PR%20description%20says%20it%20should%20%22fail%20closed%20on%20checksum%20mismatches%2C%22%20but%20in%20practice%20a%20mismatch%20only%20produces%20a%20warning%20annotation%20and%20the%20PR%20can%20still%20be%20merged.%0A%0A%23%23%23%20Issue%202%20of%202%0A.github%2Fworkflows%2Fci.yml%3A73-74%0A**Hardcoded%20checksums%20should%20be%20cross-referenced%20against%20the%20upstream%20release**%0A%0AThe%20pinned%20checksums%20for%20%60linux%2Famd64%60%20%28%60023070a...%60%29%20and%20%60linux%2Farm64%60%20%28%60401942f...%60%29%20cannot%20be%20independently%20verified%20without%20fetching%20the%20official%20%60actionlint_1.7.7_checksums.txt%60%20artifact%20from%20the%20release.%20The%20actionlint%20project%20publishes%20a%20per-release%20checksums%20file%20at%20%60https%3A%2F%2Fgithub.com%2Frhysd%2Factionlint%2Freleases%2Fdownload%2Fv1.7.7%2Factionlint_1.7.7_checksums.txt%60%20%E2%80%94%20please%20confirm%20these%20values%20match%20that%20file.%20If%20they%20were%20copied%20from%20memory%20or%20a%20secondary%20source%20rather%20than%20the%20canonical%20release%20artifact%2C%20a%20mismatch%20would%20mean%20the%20%60sha256sum%60%20check%20validates%20the%20wrong%20expected%20value%20and%20provides%20no%20real%20protection.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.github/workflows/ci.yml:51
**`continue-on-error: true` negates the checksum security guarantee**

The `workflow_lint` job has `continue-on-error: true` at the job level. Even though `set -euo pipefail` ensures `sha256sum -c -` failure exits the step non-zero, a job-level `continue-on-error: true` marks the job as "succeeded" regardless — so a tampered binary that produces a checksum mismatch will not cause the workflow run to fail. The PR description says it should "fail closed on checksum mismatches," but in practice a mismatch only produces a warning annotation and the PR can still be merged.

### Issue 2 of 2
.github/workflows/ci.yml:73-74
**Hardcoded checksums should be cross-referenced against the upstream release**

The pinned checksums for `linux/amd64` (`023070a...`) and `linux/arm64` (`401942f...`) cannot be independently verified without fetching the official `actionlint_1.7.7_checksums.txt` artifact from the release. The actionlint project publishes a per-release checksums file at `https://github.com/rhysd/actionlint/releases/download/v1.7.7/actionlint_1.7.7_checksums.txt` — please confirm these values match that file. If they were copied from memory or a secondary source rather than the canonical release artifact, a mismatch would mean the `sha256sum` check validates the wrong expected value and provides no real protection.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: verify actionlint download checksum"](https://github.com/kinginyellows/codemachine-pipeline/commit/4d61f3a6ad410b02bbb67cad4bbae89e5d4e5c61) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30937527)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->