### PR TITLE
fix: contain execution task paths (prevent spec/log path traversal)

### DIFF
--- a/src/workflows/cliExecutionEngine.ts
+++ b/src/workflows/cliExecutionEngine.ts
@@ -16,7 +16,7 @@ import { getErrorMessage } from '../utils/errors.js';
 import { DEFAULT_EXECUTION_CONFIG } from '../core/config/RepoConfig.js';
 import { getReadyTasks, applyRetryBackoff } from './executionDependencyResolver.js';
 import { ExecutionTelemetryRecorder } from './executionTelemetryRecorder.js';
-import { validateTaskId, captureArtifacts } from './executionArtifactCapture.js';
+import { validateTaskId, captureArtifacts, isPathContained } from './executionArtifactCapture.js';
 
 /**
  * Configuration options for constructing a {@link CLIExecutionEngine}.
@@ -318,14 +318,33 @@ export class CLIExecutionEngine {
     }
 
     const executionConfig = this.config.execution ?? DEFAULT_EXECUTION_CONFIG;
+    const logsDir = path.join(this.runDir, 'logs');
+    const logPath = path.join(logsDir, `${task.task_id}.log`);
+    if (!isPathContained(logsDir, logPath)) {
+      this.logger?.warn('Task log path escapes logs directory, rejecting task', {
+        taskId: task.task_id,
+        logPath,
+      });
+      await updateTaskInQueue(this.runDir, task.task_id, {
+        status: 'failed',
+        retry_count: task.retry_count + 1,
+        last_error: {
+          message: 'Invalid task log path',
+          timestamp: new Date().toISOString(),
+          recoverable: false,
+        },
+      });
+      return { success: false, permanentlyFailed: true };
+    }
+
     const context: ExecutionContext = {
       runDir: this.runDir,
       workspaceDir: executionConfig.workspace_dir || this.runDir,
-      logPath: path.join(this.runDir, 'logs', `${task.task_id}.log`),
+      logPath,
       timeoutMs: executionConfig.task_timeout_ms,
     };
 
-    await fs.mkdir(path.dirname(context.logPath), { recursive: true });
+    await fs.mkdir(logsDir, { recursive: true });
 
     const strategyResult = await strategy.execute(task, context);
     const durationMs = strategyResult.durationMs ?? Date.now() - startTime;

--- a/src/workflows/codeMachineStrategy.ts
+++ b/src/workflows/codeMachineStrategy.ts
@@ -7,6 +7,7 @@
  */
 
 import * as path from 'node:path';
+import { realpath } from 'node:fs/promises';
 import type { ExecutionTask } from '../core/models/ExecutionTask.js';
 import type { ExecutionConfig } from '../core/config/RepoConfig.js';
 import type {
@@ -22,6 +23,7 @@ import {
 import { mapTaskToWorkflow, shouldUseNativeEngine } from './taskMapper.js';
 import { normalizeResult } from './resultNormalizer.js';
 import { buildStrategyResult } from './strategyHelpers.js';
+import { isPathContained, validateTaskId } from './executionArtifactCapture.js';
 import type { StructuredLogger } from '../telemetry/logger.js';
 
 /** Configuration options for the CodeMachine strategy */
@@ -61,13 +63,28 @@ export class CodeMachineStrategy implements ExecutionStrategy {
       command: mapping.command,
     });
 
-    const specPath = this.buildSpecPath(task, context);
+    const specPath = await this.buildSpecPath(task, context);
+    if (!specPath.valid) {
+      this.logger?.warn('Rejected unsafe CodeMachine spec path', {
+        taskId: task.task_id,
+        error: specPath.errorMessage,
+      });
+      return {
+        success: false,
+        status: 'failed',
+        summary: specPath.errorMessage,
+        errorMessage: specPath.errorMessage,
+        recoverable: false,
+        durationMs: 0,
+        artifacts: [],
+      };
+    }
 
     const runnerOptions: RunnerOptions = {
       taskId: task.task_id,
       prompt: task.title,
       workspaceDir: context.workspaceDir,
-      specPath,
+      specPath: specPath.path,
       timeoutMs: context.timeoutMs,
     };
 
@@ -95,13 +112,50 @@ export class CodeMachineStrategy implements ExecutionStrategy {
     };
   }
 
