### PR TITLE
fix(init): restrict scaffold permissions

### DIFF
--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -57,6 +57,9 @@ interface ProjectPaths {
   logsDir: string;
 }
 
+const PRIVATE_DIRECTORY_MODE = 0o700;
+const PRIVATE_FILE_MODE = 0o600;
+
 interface InitResultPayload {
   status: string;
   config_path: string;
@@ -200,9 +203,8 @@ export default class Init extends Command {
       return;
     }
 
-    if (!fs.existsSync(paths.logsDir)) {
-      fs.mkdirSync(paths.logsDir, { recursive: true });
-    }
+    this.ensurePrivateDirectory(paths.pipelineDir);
+    this.ensurePrivateDirectory(paths.logsDir);
 
     const logger = createCliLogger('init', 'bootstrap', paths.logsDir, {
       minLevel: LogLevel.INFO,
@@ -645,13 +647,24 @@ export default class Init extends Command {
     ];
 
     for (const dir of directories) {
-      if (!fs.existsSync(dir)) {
-        fs.mkdirSync(dir, { recursive: true });
-        if (!silent) {
-          this.log(`✓ Created directory: ${dir}`);
-        }
+      const existed = fs.existsSync(dir);
+      this.ensurePrivateDirectory(dir);
+      if (!existed && !silent) {
+        this.log(`✓ Created directory: ${dir}`);
       }
     }
+  }
+
+  /**
+   * Ensure pipeline-owned directories are private to the current user.
+   *
+   * Passing a mode to mkdir only affects newly created directories, so chmod is
+   * applied afterward to tighten permissions for directories that already exist
+   * or were partially created by recursive mkdir.
+   */
+  private ensurePrivateDirectory(dir: string): void {
+    fs.mkdirSync(dir, { recursive: true, mode: PRIVATE_DIRECTORY_MODE });
+    fs.chmodSync(dir, PRIVATE_DIRECTORY_MODE);
   }
 
   /**
@@ -671,8 +684,13 @@ export default class Init extends Command {
       throw new Error('Configuration file already exists. Use --force to overwrite.');
     }
 
-    // Write with pretty formatting
-    fs.writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8');
+    // Write with pretty formatting and restrict permissions because this file
+    // references credential environment variables and may later hold local secrets.
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2), {
+      encoding: 'utf-8',
+      mode: PRIVATE_FILE_MODE,
+    });
+    fs.chmodSync(configPath, PRIVATE_FILE_MODE);
     if (!silent) {
       this.log(`✓ Created configuration file: ${configPath}`);
     }

--- a/tests/unit/commands/init.spec.ts
+++ b/tests/unit/commands/init.spec.ts
@@ -41,6 +41,16 @@ describe('init command', () => {
       expect(fs.existsSync(path.join(pipelineDir, 'artifacts'))).toBe(true);
       expect(fs.existsSync(configPath)).toBe(true);
     });
+
+    test('creates private pipeline directories and config file', () => {
+      execSync(`node ${binPath} init`, { cwd: testDir, stdio: 'pipe' });
+
+      expect(fs.statSync(pipelineDir).mode & 0o777).toBe(0o700);
+      expect(fs.statSync(path.join(pipelineDir, 'runs')).mode & 0o777).toBe(0o700);
+      expect(fs.statSync(path.join(pipelineDir, 'logs')).mode & 0o777).toBe(0o700);
+      expect(fs.statSync(path.join(pipelineDir, 'artifacts')).mode & 0o777).toBe(0o700);
+      expect(fs.statSync(configPath).mode & 0o777).toBe(0o600);
+    });
   });
 
   describe('config.json schema validation', () => {


### PR DESCRIPTION
## **User description**
### Motivation
- @devin The init scaffolding previously created `.codepipe`, its `runs`/`logs`/`artifacts` directories and `config.json` with default filesystem modes, allowing other local users to read stored API tokens and run artifacts on shared hosts.

### Description
- Add `PRIVATE_DIRECTORY_MODE = 0o700` and `PRIVATE_FILE_MODE = 0o600` constants and an `ensurePrivateDirectory` helper to create and tighten directory permissions.
- Harden telemetry bootstrap to create/chmod the pipeline and logs directories before any telemetry is written by calling `ensurePrivateDirectory` from `initializeTelemetry`.
- Replace plain `mkdirSync` usage in `createDirectoryStructure` with `ensurePrivateDirectory` so `.codepipe`, `runs`, `logs`, and `artifacts` are created/chmodded to `0700` even if they already existed.
- Write `config.json` using `fs.writeFileSync(..., { mode: PRIVATE_FILE_MODE })` and call `fs.chmodSync(configPath, PRIVATE_FILE_MODE)` to ensure the file is `0600`.
- Add a unit regression test that verifies the created directories are `0700` and the config file is `0600`.

### Testing
- Ran `npm run build` successfully.
- Ran `npx vitest run tests/unit/commands/init.spec.ts` and all tests in that file passed.
- Ran targeted lint/format checks: `npx eslint src/cli/commands/init.ts tests/unit/commands/init.spec.ts` and `npx prettier --check src/cli/commands/init.ts tests/unit/commands/init.spec.ts` (both passed for the changed files).
- Performed an automated smoke/stat check by initializing a temporary git repo and verifying `stat -c '%a %n'` shows `700` for directories and `600` for `config.json` (passed).
- Note: running the full `npm run lint` still reports unrelated pre-existing lint errors elsewhere in the repo; the changes in this PR pass the targeted checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa968a47e483219e7734123e48e0cf)


___

## **CodeAnt-AI Description**
**Lock down init-created files and folders to the current user**

### What Changed
- The init command now creates `.codepipe` and its `runs`, `logs`, and `artifacts` folders with private access only.
- `config.json` is now written with restricted access so other local users cannot read it.
- If these folders or the config file already exist, init now tightens their permissions instead of leaving wider access in place.
- Added a test that checks the created folders are `700` and `config.json` is `600`.

### Impact
`✅ Protected local API tokens`
`✅ Safer init on shared machines`
`✅ Fewer exposed run artifacts`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=ay0QjsD-7YtFRiowYihfwP4WRFW9uWC0EcR9uNbumi0&org=KingInYellows)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens filesystem permissions for the `.codepipe` scaffold by introducing `ensurePrivateDirectory` (wrapping `mkdirSync` + `chmodSync`) and writing `config.json` with mode `0o600`. The double-write pattern (`mode` in `writeFileSync` plus an explicit `chmodSync`) correctly handles both new-file creation and force-overwrite of existing files, and the comment in `ensurePrivateDirectory` clearly explains why `chmodSync` must follow `mkdirSync`.

- **Directory hardening**: `pipelineDir` and `logsDir` are now secured before any telemetry is written; `runs` and `artifacts` are secured during `createDirectoryStructure`. Because `pipelineDir` itself is `0o700`, subdirectories created by telemetry helpers between these two steps are already inaccessible to other local users.
- **Config file hardening**: `config.json` is written with `mode: 0o600` and then `chmodSync`'d to `0o600`, ensuring correct permissions regardless of the process `umask` or whether the file pre-existed (`--force` path).
- **Test coverage**: A new integration test verifies modes on a fresh `init`, but the existing `--force` test does not assert that a previously permissive `config.json` is restored to `0o600` after re-initialization.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the permission-tightening logic is correct and the double mkdirSync+chmodSync pattern handles all relevant paths including force-overwrite.

The core change is a well-scoped security fix with a clear implementation. The only gap is that the existing --force test writes the config without restricted permissions and then never checks that init --force restores them to 0o600 — if the chmodSync call were ever dropped from writeConfiguration, that path would go undetected by the test suite.

tests/unit/commands/init.spec.ts — the force-reinit test block would benefit from a permission assertion to close the coverage gap on the most security-relevant code path.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/cli/commands/init.ts | Adds PRIVATE_DIRECTORY_MODE/PRIVATE_FILE_MODE constants and ensurePrivateDirectory helper; replaces plain mkdirSync calls with ensurePrivateDirectory (mkdirSync + chmodSync) in both initializeTelemetry and createDirectoryStructure; writes config.json with mode 0o600 and chmodSyncs afterward. Logic is correct and well-commented; one test coverage gap in the force-reinit path. |
| tests/unit/commands/init.spec.ts | Adds a new integration test that verifies directories are mode 0o700 and config.json is 0o600 after a fresh init. Does not cover permission restoration after a --force re-init over a file with relaxed permissions. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[run init] --> B[resolveProjectPaths]
    B --> C[initializeTelemetry]
    C --> D{dry-run?}
    D -- yes --> E[skip / return]
    D -- no --> F[ensurePrivateDirectory pipelineDir\nmkdirSync 0o700 + chmodSync 0o700]
    F --> G[ensurePrivateDirectory logsDir\nmkdirSync 0o700 + chmodSync 0o700]
    G --> H[create logger / metrics / traces]
    H --> I{validate-only?}
    I -- yes --> J[validateExistingConfig and exit]
    I -- no --> K{already initialized?}
    K -- yes --> L[return early\npipelineDir + logsDir already re-secured]
    K -- no --> M[scaffoldConfiguration]
    M --> N[createDirectoryStructure]
    N --> O[ensurePrivateDirectory runs\nmkdirSync 0o700 + chmodSync 0o700]
    N --> P[ensurePrivateDirectory artifacts\nmkdirSync 0o700 + chmodSync 0o700]
    M --> Q[writeConfiguration]
    Q --> R[writeFileSync config.json\nmode: 0o600]
    R --> S[chmodSync config.json 0o600]
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `tests/unit/commands/init.spec.ts`, line 263-278 ([link](https://github.com/kinginyellows/codemachine-pipeline/blob/d9315accda8f987b13320cd0a0283cb2908756b5/tests/unit/commands/init.spec.ts#L263-L278)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Permission restoration after `--force` is untested**

   The test deliberately writes `configPath` back with default permissions (`fs.writeFileSync(..., 'utf-8')`, no mode), producing a typical `0o644` file, then exercises `init --force`. The only assertion after the force-reinit is that the content changed — the mode is never checked. If the `chmodSync` call in `writeConfiguration` were accidentally removed or skipped, this test would still pass while leaving `config.json` world-readable.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: tests/unit/commands/init.spec.ts
   Line: 263-278

   Comment:
   **Permission restoration after `--force` is untested**

   The test deliberately writes `configPath` back with default permissions (`fs.writeFileSync(..., 'utf-8')`, no mode), producing a typical `0o644` file, then exercises `init --force`. The only assertion after the force-reinit is that the content changed — the mode is never checked. If the `chmodSync` call in `writeConfiguration` were accidentally removed or skipped, this test would still pass while leaving `config.json` world-readable.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fcodemachine-pipeline%22%20on%20the%20existing%20branch%20%22codex%2Ffix-config-and-run-directory-permissions%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ffix-config-and-run-directory-permissions%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20tests%2Funit%2Fcommands%2Finit.spec.ts%0ALine%3A%20263-278%0A%0AComment%3A%0A**Permission%20restoration%20after%20%60--force%60%20is%20untested**%0A%0AThe%20test%20deliberately%20writes%20%60configPath%60%20back%20with%20default%20permissions%20%28%60fs.writeFileSync%28...%2C%20'utf-8'%29%60%2C%20no%20mode%29%2C%20producing%20a%20typical%20%600o644%60%20file%2C%20then%20exercises%20%60init%20--force%60.%20The%20only%20assertion%20after%20the%20force-reinit%20is%20that%20the%20content%20changed%20%E2%80%94%20the%20mode%20is%20never%20checked.%20If%20the%20%60chmodSync%60%20call%20in%20%60writeConfiguration%60%20were%20accidentally%20removed%20or%20skipped%2C%20this%20test%20would%20still%20pass%20while%20leaving%20%60config.json%60%20world-readable.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22kinginyellows%2Fcodemachine-pipeline%22%20on%20the%20existing%20branch%20%22codex%2Ffix-config-and-run-directory-permissions%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Ffix-config-and-run-directory-permissions%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Atests%2Funit%2Fcommands%2Finit.spec.ts%3A263-278%0A**Permission%20restoration%20after%20%60--force%60%20is%20untested**%0A%0AThe%20test%20deliberately%20writes%20%60configPath%60%20back%20with%20default%20permissions%20%28%60fs.writeFileSync%28...%2C%20'utf-8'%29%60%2C%20no%20mode%29%2C%20producing%20a%20typical%20%600o644%60%20file%2C%20then%20exercises%20%60init%20--force%60.%20The%20only%20assertion%20after%20the%20force-reinit%20is%20that%20the%20content%20changed%20%E2%80%94%20the%20mode%20is%20never%20checked.%20If%20the%20%60chmodSync%60%20call%20in%20%60writeConfiguration%60%20were%20accidentally%20removed%20or%20skipped%2C%20this%20test%20would%20still%20pass%20while%20leaving%20%60config.json%60%20world-readable.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fcli%2Fcommands%2Finit.ts%3A687-693%0A**%60mode%60%20in%20%60writeFileSync%60%20is%20ignored%20for%20existing%20files**%0A%0ANode.js%20applies%20the%20%60mode%60%20option%20only%20when%20creating%20a%20brand-new%20file%3B%20for%20an%20existing%20file%20%28the%20%60--force%60%20overwrite%20path%29%20the%20option%20is%20silently%20dropped%20and%20the%20original%20mode%20is%20preserved%20until%20%60chmodSync%60%20corrects%20it.%20The%20code%20is%20correct%20because%20%60chmodSync%60%20always%20runs%20immediately%20afterward%2C%20but%20the%20relationship%20isn't%20obvious%20and%20a%20future%20edit%20that%20reorders%20or%20removes%20%60chmodSync%60%20could%20leave%20a%20permissive%20file.%20A%20brief%20comment%20makes%20the%20invariant%20explicit.%0A%0A%60%60%60suggestion%0A%20%20%20%20%2F%2F%20Write%20with%20pretty%20formatting%20and%20restrict%20permissions%20because%20this%20file%0A%20%20%20%20%2F%2F%20references%20credential%20environment%20variables%20and%20may%20later%20hold%20local%20secrets.%0A%20%20%20%20%2F%2F%20NOTE%3A%20the%20%60mode%60%20option%20is%20honoured%20by%20Node.js%20only%20for%20newly%20created%20files%3B%0A%20%20%20%20%2F%2F%20for%20pre-existing%20files%20%28e.g.%20the%20--force%20overwrite%20path%29%20it%20is%20silently%0A%20%20%20%20%2F%2F%20ignored%20by%20the%20OS.%20chmodSync%20below%20is%20therefore%20the%20authoritative%20setter%20and%0A%20%20%20%20%2F%2F%20must%20always%20follow%20writeFileSync.%0A%20%20%20%20fs.writeFileSync%28configPath%2C%20JSON.stringify%28config%2C%20null%2C%202%29%2C%20%7B%0A%20%20%20%20%20%20encoding%3A%20'utf-8'%2C%0A%20%20%20%20%20%20mode%3A%20PRIVATE_FILE_MODE%2C%0A%20%20%20%20%7D%29%3B%0A%20%20%20%20fs.chmodSync%28configPath%2C%20PRIVATE_FILE_MODE%29%3B%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
tests/unit/commands/init.spec.ts:263-278
**Permission restoration after `--force` is untested**

The test deliberately writes `configPath` back with default permissions (`fs.writeFileSync(..., 'utf-8')`, no mode), producing a typical `0o644` file, then exercises `init --force`. The only assertion after the force-reinit is that the content changed — the mode is never checked. If the `chmodSync` call in `writeConfiguration` were accidentally removed or skipped, this test would still pass while leaving `config.json` world-readable.

### Issue 2 of 2
src/cli/commands/init.ts:687-693
**`mode` in `writeFileSync` is ignored for existing files**

Node.js applies the `mode` option only when creating a brand-new file; for an existing file (the `--force` overwrite path) the option is silently dropped and the original mode is preserved until `chmodSync` corrects it. The code is correct because `chmodSync` always runs immediately afterward, but the relationship isn't obvious and a future edit that reorders or removes `chmodSync` could leave a permissive file. A brief comment makes the invariant explicit.

```suggestion
    // Write with pretty formatting and restrict permissions because this file
    // references credential environment variables and may later hold local secrets.
    // NOTE: the `mode` option is honoured by Node.js only for newly created files;
    // for pre-existing files (e.g. the --force overwrite path) it is silently
    // ignored by the OS. chmodSync below is therefore the authoritative setter and
    // must always follow writeFileSync.
    fs.writeFileSync(configPath, JSON.stringify(config, null, 2), {
      encoding: 'utf-8',
      mode: PRIVATE_FILE_MODE,
    });
    fs.chmodSync(configPath, PRIVATE_FILE_MODE);
```


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(init): restrict scaffold permissions"](https://github.com/kinginyellows/codemachine-pipeline/commit/d9315accda8f987b13320cd0a0283cb2908756b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30937602)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->