### PR TITLE
fix(telemetry): redact sensitive data from spans before persisting

### DIFF
--- a/src/telemetry/traces.ts
+++ b/src/telemetry/traces.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 import * as crypto from 'node:crypto';
 import type { LogContext } from '../core/sharedTypes';
 import { createLogger, LogLevel, type LoggerInterface } from './logger';
+import { RedactionEngine, REDACTED } from '../utils/redaction.js';
 import { getErrorMessage } from '../utils/errors.js';
 
 /**
@@ -142,6 +143,48 @@ function generateSpanId(): string {
   return crypto.randomBytes(8).toString('hex');
 }
 
+function redactTraceString(redactor: RedactionEngine, value: string): string {
+  return redactor.redact(value);
+}
+
+function redactTraceAttribute(
+  redactor: RedactionEngine,
+  key: string,
+  value: string | number | boolean
+): string | number | boolean {
+  if (RedactionEngine.isSensitiveFieldName(key)) {
+    return REDACTED;
+  }
+
+  return typeof value === 'string' ? redactTraceString(redactor, value) : value;
+}
+
+function redactTraceAttributes(
+  redactor: RedactionEngine,
+  attributes: Record<string, string | number | boolean>
+): Record<string, string | number | boolean> {
+  return Object.fromEntries(
+    Object.entries(attributes).map(([key, value]) => [
+      key,
+      redactTraceAttribute(redactor, key, value),
+    ])
+  );
+}
+
+function redactTraceStatus(
+  redactor: RedactionEngine,
+  status: { code: SpanStatusCode; message?: string }
+): { code: SpanStatusCode; message?: string } {
+  if (!status.message) {
+    return status;
+  }
+
+  return {
+    ...status,
+    message: redactTraceString(redactor, status.message),
+  };
+}
+
 /**
  * Active span implementation with fluent API
  */