-  private buildSpecPath(task: ExecutionTask, context: ExecutionContext): string {
+  private async buildSpecPath(
+    task: ExecutionTask,
+    context: ExecutionContext
+  ): Promise<{ valid: true; path: string } | { valid: false; errorMessage: string }> {
     const taskConfig = task.config;
     if (taskConfig && typeof taskConfig['spec_path'] === 'string') {
-      return path.resolve(context.workspaceDir, taskConfig['spec_path']);
+      const candidatePath = path.resolve(context.workspaceDir, taskConfig['spec_path']);
+      const workspaceDir = path.resolve(context.workspaceDir);
+
+      if (!isPathContained(workspaceDir, candidatePath)) {
+        return {
+          valid: false,
+          errorMessage: 'Invalid spec_path: path must stay within the workspace directory',
+        };
+      }
+
+      const realCandidatePath = await resolveRealPathSafe(candidatePath);
+      const realWorkspaceDir = await resolveRealPathSafe(workspaceDir);
+      if (!isPathContained(realWorkspaceDir, realCandidatePath)) {
+        return {
+          valid: false,
+          errorMessage: 'Invalid spec_path: path resolves outside the workspace directory',
+        };
+      }
+
+      return { valid: true, path: candidatePath };
     }
 
-    return path.join(context.runDir, 'specs', `${task.task_id}.md`);
+    if (!validateTaskId(task.task_id)) {
+      return {
+        valid: false,
+        errorMessage: 'Invalid task ID format',
+      };
+    }
+
+    return { valid: true, path: path.join(context.runDir, 'specs', `${task.task_id}.md`) };
+  }
+}
+
+async function resolveRealPathSafe(candidatePath: string): Promise<string> {
+  try {
+    return await realpath(candidatePath);
+  } catch {
+    return path.resolve(candidatePath);
   }
 }
 

--- a/tests/unit/codeMachineStrategy.spec.ts
+++ b/tests/unit/codeMachineStrategy.spec.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import type { ExecutionTask } from '../../src/core/models/ExecutionTask';
 import type { ExecutionConfig } from '../../src/core/config/RepoConfig';
 import type { ExecutionContext } from '../../src/workflows/executionStrategy';
@@ -373,6 +376,81 @@ describe('CodeMachineStrategy', () => {
           specPath: expect.stringContaining('specs/custom.md'),
         })
       );
