### PR TITLE
fix: harden fixture updater python inputs

### DIFF
--- a/scripts/tooling/update_fixtures.sh
+++ b/scripts/tooling/update_fixtures.sh
@@ -121,7 +121,15 @@ validate_fixture() {
 
   # Check required fields
   local status
-  status=$(python3 -c "import json; data=json.load(open('$file')); print(data.get('status', ''))")
+  status=$(python3 - "$file" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+print(data.get('status', ''))
+PY
+)
 
   if [[ -z "$status" ]]; then
     log_error "Missing 'status' field in $file"
@@ -129,7 +137,15 @@ validate_fixture() {
   fi
 
   local headers
-  headers=$(python3 -c "import json; data=json.load(open('$file')); print('headers' in data)")
+  headers=$(python3 - "$file" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1]) as f:
+    data = json.load(f)
+print('headers' in data)
+PY
+)
 
   if [[ "$headers" != "True" ]]; then
     log_error "Missing 'headers' field in $file"
@@ -164,19 +180,25 @@ update_manifest() {
   local temp_manifest="${provider_dir}/manifest.tmp.json"
 
   # Read existing manifest
-  python3 << EOF
+  MANIFEST_PATH="$manifest" \
+    FIXTURES_PROVIDER_DIR="$provider_dir" \
+    TEMP_MANIFEST_PATH="$temp_manifest" \
+    FIXTURE_TIMESTAMP="$timestamp" \
+    SOURCE_BRANCH="$branch" \
+    python3 <<'PY'
 import json
 import os
 
-manifest_path = '${manifest}'
-fixtures_dir = '${provider_dir}'
+manifest_path = os.environ['MANIFEST_PATH']
+fixtures_dir = os.environ['FIXTURES_PROVIDER_DIR']
+temp_manifest = os.environ['TEMP_MANIFEST_PATH']
 
 with open(manifest_path, 'r') as f:
     manifest = json.load(f)
 
 # Update metadata
-manifest['updated'] = '${timestamp}'
-manifest['source_branch'] = '${branch}'
+manifest['updated'] = os.environ['FIXTURE_TIMESTAMP']
+manifest['source_branch'] = os.environ['SOURCE_BRANCH']
 
 # Update fixture hashes
 for fixture_entry in manifest.get('fixtures', []):
@@ -193,10 +215,10 @@ for fixture_entry in manifest.get('fixtures', []):
         print(f"Warning: Fixture file not found: {fixture_file}", file=__import__('sys').stderr)
 
 # Write updated manifest
-with open('${temp_manifest}', 'w') as f:
+with open(temp_manifest, 'w') as f:
     json.dump(manifest, f, indent=2)
     f.write('\n')
-EOF
+PY
 
   if [[ $? -ne 0 ]]; then
     log_error "Failed to update manifest for $provider"


### PR DESCRIPTION
## **User description**
### Motivation
- Remove a code-injection vector where the current git branch name was interpolated directly into a Python heredoc, allowing crafted branch names to execute arbitrary Python during fixture updates.
- Preserve the existing manifest update behavior while preventing untrusted branch names or file paths from being treated as code.

### Description
- @devin
- Update `scripts/tooling/update_fixtures.sh` to pass fixture paths to inline Python via `sys.argv` instead of interpolating file paths into `python -c` strings, removing direct file interpolation in the validation helpers.
- Pass `MANIFEST_PATH`, `FIXTURES_PROVIDER_DIR`, `TEMP_MANIFEST_PATH`, `FIXTURE_TIMESTAMP`, and `SOURCE_BRANCH` into the manifest-update Python heredoc via environment variables and quote the heredoc delimiter (`<<'PY'`) so the branch name is treated as data rather than executable code.
- Keep all functionality intact: compute SHA256 fixture hashes, update `manifest.json` entries, and retain `--dry-run` output behavior; the only changes are how inputs are delivered to the Python snippets.

### Testing
- `bash -n scripts/tooling/update_fixtures.sh` succeeded with no syntax errors.
- `./scripts/tooling/update_fixtures.sh --provider github --dry-run` succeeded and printed the updated manifest JSON as expected.
- Regression check using a crafted malicious branch name was performed and confirmed that no arbitrary Python executed and that `source_branch` was recorded verbatim in the manifest output (no `/tmp/branch_pwned` created).
- `npm test` was run and returned failures in existing/unrelated unit tests (`tests/unit/traces.spec.ts` and `tests/unit/commands/health.spec.ts`), which appear pre-existing and environment-specific and are not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa96895d288321ad2dea517d551082)