@@ -152,6 +195,7 @@ class ActiveSpanImpl implements ActiveSpan {
   private readonly kind: SpanKind;
   private readonly attributes: Record<string, string | number | boolean>;
   private readonly events: SpanEvent[] = [];
+  private readonly redactor: RedactionEngine;
   private endTime?: number;
   private status: { code: SpanStatusCode; message?: string } = { code: SpanStatusCode.UNSET };
   private readonly onEnd: (span: Span) => void;
@@ -161,18 +205,20 @@ class ActiveSpanImpl implements ActiveSpan {
     context: TraceContext,
     kind: SpanKind,
     defaultAttributes: Record<string, string | number | boolean>,
-    onEnd: (span: Span) => void
+    onEnd: (span: Span) => void,
+    redactor = new RedactionEngine(true)
   ) {
     this.name = name;
     this.context = context;
     this.kind = kind;
-    this.attributes = { ...defaultAttributes };
+    this.redactor = redactor;
+    this.attributes = redactTraceAttributes(this.redactor, defaultAttributes);
     this.startTime = Date.now();
     this.onEnd = onEnd;
   }
 
   setAttribute(key: string, value: string | number | boolean): void {
-    this.attributes[key] = value;
+    this.attributes[key] = redactTraceAttribute(this.redactor, key, value);
   }
 
   addEvent(name: string, attributes?: Record<string, string | number | boolean>): void {
@@ -180,7 +226,7 @@ class ActiveSpanImpl implements ActiveSpan {
       name,
       timestamp: Date.now(),
     };
-    if (attributes) event.attributes = attributes;
+    if (attributes) event.attributes = redactTraceAttributes(this.redactor, attributes);
     this.events.push(event);
   }
 
@@ -190,7 +236,7 @@ class ActiveSpanImpl implements ActiveSpan {
     }
 
     this.endTime = Date.now();
-    this.status = status ?? { code: SpanStatusCode.OK };
+    this.status = redactTraceStatus(this.redactor, status ?? { code: SpanStatusCode.OK });
 
     // Build span record
     const span: Span = {
@@ -221,6 +267,7 @@ class ActiveSpanImpl implements ActiveSpan {
 export class TraceManager {
   private readonly options: Required<Omit<TraceManagerOptions, 'logger'>>;
   private readonly logger: LoggerInterface;
+  private readonly redactor = new RedactionEngine(true);
   private readonly tracesFilePath?: string;
   private readonly spans: Span[] = [];
   private writeQueue: Promise<void> = Promise.resolve();
@@ -307,9 +354,16 @@ export class TraceManager {
       ...attributes,
     };
 
-    return new ActiveSpanImpl(name, context, kind, mergedAttributes, (span) => {
-      this.recordSpan(span);
-    });
+    return new ActiveSpanImpl(
+      name,
+      context,
+      kind,
+      mergedAttributes,
+      (span) => {
+        this.recordSpan(span);
+      },
+      this.redactor
+    );
   }
 
   /**

--- a/tests/unit/traces.spec.ts
+++ b/tests/unit/traces.spec.ts
@@ -6,6 +6,9 @@ import {
   TraceManager,
   createTraceManager,
   createRunTraceManager,
+  withSpan,
+  withSpanSync,
+  SpanStatusCode,
 } from '../../src/telemetry/traces';
 import type { LoggerInterface } from '../../src/telemetry/logger';
 import type { LogContext } from '../../src/core/sharedTypes';
@@ -24,6 +27,19 @@ async function cleanupTempDir(dir: string): Promise<void> {
   } catch {
     // Ignore cleanup errors
   }
+}
+
+async function readTraceFile(filePath: string): Promise<unknown[]> {
+  const content = await fs.readFile(filePath, 'utf-8');
+  return content
+    .trim()
+    .split('\n')
+    .filter((line) => line)
+    .map((line) => JSON.parse(line) as unknown);
+}
+
+function buildToken(prefix: string, body: string): string {
+  return `${prefix}${body}`;
 }
 
 function createMockLogger(): LoggerInterface & {
@@ -208,5 +224,90 @@ describe('createRunTraceManager', () => {
     const tm = createRunTraceManager(tempDir, 'test-run-id', mockLogger);
 
     expect(tm).toBeInstanceOf(TraceManager);
+  });
+});
+
+describe('TraceManager Redaction', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir();
+  });
+
+  afterEach(async () => {
+    await cleanupTempDir(tempDir);
+  });
+
+  it('redacts secrets from async span error attributes and status messages before persistence', async () => {
+    const traceManager = createRunTraceManager(tempDir);
+    const token = buildToken('ghp_', 'a'.repeat(36));
+    const apiKey = buildToken('api', 'b'.repeat(30));
+    const message = `Request failed: Authorization: Bearer ${token} url=https://example.test?api_key=${apiKey}`;
+
+    await expect(
+      withSpan(traceManager, 'failing_operation', async () => {
+        throw new Error(message);
+      })
+    ).rejects.toThrow(message);
+
+    await traceManager.flush();
+
+    const tracesPath = path.join(tempDir, 'telemetry', 'traces.json');
+    const traceContent = await fs.readFile(tracesPath, 'utf-8');
+    expect(traceContent).not.toContain(token);
+    expect(traceContent).not.toContain(apiKey);
+
+    const [span] = (await readTraceFile(tracesPath)) as Array<{
+      status: { code: SpanStatusCode; message: string };
+      attributes: Record<string, string | number | boolean>;
+    }>;
+    expect(span.status.code).toBe(SpanStatusCode.ERROR);
+    expect(span.status.message).toContain('[REDACTED_GITHUB_TOKEN]');
+    expect(span.status.message).toContain('api_key=[REDACTED]');
+    expect(span.attributes['error.message']).toContain('[REDACTED_GITHUB_TOKEN]');
+    expect(span.attributes['error.stack']).not.toContain(token);
+  });
+
+  it('redacts sensitive span attributes and event attributes', async () => {
+    const traceManager = createRunTraceManager(tempDir, undefined, undefined);
+    const span = traceManager.startSpan('span_with_sensitive_attributes', undefined, {
+      Authorization: 'Bearer token-value-that-is-long-enough',
+      endpoint: 'https://example.test?token=shhh1234567890',
+    });
+    span.addEvent('http_retry', { api_key: 'test-api-key', detail: 'safe detail' });
+    span.end({ code: SpanStatusCode.ERROR, message: 'failed with password=super-secret' });
+
+    await traceManager.flush();
+
+    const tracesPath = path.join(tempDir, 'telemetry', 'traces.json');
+    const [recordedSpan] = (await readTraceFile(tracesPath)) as Array<{
+      status: { message: string };
+      attributes: Record<string, string | number | boolean>;
+      events: Array<{ attributes?: Record<string, string | number | boolean> }>;
+    }>;
+
+    expect(recordedSpan.attributes.Authorization).toBe('[REDACTED]');
+    expect(recordedSpan.attributes.endpoint).toContain('token=[REDACTED]');
+    expect(recordedSpan.events[0].attributes?.api_key).toBe('[REDACTED]');
+    expect(recordedSpan.events[0].attributes?.detail).toBe('safe detail');
+    expect(recordedSpan.status.message).toBe('failed with password=[REDACTED]');
+  });
+
+  it('redacts secrets from sync span error attributes and status messages', () => {
+    const traceManager = createRunTraceManager(tempDir);
+    const token = buildToken('ghp_', 'c'.repeat(36));
+
+    expect(() =>
+      withSpanSync(traceManager, 'sync_failure', () => {
+        throw new Error(`sync failure token=${token}`);
+      })
+    ).toThrow(`sync failure token=${token}`);
+
+    const [span] = traceManager.getSpans() as Array<{
+      status: { message: string };
+      attributes: Record<string, string | number | boolean>;
+    }>;
+    expect(span.status.message).toBe('sync failure token=[REDACTED_GITHUB_TOKEN]');
+    expect(span.attributes['error.message']).toBe('sync failure token=[REDACTED_GITHUB_TOKEN]');
   });
 });


### PR DESCRIPTION
## **User description**
@devin

### Motivation
- Close an information-disclosure issue where span attributes and status messages (including `error.message`/`error.stack`) were written to `telemetry/traces.json` without redaction, allowing secrets embedded in errors to leak.
- Ensure trace artifacts are safe to store locally by reusing the repository's credential redaction logic for traces.

### Description
- Reused the existing `RedactionEngine` and added trace-specific helpers to redact strings, attribute keys/values, event attributes, and span status messages before they become part of a `Span` record (`src/telemetry/traces.ts`).
- Applied redaction at span construction, `setAttribute`, `addEvent`, and `end` so spans are sanitized in-memory prior to being recorded or appended to `telemetry/traces.json`.
- Made the `TraceManager` provide a shared redactor to `ActiveSpanImpl` instances so all spans use consistent redaction rules.
- Added regression tests covering async and sync `withSpan`/`withSpanSync` error redaction and sensitive span/event attributes (`tests/unit/traces.spec.ts`).

### Testing
- Ran focused unit tests targeting the new behavior with `npx vitest run tests/unit/traces.spec.ts --testNamePattern "TraceManager Redaction"`, which passed.
- Built the project with `npm run build`, which succeeded.
- Ran lint on the modified files with `npx eslint src/telemetry/traces.ts tests/unit/traces.spec.ts`, which passed for the changed files (repo-wide lint run surfaced unrelated existing issues).
- Note: running the full `npm test` expanded to the broader suite and hit environment-dependent baseline failures in this execution environment; those failures are unrelated to the trace redaction changes and were observed during earlier runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa968a7ee08321882272f82eca6023)

___

## **CodeAnt-AI Description**
**Redact sensitive details from trace files before they are saved**

### What Changed
- Trace files now remove secrets from span names, attributes, event details, and error status messages before they are written to disk.
- Error messages captured from both async and sync spans are still recorded, but sensitive values are replaced with redacted text.
- Added tests that verify tokens, API keys, passwords, and authorization values do not appear in saved trace output.

### Impact
`✅ Fewer secret leaks in trace files`
`✅ Safer local telemetry storage`
`✅ Clearer error reporting without exposing credentials`

[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=KxgWREjqrLnS8H360UYDX4roQCD7UABAyD7BXZkaavk&org=KingInYellows)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes an information-disclosure path where raw span attributes and error messages (including secrets embedded in stack traces) were written to `telemetry/traces.json` without sanitization. It reuses the existing `RedactionEngine` to scrub string values and sensitive key names at every mutation point on `ActiveSpanImpl`.

- Redaction is applied in the constructor (default attributes), `setAttribute`, `addEvent` event attributes, and `end` status messages — covering all write paths before a span reaches `recordSpan`.
- A shared `RedactionEngine` instance is created on `TraceManager` and propagated to every `ActiveSpanImpl`, ensuring consistent rule application across a run.
- Three regression tests are added covering async/sync `withSpan` error flows and sensitive span/event attributes, with tokens constructed via `buildToken` to avoid triggering secret scanners on the test file itself.

<h3>Confidence Score: 3/5</h3>

Safe to merge from a security standpoint, but the overbroad key-name check will silently erase numeric token-count telemetry in an LLM pipeline.

The redaction wiring is correct for all the cases it targets — string values, event attributes, and status messages are all sanitized before disk write. The problem is that isSensitiveFieldName uses substring matching on 'token', so LLM-pipeline attributes like prompt_tokens or completion_tokens have their numeric values coerced to the string '[REDACTED]'. Downstream consumers reading the trace file would see a string where a number is expected, breaking any aggregation that sums token usage. The three new regression tests don't cover this path, so the regression would ship silently.

src/telemetry/traces.ts — specifically redactTraceAttribute and its use of isSensitiveFieldName on attribute keys

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/telemetry/traces.ts | Adds redaction helpers and wires them into ActiveSpanImpl construction, setAttribute, addEvent, and end; the shared TraceManager redactor is correctly propagated to all spans, but isSensitiveFieldName's substring matching will silently coerce numeric token-count attributes to '[REDACTED]' |
| tests/unit/traces.spec.ts | Adds three regression tests covering async/sync error redaction and sensitive attribute/event redaction; coverage is solid for the happy paths but doesn't exercise numeric attributes with token-style key names |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant TraceManager
    participant ActiveSpanImpl
    participant RedactionEngine
    participant traces.json

    Caller->>TraceManager: startSpan(name, kind, attrs)
    TraceManager->>ActiveSpanImpl: new ActiveSpanImpl(..., mergedAttrs, onEnd, this.redactor)
    ActiveSpanImpl->>RedactionEngine: redactTraceAttributes(defaultAttrs)
    RedactionEngine-->>ActiveSpanImpl: sanitized attributes (stored in-memory)

    Caller->>ActiveSpanImpl: setAttribute(key, value)
    ActiveSpanImpl->>RedactionEngine: redactTraceAttribute(key, value)
    RedactionEngine-->>ActiveSpanImpl: redacted value

    Caller->>ActiveSpanImpl: addEvent(name, attrs)
    ActiveSpanImpl->>RedactionEngine: redactTraceAttributes(attrs)
    RedactionEngine-->>ActiveSpanImpl: redacted event attributes

    Caller->>ActiveSpanImpl: end(status)
    ActiveSpanImpl->>RedactionEngine: redactTraceStatus(status)
    RedactionEngine-->>ActiveSpanImpl: redacted status message
    ActiveSpanImpl->>TraceManager: onEnd(span) — span already sanitized
    TraceManager->>traces.json: appendSpanToFile(span)
```

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fcodemachine-pipeline%22%20on%20the%20existing%20branch%20%22codex%2Ffix-unredacted-error-details-in-telemetry%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ffix-unredacted-error-details-in-telemetry%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Ftelemetry%2Ftraces.ts%3A150-160%0A**Overbroad%20key%20matching%20silently%20coerces%20numeric%20metrics%20to%20%60'%5BREDACTED%5D'%60**%0A%0A%60RedactionEngine.isSensitiveFieldName%60%20uses%20a%20substring%20%60includes%60%20check%2C%20so%20any%20attribute%20key%20containing%20%60%22token%22%60%20is%20treated%20as%20sensitive.%20In%20an%20LLM%20pipeline%20this%20means%20attributes%20like%20%60prompt_tokens%60%2C%20%60completion_tokens%60%2C%20%60total_tokens%60%2C%20or%20%60input_token_count%60%20will%20have%20their%20numeric%20values%20silently%20replaced%20with%20the%20string%20%60'%5BREDACTED%5D'%60.%20Consumers%20reading%20the%20trace%20file%20would%20see%20a%20string%20where%20a%20number%20is%20expected%2C%20breaking%20aggregation%20or%20dashboards%20that%20sum%20token%20usage.%20The%20existing%20%60redactObject%60%20path%20has%20the%20same%20false-positive%2C%20but%20this%20PR%20is%20the%20first%20to%20apply%20%60isSensitiveFieldName%60%20to%20span%20attribute%20keys.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Ftelemetry%2Ftraces.ts%3A146-150%0A%60redactTraceString%60%20is%20a%20one-line%20pass-through%20to%20%60redactor.redact%28%29%60%20with%20no%20added%20logic.%20Inlining%20it%20removes%20an%20indirection%20layer%20and%20makes%20the%20call%20sites%20self-explanatory.%0A%0A%60%60%60suggestion%0Afunction%20redactTraceAttribute%28%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/telemetry/traces.ts:150-160
**Overbroad key matching silently coerces numeric metrics to `'[REDACTED]'`**

`RedactionEngine.isSensitiveFieldName` uses a substring `includes` check, so any attribute key containing `"token"` is treated as sensitive. In an LLM pipeline this means attributes like `prompt_tokens`, `completion_tokens`, `total_tokens`, or `input_token_count` will have their numeric values silently replaced with the string `'[REDACTED]'`. Consumers reading the trace file would see a string where a number is expected, breaking aggregation or dashboards that sum token usage. The existing `redactObject` path has the same false-positive, but this PR is the first to apply `isSensitiveFieldName` to span attribute keys.

### Issue 2 of 2
src/telemetry/traces.ts:146-150
`redactTraceString` is a one-line pass-through to `redactor.redact()` with no added logic. Inlining it removes an indirection layer and makes the call sites self-explanatory.

```suggestion
function redactTraceAttribute(
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: redact trace telemetry secrets"](https://github.com/kinginyellows/codemachine-pipeline/commit/5b3f1be3dcfd0d68c80e707c724328bb7916dc52) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30937583)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->