### PR TITLE
fix(traceability): bound generated trace links

### DIFF
--- a/src/workflows/traceabilityMapper.ts
+++ b/src/workflows/traceabilityMapper.ts
@@ -84,6 +84,8 @@ interface TraceDiagnostics {
   gaps: TraceGap[];
 }
 
+const MAX_GENERATED_TRACE_LINKS = 10_000;
+
 /**
  * Trace document structure persisted to trace.json
  */
@@ -230,6 +232,27 @@ async function extractExecutionTasks(runDir: string): Promise<{
   }
 
   return { tasks };
+}
+
+function calculateTraceLinkCount(leftCount: number, rightCount: number): number {
+  return leftCount * rightCount;
+}
+
+function assertTraceLinkBudget(
+  prdGoalCount: number,
+  specRequirementCount: number,
+  executionTaskCount: number
+): void {
+  const prdToSpecCount = calculateTraceLinkCount(prdGoalCount, specRequirementCount);
+  const specToTaskCount = calculateTraceLinkCount(specRequirementCount, executionTaskCount);
+  const totalLinks = prdToSpecCount + specToTaskCount;
+
+  if (totalLinks > MAX_GENERATED_TRACE_LINKS) {
+    throw new Error(
+      `Trace map generation would create ${totalLinks.toLocaleString('en-US')} links, exceeding the safety limit of ${MAX_GENERATED_TRACE_LINKS.toLocaleString('en-US')}. ` +
+        `Reduce PRD goals (${prdGoalCount}), spec requirements (${specRequirementCount}), or execution tasks (${executionTaskCount}) before regenerating traceability.`
+    );
+  }
 }
 
 /**
@@ -450,6 +473,8 @@ export async function generateTraceMap(
     specRequirements: specRequirements.length,
     executionTasks: executionTasks.length,
   });
+
+  assertTraceLinkBudget(prdGoals.length, specRequirements.length, executionTasks.length);
 
   const prdToSpecLinks = generatePRDToSpecLinks(
     config.featureId,

--- a/tests/unit/traceabilityMapper.spec.ts
+++ b/tests/unit/traceabilityMapper.spec.ts
@@ -484,6 +484,57 @@ describe('traceabilityMapper', () => {
       expect(result.statistics.duplicatesPrevented).toBe(1);
     });
 
+    it('should reject trace maps that exceed the generated link safety limit', async () => {
+      // Arrange
+      const config: TraceMapperConfig = {
+        runDir: '/run/feat-123',
+        featureId: 'feat-123',
+        force: false,
+      };
+
+      const prdMetadata = createMockPRDMetadata();
+      const specMetadata = createMockSpecMetadata();
+      const prdMarkdown = `## Goals\n\n${Array.from({ length: 101 }, (_, index) => `- Goal ${index + 1}`).join('\n')}`;
+      const specJson = {
+        ...createMockSpecJson(),
+        test_plan: Array.from({ length: 100 }, (_, index) => ({
+          test_id: `T-UNIT-${(index + 1).toString().padStart(3, '0')}`,
+          description: `Requirement ${index + 1}`,
+          test_type: 'unit',
+          acceptance_criteria: [],
+        })),
+      };
+
+      vi.mocked(fs.access).mockRejectedValue(new Error('ENOENT'));
+      vi.mocked(fs.readFile).mockImplementation(async (filePath: string) => {
+        await Promise.resolve();
+        if (filePath.includes('prd_metadata.json')) {
+          return JSON.stringify(prdMetadata);
+        }
+        if (filePath.includes('spec_metadata.json')) {
+          return JSON.stringify(specMetadata);
+        }
+        if (filePath.includes('prd.md')) {
+          return prdMarkdown;
+        }
+        if (filePath.includes('spec.json')) {
+          return JSON.stringify(specJson);
+        }
+        if (filePath.includes('plan.json')) {
+          throw new Error('ENOENT');
+        }
+        throw new Error(`Unexpected file read: ${filePath}`);
+      });
+
+      vi.mocked(fs.writeFile).mockResolvedValue(undefined);
+
+      // Act & Assert
+      await expect(generateTraceMap(config, mockLogger, mockMetrics)).rejects.toThrow(
+        'Trace map generation would create 10,100 links, exceeding the safety limit of 10,000'
+      );
+      expect(fs.writeFile).not.toHaveBeenCalled();
+    });
+
     it('should detect gaps when PRD has no goals', async () => {
       // Arrange
       const config: TraceMapperConfig = {


### PR DESCRIPTION
## **User description**
### Motivation
- Address a denial-of-service risk where the traceability mapper materialized full cross-products (PRD→Spec and Spec→Task) from untrusted inputs, which could exhaust CPU/memory/disk when artifact counts are large (@devin).
- Fail fast before link arrays are created when a safe upper bound of generated links would be exceeded to protect CLI operators running on attacker-supplied repositories.

### Description
- Add a safety constant `MAX_GENERATED_TRACE_LINKS = 10_000` and helper functions `calculateTraceLinkCount` and `assertTraceLinkBudget` to compute and enforce a pre-generation link budget in `src/workflows/traceabilityMapper.ts`.
- Invoke `assertTraceLinkBudget` immediately after extracting entities and before generating the PRD→Spec and Spec→Task cross-products so oversized inputs are rejected before materialization.
- Add a unit test `should reject trace maps that exceed the generated link safety limit` to `tests/unit/traceabilityMapper.spec.ts` that verifies a 10,100-link attempt is rejected and that `trace.json` is not written.

### Testing
- Ran the traceability unit suite with `npx vitest run tests/unit/traceabilityMapper.spec.ts`, and the test file passed (all tests in that file succeeded).
- Ran targeted linting with `npx eslint src/workflows/traceabilityMapper.ts tests/unit/traceabilityMapper.spec.ts`, which reported no new errors for the modified files.
- Built the project with `npm run build`, which completed successfully; `npm run lint` still fails due to pre-existing unrelated lint errors in other files and therefore is not a regression from this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa968b8f40832189dbc449e7bacc60)

___

## **CodeAnt-AI Description**
**Stop trace map generation when it would create too many links**

### What Changed
- Trace map generation now checks the total number of PRD-to-spec and spec-to-task links before building them.
- If the projected link count is over 10,000, the run fails immediately with a clear error that explains how to reduce the input size.
- A test now covers the oversized case and confirms no trace file is written.

### Impact
`✅ Fewer traceability runs that exhaust resources`
`✅ Clearer errors for oversized repositories`
`✅ No partial trace file when the limit is exceeded`

[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=u9LAh862KIiOn3lDY-M5NhW2p_FoNPa3wVSZdIW-vts&org=KingInYellows)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a pre-generation link budget guard in the traceability mapper to prevent a denial-of-service via cross-product explosion when large numbers of PRD goals, spec requirements, or execution tasks are extracted from untrusted repositories. The check is correctly placed before any link array is materialized.

- Adds `MAX_GENERATED_TRACE_LINKS = 10_000`, `calculateTraceLinkCount`, and `assertTraceLinkBudget` to `src/workflows/traceabilityMapper.ts`; the budget is enforced immediately after entity extraction in `generateTraceMap`, which is also the codepath called by `updateTraceMapOnSpecChange`.
- Adds a unit test that verifies a 101-goal × 100-requirement scenario (10,100 links) is rejected and that `trace.json` is never written.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the budget guard is placed correctly before link materialization and is exercised by the update path as well as the primary generation path.

The core protection logic is correct: counts come from `.length` values so they are always non-negative, the guard fires before any array allocation, and `updateTraceMapOnSpecChange` delegates to `generateTraceMap` so no code path bypasses the check. The only gaps are a thin helper function that adds indirection and a missing boundary-value test case, both minor style/coverage concerns.

No files require special attention; the two changed files are small and self-contained.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/workflows/traceabilityMapper.ts | Adds budget constants and enforcement before link materialization; logic is correct but `calculateTraceLinkCount` is a trivially thin wrapper that adds no abstraction value. |
| tests/unit/traceabilityMapper.spec.ts | New test correctly exercises the rejection path (10,100 links > 10,000 limit) and verifies `writeFile` is never called; no boundary or partial-product edge-case tests are included. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[generateTraceMap called] --> B{force: false AND\ntrace.json exists?}
    B -- Yes --> C[Return cached result]
    B -- No --> D[Load PRD + Spec metadata\nValidate approval status]
    D --> E[extractPRDGoals\nextractSpecRequirements\nextractExecutionTasks]
    E --> F[assertTraceLinkBudget\nprdGoals x specReqs + specReqs x tasks]
    F -- totalLinks > 10,000 --> G[Throw Error\nDoS rejected before materialization]
    F -- totalLinks le 10,000 --> H[generatePRDToSpecLinks\ngenerateSpecToTaskLinks]
    H --> I[deduplicateLinks\nvalidateLinks\ndetectGaps]
    I --> J[Write trace.json\nReturn TraceMapperResult]
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fcodemachine-pipeline%22%20on%20the%20existing%20branch%20%22codex%2Fpropose-fix-for-trace-map-resource-exhaustion%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fpropose-fix-for-trace-map-resource-exhaustion%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fworkflows%2FtraceabilityMapper.ts%3A237-248%0A%60calculateTraceLinkCount%60%20is%20a%20single-line%20wrapper%20for%20multiplication%20with%20no%20guard%20logic%2C%20validation%2C%20or%20special-casing.%20Callers%20reading%20%60assertTraceLinkBudget%60%20must%20jump%20to%20this%20helper%20only%20to%20learn%20it%20is%20%60leftCount%20*%20rightCount%60%2C%20which%20adds%20indirection%20without%20clarity.%20Inlining%20the%20expression%20makes%20the%20budget%20formula%20immediately%20readable%20at%20the%20call%20site.%0A%0A%60%60%60suggestion%0Afunction%20assertTraceLinkBudget%28%0A%20%20prdGoalCount%3A%20number%2C%0A%20%20specRequirementCount%3A%20number%2C%0A%20%20executionTaskCount%3A%20number%0A%29%3A%20void%20%7B%0A%20%20const%20prdToSpecCount%20%3D%20prdGoalCount%20*%20specRequirementCount%3B%0A%20%20const%20specToTaskCount%20%3D%20specRequirementCount%20*%20executionTaskCount%3B%0A%20%20const%20totalLinks%20%3D%20prdToSpecCount%20%2B%20specToTaskCount%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Atests%2Funit%2FtraceabilityMapper.spec.ts%3A533%0AThe%20new%20test%20only%20covers%20the%20rejection%20side%20of%20the%20budget%20check.%20The%20boundary%20value%20%28exactly%2010%2C000%20links%2C%20e.g.%20100%20goals%20%C3%97%20100%20requirements%20%C3%97%200%20tasks%29%20and%20a%20value%20just%20below%20%28e.g.%2099%20%C3%97%20100%29%20are%20not%20tested.%20Without%20at%20least%20one%20%22allowed%22%20case%20at%20the%20boundary%2C%20a%20future%20refactor%20that%20accidentally%20changes%20%60%3E%60%20to%20%60%3E%3D%60%20in%20the%20guard%20would%20not%20be%20caught%20by%20the%20test%20suite.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/workflows/traceabilityMapper.ts:237-248
`calculateTraceLinkCount` is a single-line wrapper for multiplication with no guard logic, validation, or special-casing. Callers reading `assertTraceLinkBudget` must jump to this helper only to learn it is `leftCount * rightCount`, which adds indirection without clarity. Inlining the expression makes the budget formula immediately readable at the call site.

```suggestion
function assertTraceLinkBudget(
  prdGoalCount: number,
  specRequirementCount: number,
  executionTaskCount: number
): void {
  const prdToSpecCount = prdGoalCount * specRequirementCount;
  const specToTaskCount = specRequirementCount * executionTaskCount;
  const totalLinks = prdToSpecCount + specToTaskCount;
```

### Issue 2 of 2
tests/unit/traceabilityMapper.spec.ts:533
The new test only covers the rejection side of the budget check. The boundary value (exactly 10,000 links, e.g. 100 goals × 100 requirements × 0 tasks) and a value just below (e.g. 99 × 100) are not tested. Without at least one "allowed" case at the boundary, a future refactor that accidentally changes `>` to `>=` in the guard would not be caught by the test suite.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(traceability): bound generated trace..."](https://github.com/kinginyellows/codemachine-pipeline/commit/6c92cba576f83f02c8017a3ac79d6bfb88cafbaa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30937575)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->