### PR TITLE
chore(ci): remove unused self-hosted runner scaffolding

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,5 +1,5 @@
 name: 'Setup Node.js Environment'
-description: 'Shared CI setup: npm cache directories, Node.js installation, and runner preflight checks'
+description: 'Shared CI setup: Node.js installation and runner preflight checks'
 
 inputs:
   node-version:
@@ -17,22 +17,10 @@ inputs:
   enable-preflight:
     description: 'Run Node.js version preflight check'
     default: 'true'
-  prepare-npm-dirs:
-    description: 'Prepare npm cache directories for self-hosted runners'
-    default: 'false'
 
 runs:
   using: 'composite'
   steps:
-    - name: Prepare npm directories
-      if: inputs.prepare-npm-dirs == 'true'
-      shell: bash
-      run: |
-        set -euo pipefail
-        echo "HOME=$RUNNER_TEMP/codemachine-home" >> "$GITHUB_ENV"
-        echo "NPM_CONFIG_CACHE=$RUNNER_TEMP/codemachine-npm-cache" >> "$GITHUB_ENV"
-        mkdir -p "$RUNNER_TEMP/codemachine-home" "$RUNNER_TEMP/codemachine-npm-cache"
-
     - name: Setup Node.js
       uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.1.0
       with:


### PR DESCRIPTION
## **User description**
## Summary

CI was fully migrated to GitHub-hosted runners (`runs-on: ubuntu-latest`) in #855. This removes the leftover self-hosted scaffolding from the shared `setup-node` composite action that is no longer needed.

Removed the `prepare-npm-dirs` input and its associated "Prepare npm directories" step (which redirected `HOME`/`NPM_CONFIG_CACHE` into `$RUNNER_TEMP` for self-hosted runners). The input defaulted to `false` and no workflow set it to `true`, so this is dead, no-op code. Also trimmed the now-inaccurate "npm cache directories" phrase from the action description.

No workflow files change — all jobs already run on `ubuntu-latest`.

## Test Plan

How was this verified?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing — confirmed no workflow references `prepare-npm-dirs`; the input defaulted to `false` and was never enabled, so behavior is unchanged.

## Checklist

- [ ] `npm run format:check && npm run lint` passes
- [ ] `npm test` passes
- [ ] `npm run docs:links:check` passes
- [ ] `npm run build` succeeds
- [ ] Documentation updated (if applicable)


Link to Devin session: https://app.devin.ai/sessions/80927a29c6a94b26b3fc884f8a02c588
Requested by: @KingInYellow18

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/KingInYellows/codemachine-pipeline/pull/942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Remove unused self-hosted runner setup from the Node.js CI helper**

### What Changed
- Removed the leftover option for preparing npm directories on self-hosted runners
- Stopped creating temporary HOME and npm cache directories that were no longer used
- Updated the helper description to match the current GitHub-hosted runner setup

### Impact
`✅ Less confusing CI setup`
`✅ Fewer unused configuration options`
`✅ Clearer runner setup documentation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the shared CI setup action by removing an unused setup option.
  * Updated the action description to better reflect the current Node.js setup and runner preflight checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->