### PR TITLE
fix(init): reject symlinked codepipe paths

### DIFF
--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -124,6 +124,9 @@ export default class Init extends Command {
 
     try {
       const paths = this.resolveProjectPaths();
+      if (!flags['dry-run']) {
+        this.assertPipelinePathsSafe(paths);
+      }
       this.initializeTelemetry(paths, flags, ctx);
 
       if (flags['validate-only']) {
@@ -645,12 +648,48 @@ export default class Init extends Command {
     ];
 
     for (const dir of directories) {
+      this.assertSafeExistingPath(dir, 'directory');
       if (!fs.existsSync(dir)) {
         fs.mkdirSync(dir, { recursive: true });
         if (!silent) {
           this.log(`✓ Created directory: ${dir}`);
         }
       }
+    }
+  }
+
+  /**
+   * Reject pre-existing symlinks or unexpected file types before writing init artifacts.
+   */
+  private assertPipelinePathsSafe(paths: ProjectPaths): void {
+    this.assertSafeExistingPath(paths.pipelineDir, 'directory');
+    this.assertSafeExistingPath(path.join(paths.pipelineDir, 'runs'), 'directory');
+    this.assertSafeExistingPath(paths.logsDir, 'directory');
+    this.assertSafeExistingPath(path.join(paths.pipelineDir, 'artifacts'), 'directory');
+    this.assertSafeExistingPath(paths.configPath, 'file');
+  }
+
+  private assertSafeExistingPath(targetPath: string, expectedType: 'directory' | 'file'): void {
+    let stats: fs.Stats;
+    try {
+      stats = fs.lstatSync(targetPath);
+    } catch (error) {
+      if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+        return;
+      }
+      throw error;
+    }
+
+    if (stats.isSymbolicLink()) {
+      throw new Error(
+        `Refusing to initialize through symbolic link at ${targetPath}. ` +
+          'Remove the symlink and use a regular .codepipe path inside the repository.'
+      );
+    }
+
+    const hasExpectedType = expectedType === 'directory' ? stats.isDirectory() : stats.isFile();
+    if (!hasExpectedType) {
+      throw new Error(`Expected ${targetPath} to be a ${expectedType}.`);
     }
   }
 
@@ -667,6 +706,7 @@ export default class Init extends Command {
     force: boolean,
     silent = false
   ): void {
+    this.assertSafeExistingPath(configPath, 'file');
     if (fs.existsSync(configPath) && !force) {
       throw new Error('Configuration file already exists. Use --force to overwrite.');
     }

--- a/tests/unit/commands/init.spec.ts
+++ b/tests/unit/commands/init.spec.ts
@@ -41,6 +41,38 @@ describe('init command', () => {
       expect(fs.existsSync(path.join(pipelineDir, 'artifacts'))).toBe(true);
       expect(fs.existsSync(configPath)).toBe(true);
     });
+
+    test('rejects symlinked .codepipe directory without writing through it', () => {
+      const outsideTarget = path.join(__dirname, '../../../.test-temp-init-symlink-target');
+      if (fs.existsSync(outsideTarget)) {
+        fs.rmSync(outsideTarget, { recursive: true, force: true });
+      }
+      fs.mkdirSync(outsideTarget, { recursive: true });
+      fs.symlinkSync(outsideTarget, pipelineDir, 'dir');
+
+      try {
+        try {
+          execSync(`node ${binPath} init --yes`, {
+            cwd: testDir,
+            encoding: 'utf-8',
+            stdio: 'pipe',
+          });
+          expect.fail('init should reject symlinked .codepipe directories');
+        } catch (error: unknown) {
+          expect(error).toBeDefined();
+          if (error && typeof error === 'object' && 'stderr' in error) {
+            expect(String(error.stderr)).toContain('symbolic link');
+          }
+        }
+
+        expect(fs.existsSync(path.join(outsideTarget, 'config.json'))).toBe(false);
+        expect(fs.existsSync(path.join(outsideTarget, 'logs'))).toBe(false);
+        expect(fs.existsSync(path.join(outsideTarget, 'runs'))).toBe(false);
+        expect(fs.existsSync(path.join(outsideTarget, 'artifacts'))).toBe(false);
+      } finally {
+        fs.rmSync(outsideTarget, { recursive: true, force: true });
+      }
+    });
   });
 
   describe('config.json schema validation', () => {


### PR DESCRIPTION
## **User description**
@devin

### Motivation
- Prevent an init-time symlink-following vulnerability where a pre-existing `.codepipe` (or `.ai-feature-pipeline`) symlink could cause directory creation and `config.json` writes outside the repository boundary. The change ensures init refuses symlinked or unexpected path types before creating artifacts.

### Description
- Add defensive checks: introduce `assertPipelinePathsSafe` and `assertSafeExistingPath` to detect and reject symbolic links and unexpected file types for pipeline paths.
- Invoke the safety checks early (before telemetry bootstrap and scaffolding) and before each directory creation and before writing `config.json` to avoid following attacker-controlled symlinks.
- Emit a clear error message when a symbolic link is detected and refuse to proceed.
- Add a regression unit test in `tests/unit/commands/init.spec.ts` that symlinks `.codepipe` to an outside directory and asserts `init --yes` is rejected and no files are written through the symlink.

### Testing
- Ran `npm run build` successfully.
- Ran `npx vitest run tests/unit/commands/init.spec.ts` and the updated init tests passed.
- Ran targeted lint and formatting checks with `npx eslint src/cli/commands/init.ts tests/unit/commands/init.spec.ts` and `npx prettier --check src/cli/commands/init.ts tests/unit/commands/init.spec.ts`, both passed for the touched files.
- Note: running the full `npm run lint` still reports unrelated pre-existing lint errors in `src/cli/commands/cycle.ts` and is outside the scope of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa96893d048321a31dfd8d1de59bc8)


___

## **CodeAnt-AI Description**
**Stop init from following symlinked pipeline folders**

### What Changed
- Init now refuses to run if `.codepipe` or its key subfolders are symlinks, instead of creating files outside the repository
- Existing init paths are checked before directories or `config.json` are created, so the command stops early with a clear error
- Added a test that confirms a symlinked `.codepipe` is rejected and nothing is written through it

### Impact
`✅ Prevents init from writing outside the repo`
`✅ Safer project setup`
`✅ Clearer init failure for invalid .codepipe paths`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=bb7ZnJWVLGOXO8INE2QQbn0PsgsC_zTQdYwpbFFG-xo&org=KingInYellows)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a symlink-following vulnerability fix to the `init` command by introducing `assertSafeExistingPath` (using `lstatSync` to detect symlinks without following them) and `assertPipelinePathsSafe` (an early batch check on all pipeline paths before any writes). The approach is correct in principle and `createDirectoryStructure`/`writeConfiguration` both re-check immediately before each write, but `initializeTelemetry` creates `logsDir` (and implicitly `pipelineDir` via `recursive: true`) without a guard, leaving a narrower but still real TOCTOU window that the rest of the fix closes.