+    });
+
+    it('rejects traversal spec_path values before invoking CodeMachine', async () => {
+      const task = createMockTask({
+        config: { spec_path: '../secret.md' },
+      });
+      const context = createMockContext();
+
+      mockMapTaskToWorkflow.mockReturnValue({
+        workflow: 'codemachine start',
+        command: 'start',
+        useNativeEngine: false,
+      });
+
+      const strategy = new CodeMachineStrategy({ config });
+      const result = await strategy.execute(task, context);
+
+      expect(result.success).toBe(false);
+      expect(result.recoverable).toBe(false);
+      expect(result.errorMessage).toContain('Invalid spec_path');
+      expect(mockRunCodeMachine).not.toHaveBeenCalled();
+    });
+
+    it('rejects absolute spec_path values outside the workspace before invoking CodeMachine', async () => {
+      const task = createMockTask({
+        config: { spec_path: '/etc/passwd' },
+      });
+      const context = createMockContext();
+
+      mockMapTaskToWorkflow.mockReturnValue({
+        workflow: 'codemachine start',
+        command: 'start',
+        useNativeEngine: false,
+      });
+
+      const strategy = new CodeMachineStrategy({ config });
+      const result = await strategy.execute(task, context);
+
+      expect(result.success).toBe(false);
+      expect(result.recoverable).toBe(false);
+      expect(result.errorMessage).toContain('Invalid spec_path');
+      expect(mockRunCodeMachine).not.toHaveBeenCalled();
+    });
+
+    it('rejects spec_path symlinks that resolve outside the workspace', async () => {
+      const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'codemachine-strategy-'));
+      const workspaceDir = path.join(tempDir, 'workspace');
+      const secretPath = path.join(tempDir, 'secret.md');
+      const symlinkPath = path.join(workspaceDir, 'linked-secret.md');
+      await fs.mkdir(workspaceDir, { recursive: true });
+      await fs.writeFile(secretPath, 'secret', 'utf-8');
+      await fs.symlink(secretPath, symlinkPath);
+
+      try {
+        const task = createMockTask({
+          config: { spec_path: 'linked-secret.md' },
+        });
+        const context = createMockContext({ workspaceDir });
+
+        mockMapTaskToWorkflow.mockReturnValue({
+          workflow: 'codemachine start',
+          command: 'start',
+          useNativeEngine: false,
+        });
+
+        const strategy = new CodeMachineStrategy({ config });
+        const result = await strategy.execute(task, context);
+
+        expect(result.success).toBe(false);
+        expect(result.recoverable).toBe(false);
+        expect(result.errorMessage).toContain('resolves outside');
+        expect(mockRunCodeMachine).not.toHaveBeenCalled();
+      } finally {
+        await fs.rm(tempDir, { recursive: true, force: true });
+      }
     });
 
     it('generates default spec path when task config has no spec_path', async () => {


### PR DESCRIPTION
## **User description**
### Motivation
- @devin Ensure task-controlled filesystem paths cannot escape intended run/workspace directories to prevent arbitrary file reads/writes via crafted `task_id` or `spec_path` values.
- Close the gap where the engine built a log path and the strategy resolved a `spec_path` from untrusted task data without robust containment checks.

### Description
- Add a logs-directory containment guard in `CLIExecutionEngine.execute()` so computed `logPath` is validated with `isPathContained()` before creation and tasks are rejected when invalid, and create the `logs` directory only after validation (`src/workflows/cliExecutionEngine.ts`).
- Harden `CodeMachineStrategy.buildSpecPath()` to perform lexical `path.resolve()` checks and `realpath` (symlink) checks against the configured workspace, returning a structured `{ valid, path | errorMessage }` and failing closed before invoking the CLI when unsafe (`src/workflows/codeMachineStrategy.ts`).
- Wire the strategy `execute()` to use the validated `specPath.path` and to return a non-recoverable failure when the spec path is rejected (`src/workflows/codeMachineStrategy.ts`).
- Add unit tests covering traversal `spec_path`, absolute outside-workspace `spec_path`, and symlink-escape cases, and update formatting for the touched tests (`tests/unit/codeMachineStrategy.spec.ts`).

### Testing
- Ran `npx prettier --check` and fixed style; check passed for the touched files (succeeded).
- Ran `npx eslint` against the modified files (succeeded with no new issues in the touched files).
- Ran `npx vitest run tests/unit/codeMachineStrategy.spec.ts` and observed all tests in that file passed (`22 passed`).
- Ran `npm run build` (TypeScript compilation + manifest generation) with success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa9688e4408321aa8e9b11affd852d)

___

## **CodeAnt-AI Description**
**Block task paths that escape the allowed workspace and logs folders**

### What Changed
- Tasks are now rejected when their spec file path points outside the workspace, including traversal paths, absolute paths, and symlink-based escapes.
- Task logs are only created inside the run’s logs folder; if a task would write a log elsewhere, it fails immediately with a non-recoverable error.
- Added coverage for unsafe spec paths so these cases are caught before CodeMachine starts.

### Impact
`✅ Prevents writing task files outside the workspace`
`✅ Fewer unsafe task runs from crafted paths`
`✅ Clearer failures for invalid task paths`

[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=WTJwT6_6pbD5KMT5JaHyBF6E0svPvAYlqc-x4YNprcE&org=KingInYellows)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds path-traversal containment guards to two execution paths: `CLIExecutionEngine.executeTask()` now validates the computed log path with `isPathContained()` before creating the `logs` directory, and `CodeMachineStrategy.buildSpecPath()` is hardened to perform both a lexical `path.resolve()` check and a `realpath` symlink check against the configured workspace, rejecting tasks non-recoverably when either check fails.

- **`codeMachineStrategy.ts`**: `buildSpecPath` is now `async`, introduces a private `resolveRealPathSafe` (duplicated from `executionArtifactCapture.ts`), and returns a discriminated union so callers fail closed without invoking the CLI.
- **`cliExecutionEngine.ts`**: Moves `logsDir`/`logPath` construction before `ExecutionContext` assembly and inserts an `isPathContained` guard, also deferring `fs.mkdir` until after validation.
- **`tests/unit/codeMachineStrategy.spec.ts`**: Adds three new integration-style tests using real filesystem fixtures covering relative traversal, absolute outside-workspace, and symlink-escape rejection paths.

<h3>Confidence Score: 3/5</h3>

The symlink containment check validates the target at call time but passes the unresolved symlink path to the CLI, leaving a race window that can bypass the guard this PR is meant to provide.

The symlink validation logic validates `realCandidatePath` but hands `candidatePath` (the symlink itself) to the CLI, leaving a race window that an attacker with write access to the workspace could exploit to redirect the spec file after validation passes. This is the security-critical path the PR is hardening, so the residual bypass matters more here than it would in a less sensitive context.

src/workflows/codeMachineStrategy.ts — specifically the `return { valid: true, path: candidatePath }` line in `buildSpecPath`; src/workflows/cliExecutionEngine.ts has a dead branch worth cleaning up but is otherwise safe.

<details open><summary><h3>Security Review</h3></summary>

- **TOCTOU / Symlink-swap** (`src/workflows/codeMachineStrategy.ts`, `buildSpecPath`): The realpath check validates the symlink target at call time, but the unresolved `candidatePath` (the symlink) is what gets passed to the CLI. A process that can modify workspace symlinks between validation and CLI invocation can redirect the spec file to an arbitrary location, bypassing the containment guard this PR introduces.
- No hardcoded secrets, injection sinks, or credential-forwarding issues were observed in the changed code.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/workflows/codeMachineStrategy.ts | Adds async `buildSpecPath` with lexical + symlink containment checks; returns the unresolved symlink path after validation, creating a TOCTOU window; also duplicates `resolveRealPathSafe` from `executionArtifactCapture.ts`. |
| src/workflows/cliExecutionEngine.ts | Adds `isPathContained` guard for the log path, but the check is unreachable because `validateTaskId` (called earlier in the same method) already ensures the task ID cannot escape the logs directory. |
| tests/unit/codeMachineStrategy.spec.ts | Adds three targeted traversal tests (relative `../`, absolute outside-workspace, and symlink escape) using real filesystem fixtures; coverage is correct for the three new rejection paths. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Engine as CLIExecutionEngine
    participant Strategy as CodeMachineStrategy
    participant ArtifactCapture as executionArtifactCapture
    participant CLI as runCodeMachine

    Engine->>ArtifactCapture: validateTaskId(task.task_id)
    alt Invalid task ID
        ArtifactCapture-->>Engine: false, reject permanentlyFailed
    end
    Engine->>ArtifactCapture: isPathContained(logsDir, logPath)
    note over Engine: dead branch - always true after validateTaskId passes
    Engine->>Strategy: execute(task, context)
    Strategy->>Strategy: buildSpecPath(task, context)
    alt spec_path in config
        Strategy->>ArtifactCapture: isPathContained(workspaceDir, candidatePath)
        alt Lexical escape
            ArtifactCapture-->>Strategy: false, return invalid
        end
        Strategy->>Strategy: resolveRealPathSafe(candidatePath)
        Strategy->>ArtifactCapture: isPathContained(realWorkspaceDir, realCandidatePath)
        alt Symlink escape
            ArtifactCapture-->>Strategy: false, return invalid
        end
        Strategy-->>Strategy: valid true path candidatePath TOCTOU gap
    else default spec path
        Strategy->>ArtifactCapture: validateTaskId(task.task_id)
        Strategy-->>Strategy: valid true path runDir specs task_id md
    end
    alt specPath invalid
        Strategy-->>Engine: success false recoverable false
    else specPath valid
        Strategy->>CLI: runCodeMachine(config, runnerOptions)
        CLI-->>Strategy: RunnerResult
        Strategy-->>Engine: ExecutionStrategyResult
    end
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fcodemachine-pipeline%22%20on%20the%20existing%20branch%20%22codex%2Ffix-path-traversal-vulnerability-in-cliexecutionengine%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ffix-path-traversal-vulnerability-in-cliexecutionengine%22.%0A%0AFix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2Fworkflows%2FcodeMachineStrategy.ts%3A140%0A**TOCTOU%3A%20symlink%20returned%20is%20the%20unresolved%20path%2C%20not%20the%20validated%20real%20path**%0A%0AAfter%20verifying%20that%20%60realCandidatePath%60%20resolves%20within%20the%20workspace%2C%20the%20code%20returns%20%60candidatePath%60%20%28the%20original%2C%20possibly-symlink%20path%29%20rather%20than%20%60realCandidatePath%60.%20If%20an%20attacker%20can%20modify%20the%20symlink%20between%20the%20%60realpath%60%20validation%20and%20the%20point%20CodeMachine%20opens%20the%20file%2C%20the%20CLI%20will%20follow%20the%20newly-swapped%20symlink%20to%20an%20arbitrary%20location%20outside%20the%20workspace.%20Returning%20%60realCandidatePath%60%20instead%20eliminates%20this%20window%20entirely.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20return%20%7B%20valid%3A%20true%2C%20path%3A%20realCandidatePath%20%7D%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%203%0Asrc%2Fworkflows%2FcodeMachineStrategy.ts%3A154-160%0A**%60resolveRealPathSafe%60%20is%20duplicated%20from%20%60executionArtifactCapture.ts%60**%0A%0AThe%20same%20function%20body%20already%20exists%20as%20a%20private%20function%20in%20%60executionArtifactCapture.ts%60%20%28lines%2019%E2%80%9325%29.%20Because%20it%20is%20not%20exported%2C%20a%20second%20copy%20was%20introduced%20here.%20Consider%20exporting%20it%20from%20%60executionArtifactCapture.ts%60%20%28or%20a%20shared%20utility%20module%29%20and%20importing%20it%20in%20both%20consumers%20to%20keep%20the%20symlink-fallback%20logic%20in%20one%20place.%0A%0A%23%23%23%20Issue%203%20of%203%0Asrc%2Fworkflows%2FcliExecutionEngine.ts%3A321-338%0A**%60isPathContained%60%20log-path%20guard%20is%20unreachable%20after%20the%20prior%20%60validateTaskId%60%20check**%0A%0A%60validateTaskId%60%20%28line%20292%29%20requires%20the%20task%20ID%20to%20match%20%60%2F%5E%5Ba-zA-Z0-9_-%5D%2B%24%2F%60%20and%20explicitly%20rejects%20%60..%60.%20A%20task%20that%20passes%20that%20check%20can%20only%20produce%20a%20%60logPath%60%20of%20the%20form%20%60%3ClogsDir%3E%2F%3Csafe-alphanumeric-chars%3E.log%60%2C%20which%20can%20never%20escape%20%60logsDir%60.%20The%20%60isPathContained%60%20guard%20therefore%20can%20never%20evaluate%20to%20%60false%60%20at%20runtime%20and%20the%20early-return%20branch%20is%20dead%20code.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/workflows/codeMachineStrategy.ts:140
**TOCTOU: symlink returned is the unresolved path, not the validated real path**

After verifying that `realCandidatePath` resolves within the workspace, the code returns `candidatePath` (the original, possibly-symlink path) rather than `realCandidatePath`. If an attacker can modify the symlink between the `realpath` validation and the point CodeMachine opens the file, the CLI will follow the newly-swapped symlink to an arbitrary location outside the workspace. Returning `realCandidatePath` instead eliminates this window entirely.

```suggestion
      return { valid: true, path: realCandidatePath };
```

### Issue 2 of 3
src/workflows/codeMachineStrategy.ts:154-160
**`resolveRealPathSafe` is duplicated from `executionArtifactCapture.ts`**

The same function body already exists as a private function in `executionArtifactCapture.ts` (lines 19–25). Because it is not exported, a second copy was introduced here. Consider exporting it from `executionArtifactCapture.ts` (or a shared utility module) and importing it in both consumers to keep the symlink-fallback logic in one place.

### Issue 3 of 3
src/workflows/cliExecutionEngine.ts:321-338
**`isPathContained` log-path guard is unreachable after the prior `validateTaskId` check**

`validateTaskId` (line 292) requires the task ID to match `/^[a-zA-Z0-9_-]+$/` and explicitly rejects `..`. A task that passes that check can only produce a `logPath` of the form `<logsDir>/<safe-alphanumeric-chars>.log`, which can never escape `logsDir`. The `isPathContained` guard therefore can never evaluate to `false` at runtime and the early-return branch is dead code.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: contain execution task paths"](https://github.com/kinginyellows/codemachine-pipeline/commit/aec86ccfd5efb06d1f58490b77e03961c41b70d3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30937546)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->