### PR TITLE
fix: block unsafe deployment readiness fallback

### DIFF
--- a/src/workflows/deployment/execution.ts
+++ b/src/workflows/deployment/execution.ts
@@ -373,14 +373,21 @@ export async function assessMergeReadiness(
       });
     }
   } else {
-    // No branch protection report - use basic GitHub mergeable_state
+    // No branch protection report - conservatively allow only known ready states. Other
+    // GitHub mergeable_state values can represent failing checks, pending reviews, stale
+    // branches, or a still-computing mergeability result.
     logger.debug('No branch protection report - using basic GitHub mergeable_state');
 
-    if (freshPR.mergeable_state === 'blocked') {
+    const readyMergeableStates = new Set(['clean', 'has_hooks']);
+    if (!freshPR.mergeable_state || !readyMergeableStates.has(freshPR.mergeable_state)) {
+      const stateDescription = freshPR.mergeable_state ?? 'unknown';
       blockers.push({
         type: 'protection',
-        message: 'PR is blocked by branch protection rules',
-        recommended_action: 'Run "codepipe status" to check specific protection requirements',
+        message: `PR mergeable_state is ${stateDescription}; deployment requires a clean mergeable state when the branch protection report is unavailable`,
+        recommended_action: 'Run "codepipe status" to refresh branch protection requirements',
+        metadata: {
+          mergeable_state: freshPR.mergeable_state,
+        },
       });
     }
   }

--- a/tests/unit/deploymentTrigger.spec.ts
+++ b/tests/unit/deploymentTrigger.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeAll } from 'vitest';
 import {
+  assessMergeReadiness,
   selectDeploymentStrategy,
   DeploymentStrategy,
   type DeploymentContext,
@@ -9,6 +10,7 @@ import {
 } from '../../src/workflows/deployment/trigger';
 import type { StructuredLogger } from '../../src/telemetry/logger';
 import type { BranchProtectionReport } from '../../src/workflows/branchProtectionReporter';
+import type { GitHubAdapter, PullRequest } from '../../src/adapters/github/GitHubAdapter';
 
 // Create a mock logger that does nothing
 function createMockLogger(): StructuredLogger {
@@ -48,8 +50,14 @@ function createDeploymentContext(
             ...overrides.branchProtection,
           } as BranchProtectionReport),
     logger: createMockLogger(),
-    pr: { url: 'https://github.com/test/repo/pull/1' } as DeploymentContext['pr'],
-    approvals: { approvalsHash: 'abc123' } as DeploymentContext['approvals'],
+    pr: { pr_number: 1, url: 'https://github.com/test/repo/pull/1' } as DeploymentContext['pr'],
+    approvals: {
+      approvalsHash: 'abc123',
+      pending: [],
+      completed: [],
+      deployApprovalRequired: false,
+      deployApprovalGranted: true,
+    } as DeploymentContext['approvals'],
     branchProtectionHash: 'def456',
     runDir: '/tmp/test-run',
     featureId: 'test-feature',
@@ -261,6 +269,45 @@ describe('deploymentTrigger', () => {
   // ==========================================================================
   // Coverage gap-fill: exported function signatures (CDMCH-87)
   // ==========================================================================
+
+  describe('assessMergeReadiness', () => {
+    function createGitHubAdapter(mergeableState: string | null): GitHubAdapter {
+      return {
+        getPullRequest: vi.fn().mockResolvedValue({
+          number: 1,
+          state: 'open',
+          draft: false,
+          mergeable: true,
+          mergeable_state: mergeableState,
+          head: { ref: 'feature', sha: 'abc123' },
+          base: { ref: 'main', sha: 'def456' },
+        } as PullRequest),
+      } as unknown as GitHubAdapter;
+    }
+
+    it('should allow clean PRs when branch protection report is unavailable', async () => {
+      const context = createDeploymentContext({ branchProtection: null });
+
+      const readiness = await assessMergeReadiness(context, createGitHubAdapter('clean'));
+
+      expect(readiness.eligible).toBe(true);
+      expect(readiness.blockers).toHaveLength(0);
+    });
+
+    it('should block unsafe mergeable_state values when branch protection report is unavailable', async () => {
+      const context = createDeploymentContext({ branchProtection: null });
+
+      const readiness = await assessMergeReadiness(context, createGitHubAdapter('unstable'));
+
+      expect(readiness.eligible).toBe(false);
+      expect(readiness.blockers).toHaveLength(1);
+      expect(readiness.blockers[0]).toMatchObject({
+        type: 'protection',
+        metadata: { mergeable_state: 'unstable' },
+      });
+      expect(readiness.blockers[0].message).toContain('unstable');
+    });
+  });
 
   describe('deployment function exports', () => {
     let mod: typeof import('../../src/workflows/deployment/trigger');


### PR DESCRIPTION
## **User description**
@devin

### Motivation
- Prevent a readiness bypass when the branch protection report is missing by avoiding permissive fallback logic that treated absent reports as non-blocking.
- Ensure deployments only proceed when GitHub reports an explicitly ready `mergeable_state` to avoid auto-merging or dispatching workflows on PRs with pending/failing checks or reviews.

### Description
- Tighten `assessMergeReadiness` fallback in `src/workflows/deployment/execution.ts` to accept only known-ready GitHub `mergeable_state` values (`clean`, `has_hooks`) and add a `protection` blocker for other or missing states with `mergeable_state` included in `metadata`.
- Update unit test fixtures to supply the minimal PR number and approvals shape required by `assessMergeReadiness`.
- Add unit tests in `tests/unit/deploymentTrigger.spec.ts` covering the no-report fallback: one test verifies a `clean` state is allowed, and another verifies an `unstable` state is blocked and records metadata.

### Testing
- Ran `npx vitest run tests/unit/deploymentTrigger.spec.ts` and the modified unit tests passed. (Success)
- Ran `npm run build` to compile TypeScript and it completed successfully. (Success)
- Ran `npx eslint src/workflows/deployment/execution.ts tests/unit/deploymentTrigger.spec.ts --quiet` and there were no lint errors for the modified files. (Success)
- Ran `npx prettier --check src/workflows/deployment/execution.ts tests/unit/deploymentTrigger.spec.ts` and formatting checks passed. (Success)
- Attempted broader integration run via the repo test script; this previously exercised unrelated, environment-sensitive suites and surfaced pre-existing failures in `tests/unit/traces.spec.ts` and `tests/unit/commands/health.spec.ts`, so end-to-end repo test was not used to gate this focused fix. (Not applicable to this change)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa968a4a948321bc4885eb4b33b838)

___

## **CodeAnt-AI Description**
Block deployments unless GitHub reports a clearly ready merge state

### What Changed
- When branch protection details are missing, deployments now continue only if GitHub says the pull request is in a clearly ready state.
- Pull requests in uncertain or unsafe states are now blocked, with a message that points to the current merge state and suggests refreshing branch protection details.
- The deployment readiness check now includes the merge state in the block details so the reason is easier to understand.

### Impact
`✅ Fewer unsafe deployments`
`✅ Clearer deployment blocking messages`
`✅ Safer fallback when branch protection data is missing`

[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=ek50Dz5YtRS8D6rmhovTgvlLbcGRjlFpzPSNSJ9bB8c&org=KingInYellows)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens the `assessMergeReadiness` fallback in `execution.ts` by replacing a single denylist check (`blocked`) with an explicit allowlist (`clean`, `has_hooks`), so deployments are blocked when GitHub reports any other or absent `mergeable_state` while no branch protection report is available. Fixture updates and two new unit tests accompany the logic change.

- **Allowlist fallback** (`execution.ts`): the old code only blocked `'blocked'`; states like `'unstable'`, `'behind'`, and `'unknown'` (still-computing) would pass silently. The new guard blocks all states not in `{'clean', 'has_hooks'}` and attaches a `metadata.mergeable_state` field to the blocker.
- **Test fixtures** (`deploymentTrigger.spec.ts`): `pr` and `approvals` shapes are expanded with fields required by `assessMergeReadiness`; two new tests verify the `clean`-allowed and `unstable`-blocked paths.
- **Gap**: there is no test for `null` `mergeable_state`, which is the GitHub response when mergeability is still computing — the exact scenario the `!freshPR.mergeable_state` clause targets.

<h3>Confidence Score: 4/5</h3>

The core logic change is correct and closes a real gap in the deployment gate; two minor inconsistencies are worth fixing before the next iteration.

The allowlist switch in `assessMergeReadiness` is sound and the new tests validate the primary happy and error paths. `metadata.mergeable_state` stores raw `null` while the message string says `'unknown'`, which can confuse log consumers; and there is no test exercising the `null` path despite it being the precise scenario the `!freshPR.mergeable_state` guard was written for.

The `null`-state branch in `execution.ts` (lines 382-391) and the corresponding test suite in `deploymentTrigger.spec.ts` would benefit from an additional test case before shipping.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/workflows/deployment/execution.ts | Replaces denylist-only check (`blocked`) with allowlist (`clean`, `has_hooks`) for no-report fallback; minor metadata/message inconsistency when mergeable_state is null. |
| tests/unit/deploymentTrigger.spec.ts | Adds fixture fields required by updated assessMergeReadiness and two new tests (clean allowed, unstable blocked); missing coverage for the null mergeable_state edge case. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[assessMergeReadiness called] --> B[Fetch fresh PR via githubAdapter.getPullRequest]
    B --> C{branchProtection report present?}
    C -- Yes --> D[Run detailed checks: auto_merge, conflicts, status checks, reviews, branch staleness]
    D --> E[Collect blockers]
    C -- No --> F{freshPR.mergeable_state in allowlist?}
    F -- clean or has_hooks --> G[No protection blocker added]
    F -- null / unknown / unstable / blocked / behind / dirty --> H[Push protection blocker with metadata.mergeable_state]
    E --> I{approvals gate check}
    G --> I
    H --> I
    I --> J[Return MergeReadiness eligible = blockers.length === 0]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fcodemachine-pipeline%22%20on%20the%20existing%20branch%20%22codex%2Fpropose-fix-for-deployment-trigger-vulnerability%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fpropose-fix-for-deployment-trigger-vulnerability%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atests%2Funit%2FdeploymentTrigger.spec.ts%3A273-310%0A**Missing%20test%20for%20%60null%60%20mergeable_state**%0A%0AThe%20new%20test%20suite%20covers%20%60'clean'%60%20%28allowed%29%20and%20%60'unstable'%60%20%28blocked%29%2C%20but%20not%20the%20%60null%60%20case%20%E2%80%94%20the%20most%20important%20edge%20from%20this%20PR's%20perspective.%20GitHub%20returns%20%60null%60%20when%20mergeability%20hasn't%20been%20computed%20yet%2C%20and%20the%20new%20guard's%20first%20clause%20%28%60!freshPR.mergeable_state%60%29%20is%20the%20only%20code%20path%20that%20handles%20it.%20Without%20a%20test%2C%20a%20future%20refactor%20that%20drops%20the%20null%20check%20would%20silently%20regress%20the%20behavior%20this%20PR%20was%20specifically%20designed%20to%20prevent.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fworkflows%2Fdeployment%2Fexecution.ts%3A383-391%0A**Metadata%20and%20message%20disagree%20on%20%60null%60%20state%20label**%0A%0AWhen%20%60freshPR.mergeable_state%60%20is%20%60null%60%2C%20%60stateDescription%60%20is%20%60'unknown'%60%20%28via%20%60%3F%3F%60%29%2C%20so%20the%20human-readable%20message%20says%20%60%22PR%20mergeable_state%20is%20unknown%22%60.%20However%2C%20%60metadata.mergeable_state%60%20stores%20the%20raw%20%60null%60.%20A%20downstream%20consumer%20correlating%20the%20message%20text%20with%20the%20structured%20metadata%20field%20will%20see%20a%20mismatch%20%E2%80%94%20the%20message%20says%20%60'unknown'%60%20but%20the%20metadata%20says%20%60null%60.%20Normalising%20both%20to%20%60'unknown'%60%20keeps%20them%20consistent.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20const%20stateDescription%20%3D%20freshPR.mergeable_state%20%3F%3F%20'unknown'%3B%0A%20%20%20%20%20%20blockers.push%28%7B%0A%20%20%20%20%20%20%20%20type%3A%20'protection'%2C%0A%20%20%20%20%20%20%20%20message%3A%20%60PR%20mergeable_state%20is%20%24%7BstateDescription%7D%3B%20deployment%20requires%20a%20clean%20mergeable%20state%20when%20the%20branch%20protection%20report%20is%20unavailable%60%2C%0A%20%20%20%20%20%20%20%20recommended_action%3A%20'Run%20%22codepipe%20status%22%20to%20refresh%20branch%20protection%20requirements'%2C%0A%20%20%20%20%20%20%20%20metadata%3A%20%7B%0A%20%20%20%20%20%20%20%20%20%20mergeable_state%3A%20stateDescription%2C%0A%20%20%20%20%20%20%20%20%7D%2C%0A%20%20%20%20%20%20%7D%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
tests/unit/deploymentTrigger.spec.ts:273-310
**Missing test for `null` mergeable_state**

The new test suite covers `'clean'` (allowed) and `'unstable'` (blocked), but not the `null` case — the most important edge from this PR's perspective. GitHub returns `null` when mergeability hasn't been computed yet, and the new guard's first clause (`!freshPR.mergeable_state`) is the only code path that handles it. Without a test, a future refactor that drops the null check would silently regress the behavior this PR was specifically designed to prevent.

### Issue 2 of 2
src/workflows/deployment/execution.ts:383-391
**Metadata and message disagree on `null` state label**

When `freshPR.mergeable_state` is `null`, `stateDescription` is `'unknown'` (via `??`), so the human-readable message says `"PR mergeable_state is unknown"`. However, `metadata.mergeable_state` stores the raw `null`. A downstream consumer correlating the message text with the structured metadata field will see a mismatch — the message says `'unknown'` but the metadata says `null`. Normalising both to `'unknown'` keeps them consistent.

```suggestion
      const stateDescription = freshPR.mergeable_state ?? 'unknown';
      blockers.push({
        type: 'protection',
        message: `PR mergeable_state is ${stateDescription}; deployment requires a clean mergeable state when the branch protection report is unavailable`,
        recommended_action: 'Run "codepipe status" to refresh branch protection requirements',
        metadata: {
          mergeable_state: stateDescription,
        },
      });
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: block unsafe deployment readiness f..."](https://github.com/kinginyellows/codemachine-pipeline/commit/09a592fcaf423eaefc24fe3e879a283e2a69294c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30937558)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->