- **`assertSafeExistingPath` / `assertPipelinePathsSafe`**: `lstatSync` is the correct syscall (does not follow symlinks); paths are checked early before telemetry, scaffolding, and config writes. Defense-in-depth re-checks are added inside `createDirectoryStructure` and `writeConfiguration`.
- **`initializeTelemetry` gap**: The method creates `paths.logsDir` without calling `assertSafeExistingPath` immediately before the `mkdirSync`, unlike every directory creation in `createDirectoryStructure`. An attacker can plant a symlink in the window between the early batch check and this creation.
- **Regression test**: Overall structure is sound, but `expect.fail()` inside the inner `try` is silently swallowed by the immediately enclosing `catch` block, making the \"init should reject\" assertion unreliable.

<h3>Confidence Score: 3/5</h3>

The symlink rejection logic works correctly for the main write paths, but telemetry directory creation in `initializeTelemetry` bypasses the immediate pre-creation guard that `createDirectoryStructure` applies to every directory it creates.

The core fix (`lstatSync`-based checks in `assertSafeExistingPath`) is mechanically correct and is applied before config writes and directory scaffolding. However, `initializeTelemetry` creates `logsDir` (and `pipelineDir` implicitly) with no re-check between the early batch assertion and the actual `mkdirSync`, leaving a window that contradicts the defense-in-depth pattern established elsewhere. The regression test's `expect.fail()` is also swallowed by the catch block it sits inside, meaning the guard relies only on the file-existence assertions rather than a proper assertion that the command failed.