___

## **CodeAnt-AI Description**
Harden fixture updates so file paths and branch names are treated as data, not executable input

### What Changed
- Fixture validation now reads JSON file paths safely instead of building Python commands with inline file text
- Manifest updates now pass the manifest path, fixture directory, timestamp, temporary output path, and branch name through environment variables
- The updater still refreshes fixture hashes, writes the updated manifest, and keeps dry-run output unchanged

### Impact
`✅ Safer fixture updates`
`✅ No branch-name code execution`
`✅ Fewer manifest update failures from untrusted input`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=n5aSuOhtRqd-RQ_88562m-R-FClR6Ayqzv50LxZQj00&org=KingInYellows)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens `scripts/tooling/update_fixtures.sh` by eliminating two categories of Python code-injection: file-path interpolation into `python3 -c` strings and unquoted heredocs that allowed arbitrary shell expansion (including the git branch name) inside the Python block.

- In `validate_fixture`, the two `python3 -c \"...open('$file')...\"` one-liners are replaced with quoted `<<'PY'` heredocs that receive the file path via `sys.argv[1]`, so a malicious filename cannot escape the string literal.
- In `update_manifest`, the unquoted `<< EOF` heredoc (where `$branch`, `$manifest`, etc. were expanded inside Python source) is replaced with a quoted `<<'PY'` heredoc; all five values are now delivered through environment variables set on the `python3` invocation and read via `os.environ`, making crafted branch names data rather than executable code.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the injection vectors are correctly closed and no new defects are introduced.

The core security fix is sound: quoting the heredoc delimiters and delivering inputs through sys.argv and environment variables fully closes the branch-name and file-path injection paths. The only noteworthy gap is a pre-existing dead error handler in update_manifest that has never fired and still won’t after this change.

scripts/tooling/update_fixtures.sh — specifically the $? check at line 223 that is unreachable under set -e.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/tooling/update_fixtures.sh | Injection vectors correctly eliminated via sys.argv and env-var delivery; one pre-existing dead error-handler ($? check after a standalone command under set -e) remains at line 223. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Shell as update_fixtures.sh
    participant Git as git
    participant PY1 as python3 (validate_fixture)
    participant PY2 as python3 (update_manifest)
    participant FS as Filesystem

    Shell->>Git: git rev-parse --abbrev-ref HEAD
    Git-->>Shell: branch (untrusted string)

    loop each fixture file
        Shell->>PY1: python3 - "$file" <<'PY' (sys.argv[1])
        PY1->>FS: open(sys.argv[1])
        FS-->>PY1: JSON data
        PY1-->>Shell: status / headers check result
    end

    Shell->>PY2: MANIFEST_PATH=... SOURCE_BRANCH=... python3 <<'PY'
    Note over Shell,PY2: branch passed as env var, not interpolated into source
    PY2->>FS: open(os.environ['MANIFEST_PATH'])
    FS-->>PY2: manifest JSON
    PY2->>FS: write os.environ['TEMP_MANIFEST_PATH']
    PY2-->>Shell: exit 0

    alt DRY_RUN
        Shell->>FS: cat temp_manifest && rm temp_manifest
    else
        Shell->>FS: mv temp_manifest to manifest.json
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `scripts/tooling/update_fixtures.sh`, line 223-226 ([link](https://github.com/kinginyellows/codemachine-pipeline/blob/d0ee783336e975e8d750f1fce025d9a5d4e63312/scripts/tooling/update_fixtures.sh#L223-L226)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Dead error handler under `set -euo pipefail`**

   Because `set -euo pipefail` is active (line 24) and the `python3 <<'PY' ... PY` block at line 188 is a standalone statement (not inside an `if`/`while`/`||` context), a non-zero exit from Python causes bash to terminate the script immediately — before this `$?` check is ever evaluated. The `log_error "Failed to update manifest…"` message and `return 1` are therefore unreachable. This was present before the PR too, but the refactor is a good moment to fix it by wrapping the invocation in `if ! python3 <<'PY' ... PY; then`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: scripts/tooling/update_fixtures.sh
   Line: 223-226

   Comment:
   **Dead error handler under `set -euo pipefail`**

   Because `set -euo pipefail` is active (line 24) and the `python3 <<'PY' ... PY` block at line 188 is a standalone statement (not inside an `if`/`while`/`||` context), a non-zero exit from Python causes bash to terminate the script immediately — before this `$?` check is ever evaluated. The `log_error "Failed to update manifest…"` message and `return 1` are therefore unreachable. This was present before the PR too, but the refactor is a good moment to fix it by wrapping the invocation in `if ! python3 <<'PY' ... PY; then`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fcodemachine-pipeline%22%20on%20the%20existing%20branch%20%22codex%2Ffix-python-injection-in-fixture-update-script%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ffix-python-injection-in-fixture-update-script%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Ftooling%2Fupdate_fixtures.sh%0ALine%3A%20223-226%0A%0AComment%3A%0A**Dead%20error%20handler%20under%20%60set%20-euo%20pipefail%60**%0A%0ABecause%20%60set%20-euo%20pipefail%60%20is%20active%20%28line%2024%29%20and%20the%20%60python3%20%3C%3C'PY'%20...%20PY%60%20block%20at%20line%20188%20is%20a%20standalone%20statement%20%28not%20inside%20an%20%60if%60%2F%60while%60%2F%60%7C%7C%60%20context%29%2C%20a%20non-zero%20exit%20from%20Python%20causes%20bash%20to%20terminate%20the%20script%20immediately%20%E2%80%94%20before%20this%20%60%24%3F%60%20check%20is%20ever%20evaluated.%20The%20%60log_error%20%22Failed%20to%20update%20manifest%E2%80%A6%22%60%20message%20and%20%60return%201%60%20are%20therefore%20unreachable.%20This%20was%20present%20before%20the%20PR%20too%2C%20but%20the%20refactor%20is%20a%20good%20moment%20to%20fix%20it%20by%20wrapping%20the%20invocation%20in%20%60if%20!%20python3%20%3C%3C'PY'%20...%20PY%3B%20then%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fcodemachine-pipeline%22%20on%20the%20existing%20branch%20%22codex%2Ffix-python-injection-in-fixture-update-script%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ffix-python-injection-in-fixture-update-script%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Ascripts%2Ftooling%2Fupdate_fixtures.sh%3A223-226%0A**Dead%20error%20handler%20under%20%60set%20-euo%20pipefail%60**%0A%0ABecause%20%60set%20-euo%20pipefail%60%20is%20active%20%28line%2024%29%20and%20the%20%60python3%20%3C%3C'PY'%20...%20PY%60%20block%20at%20line%20188%20is%20a%20standalone%20statement%20%28not%20inside%20an%20%60if%60%2F%60while%60%2F%60%7C%7C%60%20context%29%2C%20a%20non-zero%20exit%20from%20Python%20causes%20bash%20to%20terminate%20the%20script%20immediately%20%E2%80%94%20before%20this%20%60%24%3F%60%20check%20is%20ever%20evaluated.%20The%20%60log_error%20%22Failed%20to%20update%20manifest%E2%80%A6%22%60%20message%20and%20%60return%201%60%20are%20therefore%20unreachable.%20This%20was%20present%20before%20the%20PR%20too%2C%20but%20the%20refactor%20is%20a%20good%20moment%20to%20fix%20it%20by%20wrapping%20the%20invocation%20in%20%60if%20!%20python3%20%3C%3C'PY'%20...%20PY%3B%20then%60.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
scripts/tooling/update_fixtures.sh:223-226
**Dead error handler under `set -euo pipefail`**

Because `set -euo pipefail` is active (line 24) and the `python3 <<'PY' ... PY` block at line 188 is a standalone statement (not inside an `if`/`while`/`||` context), a non-zero exit from Python causes bash to terminate the script immediately — before this `$?` check is ever evaluated. The `log_error "Failed to update manifest…"` message and `return 1` are therefore unreachable. This was present before the PR too, but the refactor is a good moment to fix it by wrapping the invocation in `if ! python3 <<'PY' ... PY; then`.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: harden fixture updater python input..."](https://github.com/kinginyellows/codemachine-pipeline/commit/d0ee783336e975e8d750f1fce025d9a5d4e63312) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30937567)</sub>

<!-- /greptile_comment -->