`src/cli/commands/init.ts` — specifically the `initializeTelemetry` method's directory creation at line 207. `tests/unit/commands/init.spec.ts` — the inner try/catch pattern in the new symlink rejection test.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/cli/commands/init.ts | Adds `assertPipelinePathsSafe` (early batch check) and `assertSafeExistingPath` (per-path check using `lstatSync`) to block symlink traversal. Defense-in-depth is good, but `initializeTelemetry` creates `logsDir`/`pipelineDir` without an immediate re-check, leaving a TOCTOU gap that the defense in `createDirectoryStructure` avoids. |
| tests/unit/commands/init.spec.ts | Adds a regression test for the symlink rejection. Cleanup is correct via `afterEach`. However, `expect.fail()` is swallowed by the enclosing catch block, making the "init should reject" assertion unreliable — only the file-existence checks at the end provide a real guard. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[init run] --> B[resolveProjectPaths]
    B --> C{dry-run?}
    C -- No --> D[assertPipelinePathsSafe batch lstatSync checks]
    C -- Yes --> E[initializeTelemetry]
    D --> E
    E --> F{logsDir exists?}
    F -- No --> G[mkdirSync logsDir recursive - no assertSafeExistingPath here]
    F -- Yes --> H[createLogger / metrics / traces]
    G --> H
    H --> I{validate-only?}
    I -- Yes --> J[validateExistingConfig read-only path]
    I -- No --> K[shouldAbortFromPrompt]
    K --> L[scaffoldConfiguration]
    L --> M[createDirectoryStructure]
    M --> N[assertSafeExistingPath per-directory immediate]
    N --> O[mkdirSync if not exists]
    O --> P[writeConfiguration]
    P --> Q[assertSafeExistingPath immediate before write]
    Q --> R[fs.writeFileSync config.json]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `src/cli/commands/init.ts`, line 202-208 ([link](https://github.com/kinginyellows/codemachine-pipeline/blob/6496a9cca47f1102f982b220e86a9d4d1df47509/src/cli/commands/init.ts#L202-L208)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Telemetry creates `logsDir` without an immediate safety re-check**

   `initializeTelemetry` calls `fs.mkdirSync(paths.logsDir, { recursive: true })` (and implicitly creates `pipelineDir` when it doesn't yet exist) with no `assertSafeExistingPath` guard directly before the creation. In contrast, `createDirectoryStructure` calls `assertSafeExistingPath` on every path immediately before the corresponding `mkdirSync`. Because an attacker-controlled process can replace a not-yet-existing path with a symlink in the window between the early `assertPipelinePathsSafe` batch check and the `mkdirSync` call inside `initializeTelemetry`, telemetry log files can still be written through a freshly planted symlink to an arbitrary location outside the repo. Adding `this.assertSafeExistingPath(paths.logsDir, 'directory')` immediately before the `mkdirSync` call here would close the gap and match the pattern used in `createDirectoryStructure`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: src/cli/commands/init.ts
   Line: 202-208

   Comment:
   **Telemetry creates `logsDir` without an immediate safety re-check**

   `initializeTelemetry` calls `fs.mkdirSync(paths.logsDir, { recursive: true })` (and implicitly creates `pipelineDir` when it doesn't yet exist) with no `assertSafeExistingPath` guard directly before the creation. In contrast, `createDirectoryStructure` calls `assertSafeExistingPath` on every path immediately before the corresponding `mkdirSync`. Because an attacker-controlled process can replace a not-yet-existing path with a symlink in the window between the early `assertPipelinePathsSafe` batch check and the `mkdirSync` call inside `initializeTelemetry`, telemetry log files can still be written through a freshly planted symlink to an arbitrary location outside the repo. Adding `this.assertSafeExistingPath(paths.logsDir, 'directory')` immediately before the `mkdirSync` call here would close the gap and match the pattern used in `createDirectoryStructure`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fcodemachine-pipeline%22%20on%20the%20existing%20branch%20%22codex%2Ffix-vulnerability-in-init-command%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ffix-vulnerability-in-init-command%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20src%2Fcli%2Fcommands%2Finit.ts%0ALine%3A%20202-208%0A%0AComment%3A%0A**Telemetry%20creates%20%60logsDir%60%20without%20an%20immediate%20safety%20re-check**%0A%0A%60initializeTelemetry%60%20calls%20%60fs.mkdirSync%28paths.logsDir%2C%20%7B%20recursive%3A%20true%20%7D%29%60%20%28and%20implicitly%20creates%20%60pipelineDir%60%20when%20it%20doesn't%20yet%20exist%29%20with%20no%20%60assertSafeExistingPath%60%20guard%20directly%20before%20the%20creation.%20In%20contrast%2C%20%60createDirectoryStructure%60%20calls%20%60assertSafeExistingPath%60%20on%20every%20path%20immediately%20before%20the%20corresponding%20%60mkdirSync%60.%20Because%20an%20attacker-controlled%20process%20can%20replace%20a%20not-yet-existing%20path%20with%20a%20symlink%20in%20the%20window%20between%20the%20early%20%60assertPipelinePathsSafe%60%20batch%20check%20and%20the%20%60mkdirSync%60%20call%20inside%20%60initializeTelemetry%60%2C%20telemetry%20log%20files%20can%20still%20be%20written%20through%20a%20freshly%20planted%20symlink%20to%20an%20arbitrary%20location%20outside%20the%20repo.%20Adding%20%60this.assertSafeExistingPath%28paths.logsDir%2C%20'directory'%29%60%20immediately%20before%20the%20%60mkdirSync%60%20call%20here%20would%20close%20the%20gap%20and%20match%20the%20pattern%20used%20in%20%60createDirectoryStructure%60.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fcodemachine-pipeline%22%20on%20the%20existing%20branch%20%22codex%2Ffix-vulnerability-in-init-command%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ffix-vulnerability-in-init-command%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Fcli%2Fcommands%2Finit.ts%3A202-208%0A**Telemetry%20creates%20%60logsDir%60%20without%20an%20immediate%20safety%20re-check**%0A%0A%60initializeTelemetry%60%20calls%20%60fs.mkdirSync%28paths.logsDir%2C%20%7B%20recursive%3A%20true%20%7D%29%60%20%28and%20implicitly%20creates%20%60pipelineDir%60%20when%20it%20doesn't%20yet%20exist%29%20with%20no%20%60assertSafeExistingPath%60%20guard%20directly%20before%20the%20creation.%20In%20contrast%2C%20%60createDirectoryStructure%60%20calls%20%60assertSafeExistingPath%60%20on%20every%20path%20immediately%20before%20the%20corresponding%20%60mkdirSync%60.%20Because%20an%20attacker-controlled%20process%20can%20replace%20a%20not-yet-existing%20path%20with%20a%20symlink%20in%20the%20window%20between%20the%20early%20%60assertPipelinePathsSafe%60%20batch%20check%20and%20the%20%60mkdirSync%60%20call%20inside%20%60initializeTelemetry%60%2C%20telemetry%20log%20files%20can%20still%20be%20written%20through%20a%20freshly%20planted%20symlink%20to%20an%20arbitrary%20location%20outside%20the%20repo.%20Adding%20%60this.assertSafeExistingPath%28paths.logsDir%2C%20'directory'%29%60%20immediately%20before%20the%20%60mkdirSync%60%20call%20here%20would%20close%20the%20gap%20and%20match%20the%20pattern%20used%20in%20%60createDirectoryStructure%60.%0A%0A%23%23%23%20Issue%202%20of%202%0Atests%2Funit%2Fcommands%2Finit.spec.ts%3A54-66%0A**%60expect.fail%28%29%60%20is%20silently%20swallowed%20by%20the%20catch%20block**%0A%0AIf%20%60execSync%60%20succeeds%20%28i.e.%2C%20%60init%60%20does%20not%20reject%20the%20symlink%29%2C%20%60expect.fail%28...%29%60%20is%20called%2C%20which%20throws%20an%20%60AssertionError%60.%20That%20error%20is%20immediately%20caught%20by%20the%20very%20%60catch%60%20block%20below%20it.%20The%20catch%20block%20then%20evaluates%20%60expect%28error%29.toBeDefined%28%29%60%20%E2%80%94%20which%20passes%20because%20the%20%60AssertionError%60%20is%20defined%20%E2%80%94%20and%20checks%20%60'stderr'%20in%20error%60%20%E2%80%94%20which%20is%20false%20for%20an%20%60AssertionError%60%20%E2%80%94%20so%20the%20block%20exits%20cleanly%2C%20with%20no%20test%20failure.%20The%20only%20safety%20net%20is%20the%20subsequent%20file-existence%20assertions.%20A%20more%20reliable%20pattern%20is%20to%20use%20a%20boolean%20flag%20set%20inside%20the%20catch%20or%20to%20re-throw%20non-%60execSync%60%20errors%20from%20the%20catch%20block%20so%20a%20genuine%20assertion%20failure%20propagates%20correctly.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
src/cli/commands/init.ts:202-208
**Telemetry creates `logsDir` without an immediate safety re-check**

`initializeTelemetry` calls `fs.mkdirSync(paths.logsDir, { recursive: true })` (and implicitly creates `pipelineDir` when it doesn't yet exist) with no `assertSafeExistingPath` guard directly before the creation. In contrast, `createDirectoryStructure` calls `assertSafeExistingPath` on every path immediately before the corresponding `mkdirSync`. Because an attacker-controlled process can replace a not-yet-existing path with a symlink in the window between the early `assertPipelinePathsSafe` batch check and the `mkdirSync` call inside `initializeTelemetry`, telemetry log files can still be written through a freshly planted symlink to an arbitrary location outside the repo. Adding `this.assertSafeExistingPath(paths.logsDir, 'directory')` immediately before the `mkdirSync` call here would close the gap and match the pattern used in `createDirectoryStructure`.

### Issue 2 of 2
tests/unit/commands/init.spec.ts:54-66
**`expect.fail()` is silently swallowed by the catch block**

If `execSync` succeeds (i.e., `init` does not reject the symlink), `expect.fail(...)` is called, which throws an `AssertionError`. That error is immediately caught by the very `catch` block below it. The catch block then evaluates `expect(error).toBeDefined()` — which passes because the `AssertionError` is defined — and checks `'stderr' in error` — which is false for an `AssertionError` — so the block exits cleanly, with no test failure. The only safety net is the subsequent file-existence assertions. A more reliable pattern is to use a boolean flag set inside the catch or to re-throw non-`execSync` errors from the catch block so a genuine assertion failure propagates correctly.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(init): reject symlinked codepipe pat..."](https://github.com/kinginyellows/codemachine-pipeline/commit/6496a9cca47f1102f982b220e86a9d4d1df47509) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30937590)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->